### PR TITLE
agents: live task-status board + AGENTS.md/QWEN.md — stop redoing merged work (1.0.24)

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,4 @@
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+[prompts]
+general = "Before starting any plan.txt or lane task, check the lane queues in 'parallel execution.txt' ([✓ x.y.z] = merged, [~] = in flight elsewhere), the [✓] ticks in plan.txt, and the top entries of CHANGELOG.md — the task may already be done; if so, pick the next unticked item in the lane instead. When you finish work, in the same branch: add a CHANGELOG.md line, tick the plan.txt item, and tick your lane item in 'parallel execution.txt'."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md — for every coding agent (Codex, Qwen, Claude, ...)
+
+Now read `CLAUDE.md`. Despite the name it is the orientation file for
+ALL agents working on this repo — architecture, security invariants,
+and working conventions. Everything there applies to you.
+
+## Before starting ANY task: check it isn't already done
+
+Task completion state lives in three places. Check all three before
+writing code — merged work must not be redone:
+
+1. `parallel execution.txt` — the lane queues carry live status:
+   `[✓ x.y.z]` = merged (the x.y.z points at the CHANGELOG entry),
+   `[~]` = in flight in another workspace, `[ ]` = open.
+2. `plan.txt` — completed items are ticked `[✓]`.
+3. `CHANGELOG.md` — newest entry at top. Work merged after the lane
+   queues were last ticked shows up here first, so always scan the
+   top few entries.
+
+If the task you were given is already done, say so and pick the next
+unticked item in the same lane instead of redoing it.
+
+## When you finish a task
+
+In the SAME branch as the change: add a `CHANGELOG.md` line (newest at
+top, `version || DD.MM.YYYY`), tick the item in `plan.txt`, and tick
+your lane item in `parallel execution.txt`. If you changed the stack,
+data model, or auth flow, keep `CLAUDE.md`/`GLOSSARY.md` true and
+record big calls in `decisions.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+1.0.24 || 16.07.2026
+agent task-status hygiene (agents were re-attempting merged work):
+  - parallel execution.txt: lane queues now carry live status markers —
+    [✓ x.y.z] merged (A1, B1, D1 ticked with their changelog versions),
+    [~] in flight (C1, D3), [ ] open; wave 0 marked PARTIAL (unit layer
+    landed in 1.0.21, endpoint permission-matrix suite + CI still owed);
+    rule 3 extended: tick your lane item in this file on merge; stale
+    "suggested first board" replaced with a dated current board
+  - added AGENTS.md: orientation entry point for non-Claude agents
+    (codex/qwen read AGENTS.md, not CLAUDE.md) — points to CLAUDE.md and
+    states the check-before-you-start + tick-on-finish rules; QWEN.md
+    pointer added too (Qwen Code's default context file)
+  - added .conductor/settings.toml with a repo-wide general prompt
+    reminding conductor agents to check done-status before starting
+  - CLAUDE.md: new "check it isn't already done" convention; changelog
+    convention now includes ticking the parallel execution.txt lane
+
 1.0.23 || 16.07.2026
 plan: phase 11 gains "the keyring api" — the record-model discipline applied
 to keys: user-named keys (audience = any string, like a service name), cheap

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,10 @@ touches auth, the DB layer, or tokens, run those tests and keep them green.
       revocable token. Least privilege.
 
 ## Working conventions for parallel agents
+- **Check it isn't already done.** Before starting a plan/lane item, check
+  the lane queues in `parallel execution.txt` (`[✓ x.y.z]` = merged,
+  `[~]` = in flight elsewhere), the `[✓]` ticks in plan.txt, and the top
+  of `CHANGELOG.md`. If it's done, say so and pick the next unticked item.
 - **Stay in your lane.** `parallel execution.txt` assigns directory
   ownership. Don't edit another lane's files; if you need a change there
   (e.g. `docker-compose.yml`, `settings`), leave a note, don't reach in.
@@ -67,7 +71,9 @@ touches auth, the DB layer, or tokens, run those tests and keep them green.
 - **Update `CHANGELOG.md`.** Any improvement or change to the project gets a
   line in the changelog (newest entry at top, `version || DD.MM.YYYY`). This
   is a project rule, not a nicety — do it in the same branch as the change.
-  If your work completes a `plan.txt` item, also tick it there.
+  If your work completes a `plan.txt` item, tick it there AND tick your
+  lane item in `parallel execution.txt` — that file is the parallel
+  agents' task board and stale status there causes redone work.
 - **Keep the docs true.** If you change the stack, the data model, or the
   auth flow, update `CLAUDE.md`/`GLOSSARY.md` in the same branch. A big
   architectural decision gets an entry in `decisions.md`. Stale orientation

--- a/QWEN.md
+++ b/QWEN.md
@@ -1,0 +1,6 @@
+# QWEN.md
+
+Read `AGENTS.md` first, then `CLAUDE.md` — they are the orientation for
+all agents on this repo, including the check-before-you-start rule
+(don't redo tasks already ticked in `parallel execution.txt` /
+`plan.txt` / `CHANGELOG.md`).

--- a/parallel execution.txt
+++ b/parallel execution.txt
@@ -16,13 +16,25 @@ the two rules that make 4-wide parallelism safe:
    merging safe.
 3. EVERY BRANCH UPDATES THE CHANGELOG: add a CHANGELOG.md line for what
    you changed (newest at top), tick the plan.txt item you completed,
-   and keep CLAUDE.md/GLOSSARY.md/decisions.md true if you moved them.
+   tick your lane item in THIS file's queues below, and keep
+   CLAUDE.md/GLOSSARY.md/decisions.md true if you moved them.
    CHANGELOG.md is lane-neutral (append at top) so it rarely conflicts;
    if it does, it's a trivial resolve.
+
+STATUS KEY (check before starting anything — don't redo merged work):
+  [✓ x.y.z] = merged, see that CHANGELOG.md entry.  [~] = in flight in
+  another workspace.  [ ] = open. this file is ticked on merge, so also
+  scan the top of CHANGELOG.md for anything newer than the ticks here.
 
 
 WAVE 0 — the seatbelt (do this alone, merge fast, ~single branch)
 -----------------------------------------------------------------
+STATUS: PARTIAL — the unit layer landed (210 tests, 1.0.21: mocked-DB
+pytest for api auth/mongo logic, vitest for auth2 + sdk). still OPEN:
+github actions ci, the endpoint-level permission-matrix suite (FastAPI
+routes, star protection, forged tokens over HTTP), and the small
+security fixes below. that endpoint suite is still the top priority.
+
 before running 4-wide, land the thing that protects all 4 lanes:
 
   [seatbelt] github actions ci + the pytest permission-matrix suite
@@ -47,48 +59,49 @@ THE 4 LANES (each is an ordered queue; top of each = in flight now)
 -------------------------------------------------------------------
 
 LANE A — api / backend        (owns: api/**, docker-compose, settings)
-  A1. P0 python: uv + fastapi/pydantic/pyjwt upgrades
-      (the permission suite from wave 0 is the referee)
-  A2. P1 ferretdb/documentdb switch + compose profiles
-  A3. P3 setup wizard api side (setup mode, /setup, key generation,
+  [✓ 1.0.11] A1. P0 python: uv + fastapi/pydantic/pyjwt upgrades
+      (landed BEFORE the wave-0 endpoint suite — that referee is
+      still owed; see wave 0 status above)
+  [ ] A2. P1 ferretdb/documentdb switch + compose profiles
+  [ ] A3. P3 setup wizard api side (setup mode, /setup, key generation,
       node policy config) + one-container packaging (multi-stage
       dockerfile -- needs B2's build output, coordinate the handoff)
-  A4. P6 aggregate endpoint (the 5th verb, sandbox validator)
-  A5. P4 metering events (per-request event records for analytics)
+  [ ] A4. P6 aggregate endpoint (the 5th verb, sandbox validator)
+  [ ] A5. P4 metering events (per-request event records for analytics)
 
 LANE B — ui / frontend        (owns: auth2->ui/**, auth/**)
-  B1. P0 js: auth2 -> vite + bun + typescript
-  B2. P2 finish auth2 features, parity audit, rename to ui
-  B3. P3 setup wizard screens
-  B4. P4 admin panel: policy config, ad records crud, analytics
+  [✓ 1.0.12-1.0.14] B1. P0 js: auth2 -> vite + bun + typescript
+      (react 19, vitest, multi-stage dockerfiles, rtc to bun too)
+  [ ] B2. P2 finish auth2 features, parity audit, rename to ui
+  [ ] B3. P3 setup wizard screens
+  [ ] B4. P4 admin panel: policy config, ad records crud, analytics
       views (analytics needs A5 merged; build ui against fixtures
       until then)
 
 LANE C — greenfield services  (owns: media/, sdk/, mcp/, new dirs)
-  C1. P5 media service (presigned urls, minio profile, metadata
-      records) -- zero deps on A/B, start immediately
-  C2. P6 sdk rewrite (typescript, fetch, typed crud; aggregate
+  [~] C1. P5 media service (presigned urls, minio profile, metadata
+      records) -- zero deps on A/B, in flight (workspace, 16.07.2026)
+  [ ] C2. P6 sdk rewrite (typescript, fetch, typed crud; aggregate
       types land after A4 merges -- everything else doesn't wait)
-  C3. P6 mcp server (thin layer over the C2 surface)
-  C4. P10 backup integrations (drive/dropbox oauth, export/import
+  [ ] C3. P6 mcp server (thin layer over the C2 surface)
+  [ ] C4. P10 backup integrations (drive/dropbox oauth, export/import
       archive -- format comes from D1's conventions doc)
 
 LANE D — docs / apps / mobile (owns: mobile/**, social/, examples/,
                                *.md/txt)
-  D1. conventions doc (posts/media/contacts/inbox schemas) +
-      protocol spec draft (from api/web10.0.md). PURE WRITING,
-      zero conflicts, and THREE lanes consume it (C4, D4, D5).
-      do it first for exactly that reason.
-  D2. P7 tidy: crm/mail -> examples/, killer app dir (social/)
+  [✓ 1.0.18, 1.0.20] D1. conventions doc (posts/media/contacts/inbox
+      schemas) + protocol spec draft. docs/protocol-spec.md,
+      docs/conventions.md, docs/schemas/*.json — C4/D4/D5 now unblocked.
+  [ ] D2. P7 tidy: crm/mail -> examples/, killer app dir (social/)
       scaffolded as first-party (file moves, cheap)
-  D3. P11 mobile encryptor: the expo app can grow toward the real
+  [~] D3. P11 mobile encryptor: the expo app can grow toward the real
       keychain (secure enclave, key requests ui) fully in parallel
       -- it talks to the node over the existing api. the rtc key
       channel + sdk crypto integration waits for A/C, but the APP
-      doesn't.
-  D4. P8 killer app M0 slice: post + feed + lens chatbox. starts
+      doesn't. in flight (workspace, 16.07.2026)
+  [ ] D4. P8 killer app M0 slice: post + feed + lens chatbox. starts
       on the current wapi if needed; swaps to C2 sdk when it lands.
-  D5. P9 exporter core + instagram mapping (needs D1 conventions;
+  [ ] D5. P9 exporter core + instagram mapping (needs D1 conventions;
       client-side, so no api deps)
 
 
@@ -116,16 +129,18 @@ M3 "the network"         = encryption integration (A rtc + C2 sdk
                            polish. the last big merge.
 
 
-SUGGESTED FIRST CONDUCTOR BOARD (4 workspaces today)
-----------------------------------------------------
-  ws1: wave 0 seatbelt (ci + permission tests + small security fixes)
-  ws2: C1 media service (greenfield, conflicts with nothing)
-  ws3: D1 conventions doc + protocol spec (writing, conflicts with
-       nothing, unblocks three other queues)
-  ws4: D3 mobile encryptor modernization (expo app, own directory)
+CURRENT CONDUCTOR BOARD (as of 16.07.2026 — keep this section fresh)
+--------------------------------------------------------------------
+  ws1: wave 0 remainder: ci + ENDPOINT permission-matrix suite +
+       small security fixes (unit layer landed 1.0.21; this is what's
+       left, and it's still the highest-value slot)
+  ws2: C1 media service (in flight)
+  ws3: D3 mobile encryptor (in flight)
+  ws4: next unticked pick — C2 sdk rewrite, D2 tidy, or D5 exporters
+       (D1 merged, so D5 is unblocked); B2 if you want the B lane
+       moving (A1/B1/D1 are DONE — do not pick them again)
 
-  when ws1 merges -> replace with A1 (python upgrade, now refereed).
-  when ws3 merges -> replace with B1 (vite/bun/ts port).
-  from then on: pull the top of whichever lane's queue is unblocked.
-  lanes A and B are long marches; C and D are a stream of short
-  branches that keep two slots busy without ever touching A/B files.
+  from here on: pull the top unticked item of whichever lane's queue
+  is unblocked. lanes A and B are long marches; C and D are a stream
+  of short branches that keep two slots busy without touching A/B
+  files.


### PR DESCRIPTION
## Problem

Parallel agents (qwen included) keep re-attempting tasks that are already merged — e.g. D1 and B1. Root causes:

1. `parallel execution.txt` — the file agents pick tasks from — was never updated with completion status. It still said "do D1 first" and listed A1/B1 as open queue-tops.
2. Non-Claude agents never see the repo rules: codex-style harnesses read `AGENTS.md`, Qwen Code reads `QWEN.md`, and neither file existed.
3. Nothing told any agent to check plan.txt ticks / CHANGELOG.md before starting.

## Changes

- **`parallel execution.txt`**: lane queues now carry live status — `[✓ 1.0.11] A1`, `[✓ 1.0.12-1.0.14] B1`, `[✓ 1.0.18, 1.0.20] D1`, `[~]` on in-flight C1/D3, `[ ]` open. Wave 0 marked **PARTIAL** (unit layer landed in 1.0.21; endpoint permission-matrix suite + CI still owed — still the top-priority open slot). Rule 3 extended: tick your lane item here on merge. Stale "suggested first board" replaced with a dated current board.
- **`AGENTS.md`** (new) + **`QWEN.md`** (new): orientation entry points for non-Claude agents, pointing at CLAUDE.md and stating the check-before-you-start / tick-on-finish rules.
- **`.conductor/settings.toml`** (new): repo-wide `prompts.general` reminding Conductor agents to check done-status first (takes effect once merged to the repo's default branch).
- **`CLAUDE.md`**: new "check it isn't already done" convention; changelog rule now includes ticking the lane in `parallel execution.txt`.
- **`CHANGELOG.md`**: entry 1.0.24.

## Notes

- Pure docs/config — no code paths touched, no tests affected.
- The `[~]` in-flight markers are dated snapshots; the changelog remains ground truth (rules say to scan its top entries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)