### PR TITLE
Re-plan lens chatbox LLM backing: BYOK-only, phone-wallet key (D19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+1.0.41 || 17.07.2026
+lens chatbox llm backing re-planned (plan.txt phase 8): BYOK-only —
+v1 key stays client-side, chatbox calls go browser -> provider direct
+so the node never sees the key or the chat; presets work with zero llm;
+phase 11 upgrade puts the key in the phone wallet as an e2e-encrypted
+record the phone beams to the apps the user picks; node-provided
+inference demoted to a capped operator opt-in, never the default.
+new decision D19 in decisions.md.
+
 1.0.40 || 17.07.2026
 wave 0 seatbelt — endpoint-level permission-matrix suite (45 new tests,
 280 total api tests green). runs through the FastAPI app (TestClient)

--- a/decisions.md
+++ b/decisions.md
@@ -9,6 +9,27 @@ Status legend: [decided] intent set · [in-progress] · [open] still debating.
 
 ---
 
+### D19 — Chatbox LLM is BYOK-only; the key is a wallet secret the phone beams to chosen apps [decided]
+The phase-8 lens chatbox never runs on operator-paid inference by default: a
+free-signup node exposing a server-side LLM endpoint is a free API proxy, and
+the abuse lands on the operator's bill — exactly the surprise cost that kills
+hobbyist self-hosting. v1 is bring-your-own-key, held client-side
+(localStorage) and calling the provider directly from the browser, so the
+node never sees the key or the conversation. Presets (chronological, detox,
+close-friends) need zero LLM, so the "own your algorithm" pitch works without
+a key. Phase 11 graduates the key into the phone wallet: an e2e-encrypted
+record (ciphertext on the node, portable like everything else) that the phone
+beams only to the web10 apps the user picks at provisioning — the keyring's
+`agent:lens-llm` naming already anticipates this (D18). True revocation is
+rotating the key at the provider; device revocation only stops future
+provisioning. Node-provided inference may return later as an operator OPT-IN
+with hard per-user caps, never the default. The LLM's web10 token stays
+scoped to the lens service regardless (I5) — who pays for inference is
+independent of what the token can touch. Rejects: operator-pays-by-default,
+proxying chat through the node, storing the key as a plaintext record, and
+routing every chat call through the phone (D15: the phone is the root of
+trust, not a proxy).
+
 ### D18 — The keyring is generic like the record model: named keys, a small closed verb set [decided]
 The same discipline that made `{service, body}` survive: no hardcoded schema.
 Audiences are user-named keys (any string — a circle, a single record, an LLM

--- a/plan.txt
+++ b/plan.txt
@@ -535,8 +535,19 @@ rotting your brain? reconfig.
     posts to help it understand). it can never touch dms/contacts.
     scoped tokens make "an ai rewrites my feed" safe -- this is the
     token model earning its keep, say so in the demo.
-[ ] llm backing: node-provided by default (operator pays, it's an
-    acquisition feature), bring-your-own-key for the sovereign.
+[ ] llm backing: bring-your-own-key ONLY. v1: user pastes a key, it
+    stays client-side (localStorage), chatbox calls go browser ->
+    provider directly -- the node never sees the key or the chat.
+    never store the key as a plain record (operator-readable until
+    e2e). presets need zero llm, so "own your algorithm" works
+    without a key. phase 11 upgrade: the key lives in the phone
+    wallet as an e2e-encrypted record and the phone BEAMS it to the
+    web10 apps the user picks at provisioning (per-app; true
+    revocation = rotate the key at the provider). node-provided
+    inference is at most a later operator OPT-IN with hard per-user
+    caps, never the default: a free-signup node with a server-side
+    llm endpoint is a free api proxy, and the abuse lands on the
+    operator's bill. (D19)
 [ ] preset lenses to start from: chronological, close-friends-only,
     detox mode, creator mode. chatbox edits from there.
 [ ] the lens record is portable like everything else: your algorithm
@@ -638,6 +649,11 @@ the key hierarchy (what's in the wallet):
 [ ] storage: hardware-backed where the platform allows; enclave-
     wrapped at rest otherwise (ios secure enclave won't do x25519 --
     wrap the sodium keys under an enclave key, don't fight it).
+[ ] the wallet guards opaque secrets too, not just derived keys: the
+    byok llm api key (phase 8 chatbox) is an e2e-encrypted record
+    the phone beams only to the apps the user picks -- the node
+    holds ciphertext, the operator can never read or exfiltrate it,
+    and it moves nodes with you like any record. (D19)
 
 the keyring api (design it like the record api -- generic or dead):
 the record model survived because it never hardcoded a schema:


### PR DESCRIPTION
Planning-docs-only change; no code touched. Flips the phase-8 "llm backing" item in plan.txt from operator-pays-by-default to bring-your-own-key only: the v1 key stays client-side with chatbox calls going browser → provider directly (the node never sees the key or the chat), presets work with zero LLM, and node-provided inference is demoted to a capped operator opt-in. Adds a phase-11 wallet item: the BYOK LLM key is an e2e-encrypted record the phone beams only to the web10 apps the user picks at provisioning. Records the rationale (free-signup node + server-side LLM endpoint = free API proxy on the operator's bill) as decisions.md entry D19, with ties to D15/D18/I5. CHANGELOG entry 1.0.41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)