### PR TITLE
plan: docs explanation quadrant + media decisions D13/D14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+1.0.17 || 16.07.2026
+decisions: D13 — media fits the record abstraction: "service" stays the data
+namespace, no /{user}/{service}/{collection} restructure; media metadata is an
+ordinary {service:"media", body} record so terms/ACLs apply unchanged.
+decisions: D14 — media reads via per-request presigned URLs (30-60s expiry,
+issuance logged); check-at-issue-time gap consciously accepted, API-proxy and
+per-request auth-proxy alternatives rejected (proxy remains a later
+tightening option, not a redesign).
+plan: phase 5 read-url and metadata items tightened to carry the D13/D14
+specifics (per-read issuance, expiry window, logging, record shape).
+
+1.0.16 || 16.07.2026
+plan: CROSS-CUTTING docs gains the missing explanation quadrant — "for
+everyone" block ahead of the guides: "what is web10" concept pages (mental
+model: node, record, tokens+terms, lens, federation), per-audience why pages
+(user / creator-influencer / dev / operator, productizing pitch.txt's
+vs-crypto and vs-cloud arguments), and how-it-works diagrams as code
+(mermaid over plantuml — starlight/docusaurus render it natively). unlike
+guides these aren't milestone-gated: the architecture exists, so they're
+writable now and double as the marketing site's core copy.
+
 1.0.15 || 16.07.2026
 docs: fix D1 consumer list in parallel execution.txt — (C4, D3, D4) → (C4, D4, D5),
 matching the sequencing rule "D1 before C4/D4-schemas/D5" (D3 mobile encryptor

--- a/decisions.md
+++ b/decisions.md
@@ -9,6 +9,33 @@ Status legend: [decided] intent set · [in-progress] · [open] still debating.
 
 ---
 
+### D14 — Media reads use per-request presigned URLs with tight expiry [decided]
+S3-class stores can't express the terms model per object (bucket policies are
+bucket-level, object ACLs are coarse and deprecated). Rather than proxy every
+media read through the API to get live terms enforcement, the media service
+checks `is_permitted` **at issue time** and returns a presigned URL that is
+issued fresh on every read, expires in 30–60 seconds, and is logged on
+issuance. This consciously accepts a gap: a presigned URL is
+check-once-then-open until expiry — terms revocation inside that window is
+not enforced. The window is the safety net, and it's tiny. Rejects: streaming
+all blobs through the API (node becomes a media proxy — bandwidth and scaling
+cost); a per-request auth proxy in front of S3 (rebuilds the media CRUD
+surface we're avoiding). If a real threat model demands live revocation
+later, the proxy option remains open as a tightening, not a redesign.
+
+### D13 — Media fits the record abstraction; "service" stays the namespace [decided]
+`/{user}/{service}` keeps meaning "a data namespace in the user's collection"
+— it is not a running service, and media does not change that. The media
+service (a literal running service) gets no new URL hierarchy: uploads and
+reads are gated by the same `is_permitted` machinery against
+`service="media"`, and each blob's metadata is an ordinary
+`{service:"media", body}` record in the owner's collection, so terms/ACLs,
+portability, and the user-owns-the-policies story apply to media with zero
+new concepts. Rejects: restructuring URLs to `/{user}/{service}/{collection}`
+(breaks every existing route and app for a naming itch); renaming "service"
+(same churn, no capability gained). If the namespace word still grates later,
+that's a docs/glossary fix, not an API fix.
+
 ### D12 — Repo trio: api / ui / marketing-ui; docs live in marketing-ui [decided]
 `home/` + `docs/` merge into **`marketing-ui/`** — web10 Inc's website as one
 site (landing + dev docs, one build), because docs are a key part of a SaaS

--- a/plan.txt
+++ b/plan.txt
@@ -226,8 +226,12 @@ swappable per node.
     - issues presigned upload urls, gated by web10 token permissions
       (same is_permitted logic as CRUD -- terms records stay the single
       source of permission truth)
-    - issues short-lived signed read urls for private media
+    - issues short-lived signed read urls for private media: fresh
+      url per read, 30-60s expiry, issuance logged. check-at-issue-
+      time is an accepted gap -- see D14 in decisions.md.
     - writes a metadata record into the owner's collection on upload
+      (ordinary {service:"media", body} record -- terms/ACLs apply
+      with zero new concepts, see D13)
 [ ] minio in compose under the "media" profile for self-hosters
 [ ] config for hosted s3-compatibles (R2/B2) for bigger nodes
 [ ] size accounting: media bytes count against the user's space plan
@@ -661,11 +665,35 @@ habit (annotate as you go), and one website that waits. split by
 AUDIENCE, not by tool. generated wherever possible -- generated
 docs can't rot.
 
+for everyone -- explanation (lives in marketing-ui, phase 7):
+the missing quadrant: guides say HOW, reference says WHAT, nothing
+says WHY. the architecture (records, tokens, terms, federation)
+already exists, so unlike guides these are writable NOW -- they
+don't wait on milestones. they are the marketing site's core copy.
+[ ] "what is web10" concept pages: the mental model -- node, record
+    ({service, body}), one collection per user, tokens + terms,
+    lens, provider federation. source from GLOSSARY.md/CLAUDE.md/
+    pitch.txt, rewritten public-facing.
+[ ] per-audience "why" pages: as a user (own your data, portable
+    across apps, private/temporary unlike blockchain), as a
+    creator/influencer (run your node, own the audience
+    relationship, monetize -- the wordpress analogy), as a dev
+    (stateless frontends, no backend to run), as a node operator.
+    productize pitch.txt's vs-crypto / vs-cloud arguments here.
+[ ] how-it-works diagrams as code, versioned in-repo (generated
+    docs can't rot applies to diagrams too): token mint/certify
+    flow, request lifecycle, data model, federation between
+    providers, the e2e encryption story. mermaid over plantuml --
+    starlight/docusaurus render it natively at build time, no java
+    toolchain.
+
 for users + creators (lives in marketing-ui, phase 7):
 [ ] guides ARE the marketing content for a saas: get an account,
     reconfig your feed, import your instagram, run a node, monetize
     as a creator. write each guide when its milestone (M0-M3)
     ships, not before -- docs for unshipped features are fiction.
+    (the fiction rule gates GUIDES only -- explanation pages above
+    describe what already exists and don't wait.)
 
 for devs:
 [ ] protocol spec + conventions doc (D1): versioned markdown + JSON


### PR DESCRIPTION
## What

Planning/docs-only PR — no code changes.

**Docs plan gains the missing explanation quadrant** (`plan.txt`, cross-cutting docs):
- "what is web10" concept pages: the mental model (node, record, tokens + terms, lens, federation), sourced from GLOSSARY/CLAUDE.md/pitch.txt rewritten public-facing
- per-audience "why" pages: user / creator-influencer (the WordPress analogy) / dev / node operator, productizing pitch.txt's vs-crypto and vs-cloud arguments
- how-it-works diagrams as code (Mermaid over PlantUML — Starlight/Docusaurus render it natively, no Java toolchain)
- explicitly NOT milestone-gated: the architecture exists, so these are writable now and double as the marketing site's core copy; the "docs for unshipped features are fiction" rule gates guides only

**Two media-layer decisions recorded** (`decisions.md`), settling the phase 5 design questions before build:
- **D13** — media fits the record abstraction: `service` stays the data-namespace concept, no `/{user}/{service}/{collection}` URL restructure; media metadata is an ordinary `{service:"media", body}` record so terms/ACLs apply with zero new concepts
- **D14** — media reads via per-request presigned URLs: fresh URL per read, 30–60s expiry, issuance logged; the check-at-issue-time gap is consciously accepted (rejected: proxying blobs through the API, per-request auth proxy — the proxy remains a later tightening option, not a redesign)

Phase 5 items in `plan.txt` tightened to carry the D13/D14 specifics; CHANGELOG entries 1.0.16 + 1.0.17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)