### PR TITLE
plan: docs strategy, marketing-ui, api/ui/marketing-ui repo trio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+1.0.15 || 16.07.2026
+docs: fix D1 consumer list in parallel execution.txt — (C4, D3, D4) → (C4, D4, D5),
+matching the sequencing rule "D1 before C4/D4-schemas/D5" (D3 mobile encryptor
+has no D1 dependency)
+plan: new CROSS-CUTTING docs section — three doc surfaces, three homes:
+generated OpenAPI reference ships with the api (invest in annotations, optional
+Scalar UI), protocol spec + conventions live in-repo as versioned markdown +
+JSON Schema (conformance suite tests against them), docs/ becomes an MkDocs
+Material site (embeds OpenAPI, mkdocstrings, sdk typedoc; no hosted SaaS docs)
+plan: phase 7 — home/ + docs/ -> marketing-ui/: inc's website + dev docs as ONE
+site (docs are part of a saas marketing site), rebuilt on the ui toolchain
+(vite + react + bun), own vhost, never in the node compose; stays in the
+monorepo by choice (one dev, lean). repo reads api / ui / marketing-ui.
+docs site framework lean updated accordingly: js-native (starlight or
+docusaurus) instead of mkdocs, since it lives inside marketing-ui.
+decisions.md: new D12 recording the api / ui / marketing-ui repo trio.
+plan: docs section simplified — split by audience not tool; adds the missing
+user/creator guides (they ARE the saas marketing content, written per
+milestone as features ship); dev docs = D1 spec + generated references
+
 1.0.14 || 16.07.2026
 phase 0 completion — RTC modernization + docker image rebuild + cleanup:
   - rtc service: node:15 → bun, index.js → index.ts with types, npm → bun,

--- a/decisions.md
+++ b/decisions.md
@@ -9,6 +9,21 @@ Status legend: [decided] intent set · [in-progress] · [open] still debating.
 
 ---
 
+### D12 — Repo trio: api / ui / marketing-ui; docs live in marketing-ui [decided]
+`home/` + `docs/` merge into **`marketing-ui/`** — web10 Inc's website as one
+site (landing + dev docs, one build), because docs are a key part of a SaaS
+marketing site. With phase 2's auth2→`ui` rename, the repo reads clean:
+`api` (the node), `ui` (the node's admin/consent surface), `marketing-ui`
+(Inc's site). Everything stays in this monorepo by choice — one dev, atomic
+commits — multi-repo is a later option, not a goal. Doc surfaces split three
+ways: generated OpenAPI ships with the api (every node self-documents),
+protocol spec + conventions stay in-repo as versioned markdown/JSON Schema
+(the conformance suite tests those files), the rendered docs site is
+presentation inside marketing-ui (js-native framework: Starlight or
+Docusaurus). Rejects: docs inside the node's `ui` (ships Inc's content with
+every node); hosted SaaS docs (off-message for a self-hosting product);
+separate marketing/docs repos now.
+
 ### D11 — Killer app is first-party, in this repo (not a separate repo) [decided]
 The social app is the **default lens**: it ships with every node, renders the
 operator's ad slots, and embodies the conventions doc. Building it is how the

--- a/parallel execution.txt
+++ b/parallel execution.txt
@@ -77,7 +77,7 @@ LANE D — docs / apps / mobile (owns: mobile/**, social/, examples/,
                                *.md/txt)
   D1. conventions doc (posts/media/contacts/inbox schemas) +
       protocol spec draft (from api/web10.0.md). PURE WRITING,
-      zero conflicts, and THREE lanes consume it (C4, D3, D4).
+      zero conflicts, and THREE lanes consume it (C4, D4, D5).
       do it first for exactly that reason.
   D2. P7 tidy: crm/mail -> examples/, killer app dir (social/)
       scaffolded as first-party (file moves, cheap)

--- a/plan.txt
+++ b/plan.txt
@@ -310,8 +310,19 @@ ships its web client. same logic.
 [ ] crm/ + mail/ -> examples/ directory: kept in-repo as reference
     apps for devs, but OUT of the node's default compose. they're
     documentation that runs.
-[ ] home/ and docs/ are web10 inc's website, not part of a node --
-    out of the node compose; separate repo only if they get heavy.
+[ ] home/ + docs/ -> marketing-ui/: web10 inc's website, ONE site.
+    docs are a key part of a saas marketing site, so they live
+    together: landing pages + dev docs, one dir, one build. not part
+    of a node -- own vhost, never in the node compose. it STAYS in
+    this monorepo by choice: one dev, one repo, atomic commits
+    across product + site is lean. multi-repo is a later option,
+    not a goal.
+[ ] marketing-ui rebuild: replace home/'s static html (delete the
+    cruft: index - Copy.html) with the same toolchain as ui
+    (vite + react + bun, one stack to maintain).
+[ ] the naming makes the repo read clean: api (the node),
+    ui (the node's admin/consent surface, from auth2 -- phase 2),
+    marketing-ui (inc's website + docs).
 [ ] node compose after the tidy: api(+ui), db, social, [rtc],
     [media]. examples run via an "examples" profile for devs.
 [ ] third-party apps (the ecosystem) live in their own repos and
@@ -641,6 +652,38 @@ quality:
 [ ] health/readiness endpoints + basic metrics on every service
     (fleet ops in the white-label future depends on these)
 [ ] error responses: consistent shapes, no stack traces to clients
+
+
+CROSS-CUTTING — docs
+--------------------
+sounds like a lot; it's one writing task (the D1 spec), one coding
+habit (annotate as you go), and one website that waits. split by
+AUDIENCE, not by tool. generated wherever possible -- generated
+docs can't rot.
+
+for users + creators (lives in marketing-ui, phase 7):
+[ ] guides ARE the marketing content for a saas: get an account,
+    reconfig your feed, import your instagram, run a node, monetize
+    as a creator. write each guide when its milestone (M0-M3)
+    ships, not before -- docs for unshipped features are fiction.
+
+for devs:
+[ ] protocol spec + conventions doc (D1): versioned markdown + JSON
+    Schema, in-repo, framework-less. the conformance suite tests
+    these FILES, and the schemas double as validators for the
+    exporters (P9) and the killer app (P8). the source of truth.
+[ ] api reference: already generated -- fastapi emits openapi at
+    /docs on every node, grows with the api for free. the habit
+    that keeps it good: route tags (auth/crud/terms/billing),
+    summaries, response_model on every route, examples on the
+    pydantic models. (optional cosmetic: swagger ui -> scalar.)
+[ ] sdk reference: typedoc from the types (phase 6 item)
+[ ] dev docs pages in marketing-ui render the in-repo spec verbatim
+    + embed the generated references. js-native framework (starlight
+    or docusaurus) since marketing-ui is js. build this when there's
+    a killer app to document, not before.
+[ ] no hosted saas docs (mintlify/readme): self-hostable project,
+    self-hosted docs.
 
 
 LATER / OPEN QUESTIONS


### PR DESCRIPTION
## What

Planning/docs-only PR — gets the docs strategy and repo naming organized before the D1 writing starts.

- **`parallel execution.txt`**: fix D1's consumer list `(C4, D3, D4)` → `(C4, D4, D5)` to match the sequencing rule ("D1 before C4/D4-schemas/D5"); D3 (mobile encryptor) has no D1 dependency.
- **`plan.txt` phase 7**: `home/` + `docs/` → **`marketing-ui/`** — web10 Inc's website as one site (landing + dev docs, one build) on the ui toolchain (vite + react + bun), own vhost, never in the node compose. Stays in the monorepo by choice (one dev, atomic commits). With phase 2's auth2 → ui rename, the repo reads clean: **api / ui / marketing-ui**.
- **`plan.txt` new CROSS-CUTTING — docs section**, split by audience:
  - users + creators: guides live in marketing-ui (they ARE the SaaS marketing content), written per milestone as features ship
  - devs: D1 protocol spec + conventions as versioned markdown + JSON Schema in-repo (conformance suite tests the files; schemas double as validators for P8/P9); OpenAPI reference stays generated (invest in route annotations); sdk typedoc (phase 6); dev docs pages render the in-repo spec inside marketing-ui later (js-native framework: Starlight or Docusaurus); no hosted SaaS docs
- **`decisions.md`**: new D12 recording the trio and where docs live, so it doesn't get re-litigated.
- **`CHANGELOG.md`**: 1.0.15.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)