### PR TITLE
D20/D21 strategy pivot: creator-first plan, business plan, sales kit, timeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,218 @@
+1.0.46 || 18.07.2026
+D21: user billing stripped — users are never charged; credits/space
+metering repurposed as OPERATOR-SET quotas (rate/abuse throttle +
+storage caps, also closing the import-storage gap); stripe stays for
+the creator economy only. the studio monetization-menu screen
+(rung-0 cards) promoted INTO the M0 slice — the video shows the
+money screen (new lane items A6 + B4.5 M0-slice note; M0 milestone
+and timeline week 2 updated). outreach story-ammo gains the x
+examples (rev-share pauses, link throttling, reach-suppression as
+stated policy) — x-native creators are a fresh burn segment.
+KNOWN GAPS gains exporter battle-testing: D5 mappers are fixture-
+tested not mess-tested (week 3 real-takeout seeding = first battle
+test; promote llm-assisted mapping on first real break; white-glove
+absorbs the mess through M2); pitch-honesty facts recorded — youtube
+takeout exports content but in 50GB chunks from days-long jobs, the
+audience never ports from any platform (content ports, audiences
+are pointed), imported video plays direct-mp4 until transcode.
+imported-identity relinking recorded as a two-tier accepted
+tradeoff: ghost comments with origin provenance now; lazy
+claim-by-matching later (joiner's own takeout contains their
+comments — match origin+timestamp+text against ghosts and link
+automatically, no oauth/verification infra needed).
+timeline.md: dated M0→M2 execution schedule. weeks 0-4: B2.5 stack
+pick + D4 slice + integration + themed/seeded demo node on the colo
+box → M0 gate week (video shot by ~aug 17). weeks 5-10: the rule of
+100 (10-15 founder-sent/wk) in parallel with the creator-#1 minimum
+build (memberships + amazon tag card, hosted DR floor). verdict
+~oct 1; M2 oct-nov if green; breakeven ~mar-apr 2027. two tracks
+(machine vs founder) with founder attention named as the gating
+resource; ws2 repointed from C2 sdk (not M0-critical) to D4.
+
+1.0.45 || 18.07.2026
+the user's side of THE STORY (plan.txt): fans are a CONVERSION
+MULTIPLIER on the creator sale, not a second wedge — first sentence
+"never miss a post from [creator] + inner-circle status", quiet
+second sentence safety (delete deletes, expiry later via D16, not
+mined/sold); M0 is creator-community-shaped, not friend-graph-shaped.
+wannabe-creator segment added: we never out-dopamine tiktok (no
+lottery, no algorithm); the pitch is the LADDER — play the platform
+lottery, bank every win here where the house can't take it back —
+and since every account is creator-shaped, the user base IS the
+creator pipeline (the wordpress flywheel). aspirant psychology
+recorded: users want to BE seen, not just see — "your number is
+real here" (100% delivery flatters small accounts most; 5k = 5k),
+local fame via human curation (creator spotlights, never an
+algorithm), own-space-at-signup onboarding; manifesto.md gains the
+"you're not just in the crowd" block. THE RISE added: the aspirant's
+five-step rise-to-fame arc (free on a creator's node -> real numbers
+-> local fame -> pop off -> graduate to your own node, audience
+intact) with the economic rule "nobody pays before fame pays them
+first" (people can't afford infra until fame pops). GRADUATION added
+as a phase 10 item (mastodon Move-style follower auto-migration,
+fully live at M3; M3 deliverable gains the graduation demo). ranked
+communities added to phase 4 monetization: terms ACLs natively
+express membership tiers/ranks (the skool/whop paid-community model
+on existing machinery, ~97% payout); paid-community sellers added to
+outreach.md as a founding-creator segment (already charge members,
+most ban-prone segment); rule recorded: serve the mechanics, never
+the aesthetic — gamification layers are post-M2. THE RISE gains its
+failure branch: not popping off? switch nodes — identity/content/
+followers move sideways (same phase 10 mechanism), scene-market fit
+becomes searchable, nodes compete for rising talent, and operators
+stay honest because mistreated members walk with their followers.
+CLAUDE.md gains the D20 strategic orientation: social platform first,
+protocol second — protocol decisions judged by whether they make the
+creator platform better; generality for its own sake goes to later.md.
+KNOWN GAPS block added to the milestones: the video gap (founding
+creators #1-3 must be ones M0's format serves), memberships live
+before creator #1 (hard M2 prerequisite), a production hosted-ops
+floor before the first white-glove yes, and the dmca/csam t&s gate
+as pre-creator-#1 under white-glove hosting. adult-content fork
+decided in phase 12 (the wordpress answer, forced by stripe's terms):
+inc-hosted nodes + inc rails are clean-only; self-hosted nodes with
+their own processor are the operator's business under D10. onlyfans
+recorded as market proof (fans pay creators directly at ~$6B/yr, 20%
+take vs our ~3%, aug 2021 tried-to-evict-its-own-creators story) —
+mechanics yes, positioning never; outreach.md gains the story-ammo
+objection entry. phase 4 monetization menu researched + specced
+(07.2026 landscape): unlock ladder rung 0-4 — memberships/affiliate
+(levanta-class) day one, privacy-safe contextual fill (ethicalads-
+class; mediavine journey from ~1k sessions), sponsor-marketplace
+adapters (paved 30% / kit 23.5-30% takes = our 3% undercuts 10x),
+tracking programmatic opt-in-if-ever (manifesto constraint), and the
+M3 marketplace's nano tier ($20 promos at 5k followers — THE RISE
+stage 3 gets a paycheck; fame starts paying at 5k here, not 100k).
+phase 4 reframed as the STUDIO (youtube-studio mental model): one
+pane for post + analytics + revenue + the monetization menu rendered
+as a YPP-style unlock ladder (creators already read "X more to
+unlock Y"); creator-studio and operator-console personas designed
+as separable tabs from day one. zero-friction rule added: every menu
+option is a one-button card, adapters do the paperwork (qualify-
+gating, media-kit prefill from owned analytics, status tracking);
+rung 0 gains auto-affiliate-everything (skimlinks/sovrn pattern —
+links rewrite to earn at render); metric = time-to-first-dollar.
+composer-level monetization added (phase 8 posting flow): one-tap
+attach-product / mark-sponsored / member-gate (terms ACL on the
+record) / tips — the youtube-product-tags pattern, earning as part
+of the posting habit. amazon adapter v1 specced (07.2026 rules
+verified): paste-tag card, render-time /dp/ASIN + ?tag= rewriting
+(never cloaked), poster's-tag-wins-else-house-tag revenue routing,
+compliance baked in (disclosure chip, no email tags, no stale
+prices, 3-qualifying-sales-in-180-days countdown surfaced), pa-api
+picker deferred (gated on sales history), levanta/influencer-
+storefront as upgrade rungs. lane board gains B4.5: the STUDIO
+respec on the post-makeover stack — highest-stakes ui in the repo.
+AI product suggester specced (phase 4): scoped read-only llm on
+posts profiles the niche → studio suggestions feed + composer-time
+attach chips, always human-approved, v1 needs no pa-api; works from
+follower #1 (the wannabe gets an ai revenue manager); same profiling
+engine becomes the M3 marketplace's sponsor-matching brain; funded
+hosted-tier / byok (D19 pattern). first ai feature in the product is
+the money assistant — passes the D20 oracle where the chatbox didn't.
+new business-plan.md (v1): the lean company plan — automattic model
+(free software / hosted subscription / 3% rails / marketplace),
+proposed pricing tiers ($49/$199/$499 + 3%; founding creators free
+12mo; self-host free forever), unit economics (~$289 rev vs $70-200
+COGS per hosted creator), breakeven at ~5-10 paying creators, burn
+<$1.5k/mo, bootstrap-through-M2 funding posture, competition answers,
+top-5 risks, and milestone gates as kill tests. all numbers marked
+as estimates to falsify; pricing marked PROPOSED pending M2. CAC
+staged by tier: founder-sends-every-message for 100k-1M creators
+permanently (ai-sdr tools rejected for this tier — pattern-matched
+as spam; the in-house agent fleet runs the sdr back office instead:
+sourcing, enrichment, gap computation, draft-for-review), instantly/
+clay-class volume infra only for the post-M2 starter tier, flywheel
+as the scale CAC machine; outreach.md gains the agent-assisted-
+founder-sent division of labor. financial projections built out
+(§6a-e): 24-month bear/base/bull table (bear caps at ~$12k sunk;
+base breakeven ~month 9-10, ~$170k ARR month 24; bull ~$1M ARR),
+cumulative cash view ($0 outside capital required), KPI funnel
+dashboard, sensitivity ranking (close rate #1), and a "where this
+model lies" section (churn/LTV invented, $3k creator-revenue
+assumption, flywheel-shaped growth, founder time at $0). funding
+section expanded (§8a-c): no-investment path itemized (~$10-13k
+to breakeven), with-investment path ranked by leverage (creator
+guarantees — the substack-pro play — then designer, t&s, growth
+infra; pre-seed ~$350-500k compresses timeline ~12mo), and the
+raise trigger: never before the M0 gate, window opens at early M2
+traction, raise to accelerate a working machine, never to discover
+if it works. cost model corrected to real numbers: $200/wk tokens,
+$100/mo colo (64gb xeon hosts ~10-30 early nodes → ~$5-15 COGS/
+creator, 90%+ early margins), c-corp + trademark already done,
+founder-made demo video; ~$10k total to breakeven at ~$1k/mo burn.
+honest infra caveats recorded: single-box SPOF (off-box backups +
+restore drill for founding period, redundancy by paying tiers; colo
+bandwidth = video ceiling, R2 offload first) and the $6 dmca
+designated-agent registration as the one immediate legal spend.
+ec2/cloud compute explicitly rejected in the plan (4x compute cost,
+egress pricing is poison for a social/media platform, off-message
+for the ownership company); DR pattern = restore to hetzner-class
+dedicated on failure, second box at paying tiers, one-container
+node keeps infra reversible. horizontal-xeon scale path recorded
+(creator nodes are independent → embarrassingly parallel, failure
+domain 1/N per box, same-facility caveat → off-site DR floor).
+kill test upgraded to the RULE OF 100 (plan.txt M0, outreach.md,
+business-plan): 20 sends carry ~36% false-kill risk at a true 1/20
+close rate (0.95^20) — the verdict needs 100 sends, run in batches
+of 20 (batch one iterates the pitch), ~10-15 founder-sent per week
+(agent-drafted) over 8-10 weeks, segment split ~35/35/30, gate
+counts only with a meaningful video-watch share.
+business-plan §11 added: strategic alignments + exit posture —
+the open documentdb/ferretdb stack alignment as a NOW distribution
+asset (vendor devrel amplification; the M0 video travels to warm
+senior relationships as a progress note); plausible 5-year
+strategic homes described in loose terms only (public repo — no
+named companies or contacts in exit speculation); rule:
+bought-not-sold, roadmap never bends toward an acquirer.
+new manifesto.md: the fan-facing join-page manifesto every node ships
+(templated per creator, "you're not the product here — you're the
+point", no unshipped promises). site architecture settled in the docs
+cross-cutting section: ONE creator-first marketing site (web10.app,
+hero = THE STORY, cta = founding creator); fans convert on the
+creator's node via the manifesto page (wordpress/shopify pattern);
+no users tab, just a thin "powered by web10" footer explainer.
+
+1.0.44 || 18.07.2026
+outreach.md: the sales kit for M0's kill test (D20) — list-building
+queries (creators self-identify: shadowban/demonetization complaints,
+announced substack/rumble moves), cold email + DM + manager + call
+copy, cadence, and objection cheat sheet. core frames: lead with
+THEIR subs-vs-views gap; the ask is ADD not MOVE ("you already post
+to 5 platforms — this is #6, except you own it"), ~24h back-catalog
+onboarding via the exporters, 3 white-glove founding-creator slots,
+one per niche. plan.txt STORY beat 4 sharpened to the add-not-move
+frame. list-building has no prerequisites; sending waits on the M0
+slice + demo video.
+
+1.0.43 || 18.07.2026
+plan refactor (D20): the proposition is creator ownership — "own your
+audience, no shadow ban, this is a product for influencers." plan.txt
+gains THE STORY (the influencer pitch: subs-vs-views reach gap, AI-
+influencer urgency, 100%-delivery-by-architecture, hedge-not-exodus,
+kick/twitch-grade slick — never fediverse jank); thesis rewritten to
+lead with it. M0 redefined: "stands on its own" — post, feed
+(chronological + sort dropdown ONLY), profile, dms; deliverable = the
+pitch (story deck + demo video for creators), kill test = twenty
+creator pitches, not a viral video. feed customizability, preset
+lenses, the lens record, and the llm chatbox CUT from the roadmap to
+later.md (promotion bar recorded there; D19's byok architecture
+stands if it returns). lane board D4/D2.5 updated so no agent builds
+the chatbox; GLOSSARY lens entry updated. new decision D20 in
+decisions.md.
+
+1.0.42 || 18.07.2026
+later.md: new parking lot for far-out ideas that are deliberately NOT
+roadmap — vibe-coded apps/themes (the "real gutenberg"; no template
+dsl ever, tiers are theme-record now / generated apps far-later),
+the amorphous generative-ui app (shell + surfaces, generate-once-
+then-harden), and the conference-paper angle (lens as user-owned
+algorithm, scoped llm tokens; www/cscw/soups-class venues). each
+entry records why it's good AND why it's parked, with a promotion
+bar: m0 video shipped + a creator asked for it. distilled from a
+strategy review of plan.txt (killer-app-vs-protocol dependency,
+creator p&l, m0-first focus).
+
 1.0.41 || 17.07.2026
 lens chatbox llm backing re-planned (plan.txt phase 8): BYOK-only —
 v1 key stays client-side, chatbox calls go browser -> provider direct

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,16 @@ a tiny CRUD API. The data outlives any app. The long-term vision:
 creators (influencers) run nodes and monetize; user accounts are free;
 web10 Inc. takes a small % of revenue through its payment rails.
 
+**Strategic orientation (D20, 18.07.2026): social platform first, protocol
+second.** The product is a platform for influencers — own your audience, no
+shadow ban (100% delivery by architecture) — and the protocol exists to make
+that ownership possible. Protocol/feature decisions are judged by whether
+they make the creator platform better (the pitch truer, the creator P&L
+stronger, fan conversion higher); generality for its own sake goes to
+`later.md`. Read THE STORY at the top of `plan.txt` before touching product
+surfaces; the fan-facing voice lives in `manifesto.md`, the creator pitch in
+`outreach.md`.
+
 ## The stack (as of now — being modernized, see plan.txt phase 0)
 - `api/` — FastAPI. The node. All data + auth + billing + media. Entry: `api/app/main.py`.
   - Layered (since 1.0.31): `main.py` app init + middleware + router includes;

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -61,9 +61,10 @@ in `api/app/main.py` and `api/app/mongo.py` is the source of truth.
   web10 taking a percentage cut (`stripe.py`). The seed of the node revenue rail.
 
 ## Vision-era terms (not all built yet — see plan.txt)
-- **lens** — an app is a "lens" over data the user owns. The **lens record**
-  is the user's feed algorithm + experience config, stored as a record they
-  own and edit (including via the chatbox / an LLM).
+- **lens** — an app is a "lens" over data the user owns. (The **lens
+  record** — feed algorithm + experience config as a user-owned record,
+  editable via an LLM chatbox — was cut from the roadmap to `later.md`
+  in D20; the feed ships chronological + a sort dropdown.)
 - **inbox pattern** — feeds via fan-out-on-write: friends' nodes deliver
   posts into a collection you own, so reading your feed is one local query.
 - **zero-knowledge hosting** — the node stores ciphertext; keys live on the

--- a/business-plan.md
+++ b/business-plan.md
@@ -1,0 +1,407 @@
+# business-plan.md — web10 Inc, the business (v1, 18.07.2026)
+
+the lean business plan: model, pricing, unit economics, projections,
+costs, funding posture, risks. companion to plan.txt (product) and
+THE STORY (pitch). every number here is an ESTIMATE made explicit so
+it can be falsified — update this file when reality reports in.
+verify market figures before showing this to investors.
+
+---
+
+## 1. the business in one paragraph
+
+web10 Inc is the Automattic of creator-owned social: open,
+self-hostable software (free forever) + a hosted-node offering
+(subscription) + payment rails (~3% of revenue flowing through
+them) + eventually a sponsor marketplace (the nano-promo tier
+nothing serves today). the customer is the creator; users are free
+and arrive with the creator. the software is the funnel, hosting is
+the margin, rails are the compounding asset.
+
+## 2. problem + solution (one line each; THE STORY is the long form)
+
+- problem: creators rent their audience. 1M subs, 300k delivered.
+  the rent (reach throttling, demonetization, deplatforming) rises
+  every year, and AI-content floods make platform loyalty to human
+  creators strictly worse from here.
+- solution: a creator-owned node — their domain, their brand, 100%
+  delivery by architecture, their sponsors and memberships at ~97%
+  payout, portable forever. add-not-move: platform #6, the only
+  one they own.
+
+## 3. market
+
+- creator economy: ~$250B (2023, goldman sachs), projected ~$480B
+  by 2027. [VERIFY before external use]
+- serviceable segment: mid-tier creators (100k–500k followers) in
+  tier-one markets, monetizing or trying to — order 10^5 people —
+  plus paid-community operators (skool/whop/discord+stripe), the
+  highest-intent segment.
+- the wedge cohort (obtainable now): recently platform-burned
+  creators in that band. they self-identify publicly (reach-collapse
+  complaints, demonetization videos, announced substack/rumble
+  moves). outreach.md is the pipeline playbook.
+- comparable outcomes anchoring the ceiling: automattic ~$7.5B,
+  shopify, substack ~$650M–1.1B raise-era, onlyfans ~$6B+/yr GMV
+  with ~40 employees (the per-employee ceiling of the category).
+
+## 4. business model + pricing (PROPOSED — settle at M2)
+
+four revenue lines, in the order they turn on:
+
+1. HOSTED NODES (turns on at M2). subscription by community size:
+     - founding creators (first 3): free for 12 months, white-glove.
+     - starter: $49/mo (up to ~5k accounts)
+     - creator: $199/mo (up to ~50k accounts)
+     - scale: $499+/mo (beyond; storage/bandwidth passthrough for
+       heavy video — R2-class zero-egress keeps this sane)
+   self-hosting stays free forever (the credibility of the whole
+   ownership story depends on this — never gate the software).
+2. PAYMENT RAILS: ~3% of revenue flowing through web10 stripe
+   connect (memberships, tips, marketplace payouts). self-hosters
+   using their own processor pay 0 — the 3% is earned by
+   convenience, not lock-in (D5).
+3. SPONSOR MARKETPLACE (M3): the nano-tier ($20 promos at 5k
+   followers) up to real campaigns. take: 3% per D5 — evaluate
+   raising marketplace-side take to ~10% later; still 2-3x cheaper
+   than paved (30%) / kit (23.5-30%) / OF (20%). [DECISION OPEN]
+4. LATER, DEMAND-DRIVEN: white-label/agency tier (managers running
+   multiple creator nodes), premium studio features (AI suggester
+   is hosted-tier already, D19 pattern).
+
+the comparison that closes deals: a creator doing $3k/mo in
+memberships pays substack ~$300/mo, OF $600/mo, skool/whop
+$600-900/mo. web10 hosted: $199 + $90 rails = $289 — cheaper at
+$3k/mo and MASSIVELY cheaper as they grow ($10k/mo: substack $1k
+vs web10 $499). the take is flat-ish, not proportional: web10 gets
+cheaper as the creator wins. that's a pricing story no percentage
+platform can match, and it's D5's flat-3%+hosting doing the work.
+
+## 5. unit economics (per hosted creator node)
+
+- revenue/creator/mo (base case): $199 hosting + 3% of $3k
+  member/sponsor revenue = ~$289.
+- COGS/creator/mo (REAL infra: $100/mo colocation, 64GB xeon —
+  one box hosts ~10-30 small creator nodes): ~$5-15/creator at
+  early scale + media storage/egress ~$20-100 for video-heavy
+  nodes (R2-class offload, passthrough tier) + csam/email ~$10.
+  early gross margin: 90%+ on text/photo communities.
+- the honest infra caveats: ONE 2016 box = single point of
+  failure — every hosted creator goes dark together on a psu
+  death. free founding period: acceptable with transparency +
+  off-box backups + a REHEARSED restore (cross-cutting item);
+  the DR target is a hetzner/ovh-class dedicated box (~$40-60/mo,
+  20TB+ included traffic) spun up only on failure. by paying
+  tiers: a second box (another ~$500 ebay xeon or that hetzner
+  dedicated), priced in. colo bandwidth is the video ceiling —
+  R2 offload before any video-heavy creator onboards.
+- EXPLICITLY NOT EC2/cloud compute: 4x the compute cost and
+  egress pricing (~$0.09/GB) is poison for a social/media
+  platform — an egress business on aws turns $10 COGS/creator
+  into hundreds. also off-message: the ownership company runs
+  on hardware it owns. the phase 3 one-container node keeps
+  every infra decision reversible (docker run anywhere).
+- scale path: HORIZONTAL XEONS at the colo. creator nodes are
+  independent (no shared state across communities), so scaling
+  is embarrassingly parallel: +1 ebay xeon (~$500 one-time) →
+  place new nodes on it; failure domain shrinks to 1/N of
+  creators per box. ferretdb/postgres streaming replication per
+  node when a paying creator justifies it. caveat: N boxes in
+  ONE facility still share power/network — the hetzner-class
+  off-site restore stays the DR floor until a second site.
+- white-glove labor for founding creators is founder time,
+  unpriced at this stage.
+- CAC, staged by tier (the angles, examined):
+    - M0-M2, the 100k-1M tier (3-20 prospects): founder-sends-
+      every-message, PERMANENTLY for this tier — by 2026 creator
+      inboxes are wall-to-wall ai-personalized pitch spam and
+      managers delete it on pattern-match; the pitch's edge is
+      reading human. CAC ≈ $0 cash + founder hours (~20 pitches
+      per close assumed until measured).
+    - the ai-sdr trap, rejected: artisan/11x-class tools
+      ($1-3k/mo) are volume machines for interchangeable b2b
+      prospects — wrong motion for 20 named humans. INSTEAD: the
+      in-house agent fleet ($130/wk, already paid for) runs the
+      sdr back office as agent tasks — sweep public reach-gap
+      complaints, find biz emails/managers, compute each
+      prospect's subs-vs-views gap, detect burn events, draft
+      the personalized first line FOR FOUNDER REVIEW. research
+      automated, sending human.
+    - post-M2, the starter tier (5k-50k creators, self-serve):
+      volume outreach becomes legitimate here — instantly/clay-
+      class infra (~$100-300/mo), CAC target < 1 month gross
+      margin (~$200).
+    - at scale: the flywheel is the CAC machine (founding
+      creators' "why i left" content, graduation loop, inbound).
+      outbound only backfills; paid acquisition only if measured
+      LTV supports it.
+- LTV: unknown (churn unmeasured). the retention lever is owned
+  revenue in month one (memberships live before creator #1 —
+  KNOWN GAPS). model honestly only after 6 months of M2 data.
+
+## 6. financial projections (24-month model, three scenarios)
+
+model assumptions (base case — every one is falsifiable, §6d ranks
+which matter):
+- timeline: M0 slice + video by month 2; pitching starts month 2;
+  founding creators (free 12mo) onboard months 3-5; paid tiers
+  open month 6 (M2); marketplace (M3) contributes ~$0 within this
+  window (modeled as option value, not revenue).
+- close rate: 1 per 20 pitches (founder-sent). pitch cadence:
+  ~10-15/week after the video exists (agent-drafted, founder-
+  sent) — the rule of 100: the kill test is 100 sends in batches
+  of 20 over ~8-10 weeks, because 20 sends carry a ~36% false-
+  kill risk at a true 1/20 close rate.
+- blended revenue per paying creator: $289/mo early (creator tier
+  + rails on ~$3k/mo creator revenue), decaying to ~$200/mo
+  blended by month 24 as $49 starters mix in.
+- churn: 3%/mo assumed (INVENTED — see §6e). growth: flywheel
+  kicks ~month 12 (founding creators' "why i left" content +
+  graduation referrals), roughly doubling the close rate's yield.
+- costs: tokens ~$600/mo; blended COGS ~$100/creator/mo; tools
+  ~$200/mo; t&s/support contractor (+$1.5k/mo) from ~20 paying
+  creators; first real hire only past ~$25k MRR. founder salary
+  $0 throughout (the model's biggest unpriced cost — §6e).
+
+### 6a. scenario table (paying creators / MRR / monthly net)
+
+  month     bear            base              bull
+  ------    -------------   ---------------   -----------------
+  6         0 / $0 / -$1k   2 / $600 / -$1k   8 / $2.3k / +$1k
+  9         GATE FAILS      5 / $1.4k / ~$0   20 / $5.5k / +$3k
+  12        (stopped)       10 / $2.9k / +$1.5k   35 / $9k / +$5k
+  18        —               30 / $7k / +$4k   150 / $33k / +$22k
+  24        —               70 / $14k / +$9k  400 / $80k / +$55k
+
+  annualized at month 24:   ~$170k ARR         ~$1M ARR
+  headcount at month 24:    founder + 1 ctr    3-4 + agents
+
+- BEAR (gates fail): the full 100 pitches sent, meaningful video-
+  watch count, zero signs or zero posting — stop at month 9.
+  total cash sunk: ~$10-12k over 9 months. residual assets: the open-source node, the paper
+  (later.md conference angle), the 208+ community, the skillset.
+  the worst case is a funded education, not a crater.
+- BASE: breakeven ~month 9-10 (~5 paying creators). month 24:
+  ~$170k ARR, ~$9k/mo net to a solo founder — already a real
+  business, still 100% owned, growing on flywheel not spend.
+- BULL (a public graduation moment / AI-fear goes mainstream /
+  one founding creator is a hit): month 24 ~$1M ARR, raise becomes
+  optional leverage rather than oxygen. not planned against; the
+  plan only has to survive base.
+
+### 6b. cumulative cash view (base)
+
+months 1-9: -$12k cumulative (the full at-risk capital: token
+spend + infra + tools, no salary). months 10-24: self-funding;
+cumulative turns positive ~month 14-16. TOTAL OUTSIDE CAPITAL
+REQUIRED: $0. maximum drawdown ≈ one used car. the asymmetry (cap
+~$12k downside vs $170k-$1M ARR paths) is the entire investment
+case, and it's why bootstrapping is correct: selling equity to cap
+a $12k risk would be the worst trade in the plan.
+
+### 6c. the KPI dashboard (what gets measured, in funnel order)
+
+  1. pitches sent /wk (founder discipline — the leading indicator
+     of everything; target 5/wk once video exists)
+  2. reply rate → video-watched rate → call rate → close rate
+  3. time-to-first-post per signed creator (target <4 weeks;
+     this is the real "yes")
+  4. % of creator's audience that joins the node (the conversion
+     multiplier; the manifesto's grade)
+  5. creator's own monthly revenue on-node (drives rails revenue,
+     retention, and the case study for the next pitch)
+  6. MRR / churn / net revenue per creator (the boring truth)
+  7. cost per node (COGS creep watch, video especially)
+
+### 6d. sensitivity (which assumptions move the model most)
+
+  1. CLOSE RATE (1/20 vs 1/40 halves everything; 1/10 doubles it)
+  2. posting-within-4-weeks rate (a signed-but-dark creator is
+     $199 of revenue and a dead case study — the flywheel runs on
+     visible successes, not signatures)
+  3. creator's own revenue (the $3k/mo assumption): drives rails,
+     retention, and pitch #2's credibility. if real creators do
+     $500/mo, blended revenue/creator drops ~30% and the story
+     weakens more than the money does.
+  4. churn (3%/mo assumed blind; 6% pushes breakeven to ~month 14)
+  5. video COGS (the passthrough tier must actually get charged)
+
+### 6e. where this model lies (read before believing it)
+
+- churn and LTV are invented. no data exists until month ~12.
+- the $3k/mo creator-revenue assumption is doing enormous work
+  (rails revenue + retention story both hang on it).
+- the growth curve assumes the flywheel works (that founding
+  creators succeed VISIBLY and talk about it). if they succeed
+  quietly, growth is linear-by-pitching, roughly half the base.
+- founder hours are priced at $0. at ~20 paying creators the
+  white-glove + support load is a real job; the contractor line
+  appears then, but the model still underprices founder time
+  everywhere.
+- marketplace revenue is $0 in-window: honest, but it means the
+  10x-cheaper-marketplace wedge contributes nothing to these
+  numbers — pure upside if M3 lands.
+
+## 7. cost structure (REAL numbers, 18.07.2026)
+
+- build: ~$200/wk agent tokens (real) → ~$870/mo
+- infra: $100/mo colocation (64GB xeon; hosts staging + the first
+  ~10-30 creator nodes). media offload (R2-class) added when the
+  first video-heavy creator onboards.
+- legal: ~$0 — c-corp + trademark ALREADY DONE (the shield and
+  the brand exist). the one immediate spend: $6 dmca designated-
+  agent registration (cheapest safe harbor in existence) before
+  any hosted node serves media. tos/privacy = adapted boilerplate
+  until revenue pays a lawyer to dial it in.
+- demo video: founder-made, $0.
+- headcount: 0 beyond founder. hiring is triggered by M2 revenue
+  (first: t&s/support contractor, then a taste-owning designer),
+  never ahead of it.
+- total burn: ~$1k/mo. runway is effectively infinite for a
+  working founder.
+
+## 8. funding: the two paths, and when to raise
+
+### 8a. path one — no investment (the default; the whole base
+case in §6 IS this path)
+
+capital required before it pays for itself, itemized (REAL):
+  - agent tokens: ~$200/wk x 9 months ............ ~$7.8k
+  - colocation: $100/mo x 9 ...................... ~$0.9k
+  - domains/tools/misc ........................... ~$0.5k
+  - dmca designated agent ........................ $6
+  - legal (c-corp + trademark already done) ...... $0
+  - demo video (founder-made) .................... $0
+  - contingency .................................. ~$1k
+  TOTAL AT-RISK CAPITAL TO BREAKEVEN: ~$10k, spread over ~9
+  months, plus founder nights-and-weekends. burn ~$1k/mo means
+  breakeven at ~4-6 paying creators (~month 9-10); after that
+  the company pays for itself forever.
+this is affordable on a salary. no path dependency is created:
+bootstrapping to breakeven keeps 100% ownership and makes every
+later choice (raise, don't raise, lifestyle, swing) optional.
+
+### 8b. path two — with investment (what money actually buys here)
+
+be honest about what capital CANNOT buy in this plan: the founder-
+sent pitches (automating them kills them), taste (the kick/twitch
+bar is judgment), and the thesis validation itself ($12k covers
+that). so a raise before M0's gate buys almost nothing except
+dilution at the worst possible terms. what capital CAN buy, ranked
+by leverage:
+  1. CREATOR GUARANTEES (the substack pro play — the proven
+     capital use in exactly this market: substack paid writer
+     advances to buy its case studies). e.g. 10 creators
+     guaranteed $2k/mo for 6 months = $120k: converts the
+     scariest founding-creator objection ("will this pay?") into
+     a yes, and BUYS the visible successes the flywheel needs
+     instead of waiting ~12 months for organic proof.
+  2. a taste-owning designer/brand contract (~$60-90k/yr) — the
+     one hire that attacks the plan's weakest execution point
+     (beat 5, the polish bar).
+  3. t&s + support earlier (~$30-50k/yr contractor) — removes
+     the operational fear from white-glove hosting.
+  4. starter-tier growth infra + marketplace build-out (post-M2).
+a pre-seed of ~$350-500k covering 1-4 compresses the base-case
+timeline by roughly 12 months (month-24 base ≈ month-12 funded)
+and raises the odds the flywheel ignites at all (bought case
+studies > hoped-for case studies). that is the honest trade:
+money here buys TIME and PROOF-VELOCITY, not survival.
+
+### 8c. when to raise (the trigger, not the temptation)
+
+- NEVER before the M0 gate: pre-validation money = maximum
+  dilution for zero information. the $12k self-funded path buys
+  the same validation.
+- the window OPENS at early M2 traction, when the deck writes
+  itself: 3-5 paying creators + at least one VISIBLE success
+  (posting, earning, audience converted) + a measured funnel
+  (close rate, %-audience-joined, retention weeks). at that point
+  the story is "breakeven, 100% founder-owned, category comps are
+  automattic/OF, capital buys guarantees + speed" — the strongest
+  possible terms this company will ever see relative to risk.
+- RAISE IF, at that window: (a) demand outruns one founder's
+  white-glove capacity, or (b) the guarantee-fund math (8b.1)
+  clearly compresses the flywheel, or (c) a credible fast-follower
+  is moving. otherwise keep compounding at 100% ownership —
+  breakeven means raising stays a perpetual option, and optionality
+  unexercised costs nothing.
+- rule, stated once: raise to ACCELERATE a machine that is
+  measurably working; never raise to discover whether it works.
+  the milestones discover that for ~$500 each.
+
+## 9. competition (and the crisp answers)
+
+- rumble/locals/substack/patreon: platforms you still don't own —
+  they can throttle or drop you too. we sell the building, not a
+  nicer landlord. flat pricing beats their % take as creators grow.
+- skool/whop: 20-30% takes on communities; our tiers are terms
+  ACLs at 3% + hosting. same mechanics, 10x cheaper, owned.
+- mastodon/fediverse: jank, no creator economics, instance-flavored
+  identity. we are creator-first with kick/twitch-grade product
+  (beat 5) — different species, shared ancestor.
+- meta/tiktok/youtube: not competitors for the wedge — they're the
+  distribution we tell creators to keep using (add-not-move). they
+  cannot copy "no algorithm" without burning their revenue model.
+- a fast-follow startup cloning this: the real threat in an llm
+  world. moats: first-mover with the founding creators (brand
+  authorship), the rails network, open-source community gravity,
+  and speed. none are deep yet — being first to 10 creators is
+  the moat-building act itself.
+
+## 10. risks (top 5, honest)
+
+1. founder sales execution (the 208 pattern): the plan's #1 risk
+   is that pitches don't get sent. mitigation: outreach.md makes
+   sending mechanical; the M0 gate has a date.
+2. founding creators sign but don't post (weak-commitment yes):
+   mitigation: memberships live at onboarding, white-glove
+   includes a content-import + first-week plan, success metric is
+   posting-within-4-weeks not signing.
+3. video/streaming costs + polish vs the kick/twitch bar:
+   mitigation: creator #1-3 chosen from formats M0 serves (KNOWN
+   GAPS); R2-class storage; streaming deferred.
+4. t&s/legal incident on a hosted node before process exists:
+   mitigation: phase 12 gate is pre-creator-#1 (KNOWN GAPS);
+   clean-only rails (stripe ToS) already decided.
+5. stripe dependency: rails revenue and clean-content policy both
+   hang on stripe connect. mitigation: it's the industry default
+   and D5 predates this doc; adapterize payments later the way ads
+   are adapterized now. [watch, don't build yet]
+
+## 11. strategic alignments + exit posture (dessert, not dinner)
+
+- breakeven-at-5-customers means web10 NEVER needs to sell —
+  every strategic conversation happens from "we're fine" posture.
+- the stack alignment is REAL and useful NOW, before any exit
+  talk: web10's phase 1 (shipped) runs on the open documentdb/
+  ferretdb stack — the MIT-licensed, linux-foundation answer to
+  mongo's SSPL, open-sourced by a major cloud vendor. that makes
+  web10 one of the more visible consumer products on that stack,
+  and vendor oss/devrel machines amplify ecosystem wins: blogs,
+  conference slots, credibility — DISTRIBUTION, claimable at M0.
+  warm senior relationships exist in that world; the M0 video
+  travels there as a progress note between people who've talked
+  before, never as a pitch.
+- plausible strategic homes exist in a 5-year frame (the
+  github-playbook acquirer that buys where a community lives and
+  keeps it neutral; the shape-twin in open publishing; edge/
+  self-host infra players; payments + creator-commerce
+  platforms). listed for awareness only.
+- THE RULE: companies are bought, not sold. the roadmap never
+  bends toward an acquirer — acquirers only pay real money for
+  the thing that was built for customers (the creator network
+  is the unbuyable part). revisit this section only when someone
+  else brings it up.
+
+## 12. the operating cadence (how this plan gets executed)
+
+- the board stays CHANGELOG.md + plan.txt + lane ticks (no external
+  pm). this file gets a dated revision whenever a number turns real.
+- weekly founder discipline through M2: ship the slice (agents),
+  10-15 outreach sends/week once the video exists (rule of 100:
+  the verdict needs the full hundred), one P&L review of any
+  live node.
+- every milestone is a kill test first, a celebration second
+  (gates in §6). the plan's superpower is cheap falsification —
+  use it: no gate, no next phase.

--- a/decisions.md
+++ b/decisions.md
@@ -9,6 +9,48 @@ Status legend: [decided] intent set · [in-progress] · [open] still debating.
 
 ---
 
+### D21 — User billing is stripped; metering survives as operator-set quotas (anti-abuse), and the money screen is in M0 [decided]
+Users are never charged (D5: accounts free, paid by the operator's revenue),
+so the legacy per-user billing surface (plans, user subscriptions, per-account
+Stripe) is stripped from the product. The metering machinery it rode on
+(credits/space, `charge()`, the star-record ledger) is NOT deleted — it is
+repurposed as node policy: operator-set per-user quotas, where credits =
+rate/abuse throttle and space = storage caps (which also solves the
+import-storage-lands-on-the-creator gap). Stripe remains for the creator
+economy only (memberships, rails, marketplace). Second half of the decision:
+the Studio's monetization-menu screen (the rung-0 cards — memberships,
+Amazon tag, direct deals) is an M0 deliverable, because the pitch to
+creators is money and the demo video must SHOW the money screen, not
+describe it. Rejects: charging end users anything, deleting the metering
+code (it's the quota system), and shipping an M0 demo whose economics are
+a slide instead of a screen.
+
+### D20 — The proposition is creator ownership + no shadow ban; the killer app stands on its own; lens/customizability cut to later.md [decided]
+This is a product for influencers, and largely a story business. The pitch
+("THE STORY" in plan.txt) has to land as "oh shit... this is the only way":
+(1) you already don't own your audience — 1M subs and the video does 300k;
+subs are not delivery, and the reach gap IS the shadow ban, visible in your
+own analytics; (2) urgency — AI influencers are arriving in volume and the
+algorithm has no loyalty to humans; own your persona and channel NOW;
+(3) ownership is the only structural defense: the inbox pattern (fan-out on
+write) delivers to 100% of followers BY ARCHITECTURE — it can't be quietly
+revoked because it isn't a policy; (4) it's a hedge, not an exodus — the home
+base is owned, platforms become distribution; (5) it must be THE COOL THING:
+Kick/Twitch-grade slick, never fediverse jank (PeerTube, even Mastodon) — if
+it looks like a protest app, the pitch dies on the first screenshot.
+Consequences: the killer app must stand on its own as a plain good social app
+(post, feed, DMs, media); the feed is chronological + a sort dropdown — "no
+algorithm" IS the feed feature and costs zero code beyond the inbox pattern.
+Feed customizability, preset lenses, the lens record, and the LLM chatbox are
+cut from the roadmap to later.md (<5% of users touch settings; retention
+comes from defaults; "the customizable social network" was Ello/Vero's pitch
+and it doesn't travel). M0's kill test becomes twenty creator pitches, not a
+viral consumer video. D19's BYOK architecture stands ready if the chatbox
+earns its way back (promotion bar in later.md). Rejects: "own your algorithm"
+as the lead pitch, feed customizability as a launch feature, the
+consumer-demo wedge as primary distribution, and fediverse-adjacent
+positioning/aesthetics.
+
 ### D19 — Chatbox LLM is BYOK-only; the key is a wallet secret the phone beams to chosen apps [decided]
 The phase-8 lens chatbox never runs on operator-paid inference by default: a
 free-signup node exposing a server-side LLM endpoint is a free API proxy, and

--- a/later.md
+++ b/later.md
@@ -1,0 +1,147 @@
+# later.md — far-out ideas, deliberately NOT on the roadmap
+
+this file is the parking lot for ideas that are exciting, plausibly real,
+and explicitly not being built now. plan.txt's LATER section holds
+near-term deferrals (perf, clickhouse, schema contracts); this file
+holds the sci-fi tier. the bar for promoting anything out of here:
+the M0 video has shipped AND a creator conversation asked for it.
+until then, nothing below is anyone's task.
+
+each entry records the idea, why it's genuinely good, and the honest
+reason it's parked — so it doesn't get re-pitched from scratch every
+six months (same job decisions.md does for settled calls).
+
+
+## the lens: feed customizability + the llm chatbox (cut from phase 8, D20)
+
+the idea: the feed algorithm + experience config as a record the user
+owns (ranking rules, topic mutes, weights, time budgets, ui toggles),
+preset lenses (chronological, close-friends, detox, creator mode),
+and a chatbox where an llm edits the record in english. "my feed
+algorithm is my prompt" / "nobody has ever owned their algorithm
+before."
+
+why it's good:
+- technically NOT far out: a bounded llm task (read a json config,
+  apply an instruction, emit a schema-validated diff, show it, apply
+  it). the feed re-renders instantly from config; the llm is only in
+  the loop at moments of change. byok plumbing already decided (D19).
+  roughly a week of work on top of a config-driven feed.
+- the most legible 10-second demo of data ownership that exists:
+  "i told an ai to fix my feed and watched it happen." if a
+  consumer-attention wedge is ever needed, this is the cheapest
+  attention machine in the repo.
+- incumbents can't copy it without self-harm: engagement-optimized
+  feeds ARE their revenue.
+
+why it's parked (D20):
+- the buyer is the creator, and the creator pitch doesn't need it:
+  ownership + no-shadowban + monetization close the deal or nothing
+  does. the killer app stands on its own as a plain good social app
+  or it isn't killer.
+- <5% of users ever open settings. retention comes from good
+  defaults, not configuration surface. "the customizable social
+  network" was ello/vero's pitch and it doesn't travel.
+- the feed ships chronological + a sort dropdown. "no algorithm" is
+  itself the anti-shadowban feature (THE STORY beat 3) and costs
+  zero code beyond the inbox pattern.
+
+promotion bar (on top of the file's): creators or their audiences
+ASK for feed control, or the creator-pitch wedge stalls and a
+consumer-attention wedge is needed.
+
+
+## vibe-coded apps / themes (the real gutenberg)
+
+the idea: an llm generates a complete web10 app on request — react +
+the typed sdk (phase 6) + the conventions doc (D1) as its context —
+deployed as static files, talking to the user's node under a scoped
+token. "wordpress themes" where the marginal cost of a whole app
+dropped to the cost of a theme, so apps ARE the themes. themes/apps
+are records: portable, shareable, remixable ("steal this look" —
+the tumblr effect).
+
+why it's good:
+- interoperability is what makes generated apps safe to be DISPOSABLE:
+  the data outlives every app, so the worst a bad one does is render
+  your life ugly. no other platform can offer "run untrusted generated
+  code over your social data" — scoped tokens (I5) + the consent
+  screen bound the blast radius.
+- phases 6/6.5 are already building the llm's raw materials without
+  calling them that: typed sdk, json schemas, create-web10 templates.
+  an llms.txt-style bundle of those IS the theme development kit.
+
+why it's parked:
+- the sandboxing problem is real and unsolved here: scoping limits
+  what a generated app can REACH, not what it can EXFILTRATE from
+  what it reads. the boring answer is csp (connect-src pinned to the
+  user's node for personal apps; review-gated for shared ones) —
+  design it when tier 3 is actually being built, not before.
+- decided in-conversation, worth keeping: NO homemade template/block
+  dsl (the middle gutenberg tier). rectangles-npm was this mistake
+  once already. tiers are: (1) theme record — design tokens + ui
+  toggles as a user-owned record (was near-term while the chatbox
+  existed; parked with it under D20 — operator-level theming, a
+  creator's node wearing THEIR brand, remains phase 2.5 roadmap);
+  (3) whole generated apps, above. there is no tier 2.
+
+
+## the amorphous app (generative ui / just-in-time software)
+
+the idea: web10-social as a shell + llm chat. "i want to message
+friends" -> it codes the messenger on the spot, wired to your real
+contacts and dm records. the app is clay: surfaces get generated,
+then persist as records (generate-once-then-harden — the llm is the
+BUILDER you summon, never the per-session renderer).
+
+why it's good:
+- every generative-ui experiment dies on state: conjured apps own
+  their data, so regeneration = amnesia. web10 severs exactly that —
+  data model fixed and durable, apps stateless lenses. a conjured
+  messenger here opens ALREADY FULL of your life (exporters +
+  conventions doc). the 2021 protocol is accidentally the
+  persistence layer for software that doesn't exist until asked for.
+- demo arc: wish 1 changes what you see (lens), wish 2 changes what
+  EXISTS (a new surface, populated). wish 2 is the m1/m2 showstopper
+  — one pre-rehearsed generation, not a general capability.
+
+why it's parked:
+- as a daily driver it fails on boring physics: social apps open 40x
+  a day on reflex; codegen takes a minute and costs tokens. muscle
+  memory is a feature — an app that's different every morning is a
+  usability bug. one-shot generated code is demo-grade, not the
+  hundred-small-refinements grade a lived-in messenger needs.
+- if it ever graduates: the shape is shell + surfaces (shell = auth,
+  consent, chatbox, sandbox, design tokens — permanent; surfaces =
+  generated artifacts stored as records — mutable). that split would
+  change phase 8's structure, so decide BEFORE building it, in
+  decisions.md, not by drift.
+
+
+## the conference paper (distribution, not product)
+
+the idea: the problem is validated at the highest level (berners-lee/
+solid, activitypub, at protocol, gdpr/dma) — if web10 advances the
+state of the art, publish it. worst case upgrades from "dope project"
+to "citable contribution."
+
+the publishable claims (scoped honestly — reviewers will check):
+- the lens: feed algorithm as a user-owned, portable record, edited
+  by an llm under a scoped token. closest prior art is bluesky's
+  feed generators (feeds OTHERS run that you pick); the delta is
+  ownership + natural-language editing + token scoping. cite at
+  proto or die in review.
+- scoped/expiring/revocable tokens for llm agents over personal data
+  stores (I5 + mcp) + the conformance suite mechanically enforcing
+  the invariants.
+- NOT publishable alone: {service, body} simplicity vs solid's rdf
+  (engineering taste, not a result).
+
+venues: thewebconf (www) demo track, cscw/icwsm, soups (consent/terms
+angle); fosdem/dweb talks are not papers but reach exactly the
+self-hosting audience and double as distribution.
+
+why it's parked: the m0 demo IS the evaluation artifact — a dozen
+real users reconfiguring feeds via the chatbox, with before/after
+measurements, is the eval section nearly for free. paper is a
+byproduct of shipping m0, never a substitute for the video.

--- a/manifesto.md
+++ b/manifesto.md
@@ -1,0 +1,71 @@
+# manifesto.md — the fan-facing manifesto (ships on every node)
+
+the user-side conversion asset (THE STORY, "the user's side"). this
+is the page a fan hits when [CREATOR] points their audience at the
+node — the join screen's opening. it has to read like a movement,
+not a feature list, and land as "fuck yeah." rules: no web10 jargon,
+no unshipped promises (e2e/expiry copy joins when those phases ship),
+[CREATOR] templated per node, short enough to read in 30 seconds.
+
+---
+
+## THIS PLACE IS DIFFERENT.
+
+You subscribed to [CREATOR]. The platform decided whether you'd
+ever see them again.
+
+A million people follow. Three hundred thousand are shown. That
+was never a glitch — it's the business model. Your attention gets
+auctioned, your feed gets rigged, and the person you actually came
+for gets buried under whatever pays better.
+
+Not here.
+
+**Here, you see everything [CREATOR] makes. Every post. Every
+time.** There is no algorithm between you and them. Nothing is
+promoted into your feed, nothing is buried out of it. Newest
+first. That's it.
+
+**Here, nobody is mining you.** Your data isn't scanned, sold, or
+fed to an ad machine. The only sponsors you'll ever see are ones
+[CREATOR] chose and vouches for — and that's how they keep this
+place running without selling you.
+
+**Here, delete means delete.** Your stuff is yours. Take it with
+you, wipe it, export it to your own drive. This isn't a permanent
+record waiting to be used against you someday.
+
+**Here, [CREATOR] owns the building — and can never be evicted.**
+No shadow bans. No demonetization. No terms-of-service massacre.
+This place exists as long as they want it to, and you're in it
+with them.
+
+**And you're not just in the crowd.** Joining gives you your own
+page, your own followers, your own space — and your number here is
+*real*. Every follower you earn sees every post you make. Five
+thousand followers here means five thousand people actually see
+you. Ask the other platforms what your number really buys there.
+
+You are not the product here. You're the point.
+
+You found this place early. That means something — founding
+members are the reason it works.
+
+**Welcome to the inner circle.**
+
+[ JOIN — it's free ]
+
+---
+
+## placement + variants
+
+- renders as the node's landing/join page for logged-out visitors
+  (phase 2.5 makeover territory: this page must be the slickest
+  screen in the app — it IS the conversion moment).
+- the creator can edit it (it's their node), but this ships as the
+  default. their voice on top of this skeleton beats a blank page.
+- add when shipped, not before: expiring-posts line (D16 user-facing
+  expiry), operator-can't-read-your-DMs line (phase 11 e2e).
+- a general web10.app version of this manifesto (not creator-
+  templated) is marketing-ui copy — the "why" explanation pages in
+  the docs plan already cover that slot; reuse this voice there.

--- a/outreach.md
+++ b/outreach.md
@@ -1,0 +1,204 @@
+# outreach.md — the twenty pitches (M0 kill test, D20)
+
+the actionable version of THE STORY. this file is the sales kit:
+who to contact, how to find them, and the exact copy to send.
+prerequisite before SENDING: the M0 slice + the 2-minute demo video.
+list-building starts NOW (no prerequisite).
+
+rules for all copy below:
+- never say: web10, protocol, node, sovereignty, federation, records.
+- always say: your site, your domain, your audience, 100% delivery.
+- lead with THEIR number (subs vs. views). the pitch is their own
+  analytics explained.
+- the offer is always white-glove and free for founding creators:
+  we do the port, the domain, the branding. a yes costs them nothing.
+- "founding creator" framing turns earliness from a risk into status.
+  scarcity is real: 3 founding slots, one per niche.
+- the ask is ADD, not MOVE. they already post to 5 platforms; this
+  is #6, except they own it. back catalog imports in ~24 hours.
+  never let the pitch sound like "migrate your livelihood."
+
+---
+
+## 1. build the list (start today — 100 names total, ~35/35/30 by
+segment, worked in BATCHES of 20)
+
+the rule of 100: at a true 1-in-20 close rate, 20 sends still
+produce zero closes ~36% of the time — a sample that size can kill
+a working thesis on noise. 100 sends make zero-closes a real
+verdict (~0.6% if the thesis is true). batch one (20) is the
+pitch-iteration lab: learn objections, fix copy; batches 2-5 run
+the improved pitch. the agent fleet makes 100 enriched prospects
+affordable (back office below); the founder still reviews and
+sends every message — ~10-15/week ≈ 100 sends in 8-10 weeks.
+the kill gate counts only if a real share WATCHED the video —
+silent sends test deliverability, not demand.
+
+qualification: 100k–500k followers, recently platform-burned,
+active (posted in last 2 weeks), has a business email or manager
+listed. one per niche so founding slots stay scarce.
+
+sourcing queries (they self-identify in public):
+- X/twitter search: "shadowbanned", "reach is dead", "why is nobody
+  seeing my posts", "youtube demonetized me", "only 10% of you see"
+- youtube: recent "I got demonetized" / "my channel is dying" /
+  "why I'm leaving" videos in the 100k–500k band
+- already-moved signals (proven willingness to try owned channels):
+  creators who announced substack/patreon/rumble/locals moves
+- paid-community sellers (skool/whop/discord+stripe operators):
+  already charge members, already off-platform, most ban-prone
+  segment alive (incl. payment rails). pitch variant: "own the
+  building, keep ~97% instead of skool/whop's cut, nobody can
+  evict you." strong wildcard-slot candidates.
+- segment split per D20: ~35 right-coded, ~35 left-coded, ~30
+  wildcard (fitness, gaming, art, finance, adult-adjacent,
+  paid-community sellers, local)
+
+for each: name / platform / subs / recent avg views (compute the
+gap %) / burn event / contact route (biz email, manager, DM) / niche.
+track in one sheet. the gap number personalizes every template below.
+
+AGENT-ASSISTED, FOUNDER-SENT (the division of labor): the agent
+fleet runs the back office — sourcing sweeps, email/manager lookup,
+gap computation, burn-event detection, drafting the personalized
+first line for review. the founder reviews and SENDS every message
+personally at this tier. never automate the send: creator inboxes
+are drowning in ai pitch spam, and reading human is the whole edge.
+
+---
+
+## 2. cold email — creator direct (biz inquiry address)
+
+subject: your last video did [280k]. you have [1.2M] subs.
+
+> Hi [NAME] — [one specific, real sentence about a recent post/video
+> so this can't be mistaken for spam].
+>
+> Quick question: [1.2M] people subscribed to you. When you post,
+> [PLATFORM] shows it to about [23%] of them. That gap is the
+> platform's decision, not your content — and it gets worse every
+> year.
+>
+> You already post to five platforms. This is a sixth — except you
+> own it: your own site, on your domain, under your brand — looks
+> like Twitch, not like some janky alternative — where a post
+> reaches **100% of your followers, every time, by design**. Your
+> sponsors, your member revenue, your data. Nothing about your
+> routine changes; this is the one surface nobody can throttle,
+> demonetize, or delete.
+>
+> Onboarding takes about 24 hours: I import your entire back
+> catalog ([PLATFORM] export → your site, one shot), set up your
+> domain and branding, and hand you the keys. Free and white-glove
+> for three founding creators this [season]. One slot per niche.
+>
+> Worth 15 minutes? Or reply "video" and I'll send the 2-minute demo.
+>
+> — Jacob [signature: site, phone]
+
+---
+
+## 3. cold DM — creator direct (X/IG, 4 lines max)
+
+> your last 5 posts averaged [300k] views. [1.2M] followers. that
+> gap is [PLATFORM]'s choice, not yours.
+> you already post to 5 platforms — i set up a 6th you actually OWN.
+> your domain, 100% delivery to your followers, your sponsor +
+> member revenue. whole back catalog imported in 24 hours, free,
+> for 3 founding creators. one per niche.
+> want the 2-min demo video?
+
+---
+
+## 4. cold email — manager/agency variant
+
+subject: owned distribution channel for [CREATOR] — no exclusivity conflict
+
+> Hi [MGR NAME],
+>
+> [CREATOR]'s reach on [PLATFORM] is running ~[23%] of subscriber
+> base and declining — you can verify in the dashboard. Every brand
+> deal you price is discounted by that number.
+>
+> I set up creator-owned platforms: [CREATOR]'s own property on
+> their own domain, 100% delivery to opted-in followers, direct
+> sponsor inventory they control (podcast-grade CPMs, exportable
+> reporting) plus member subscriptions — ~97% payout. It's an
+> additional surface, not a move: [CREATOR] already distributes to
+> five platforms; this is a sixth, with zero exclusivity conflict,
+> and onboarding is ~24 hours (full back-catalog import).
+>
+> For three founding creators we run the entire setup — back
+> catalog, domain, branding — at no cost. The asset appreciates:
+> the audience relationship becomes something [CREATOR] owns
+> outright, which no algorithm change can reprice.
+>
+> 15 minutes this week? Demo video on request.
+
+---
+
+## 5. cold call — 30-second opener (if a number exists)
+
+"Hi [NAME], I'll be quick — I build creator-owned platforms.
+You've got [1.2M] subs and [PLATFORM] delivers your posts to about
+a quarter of them. You already post to five platforms — I set up a
+sixth you own: your domain, your brand, every post reaches
+everyone, your sponsors and member revenue. Back catalog imports
+in 24 hours, free for founding creators. Can I send you a
+2-minute video of it working?"
+(goal of the call is ONLY the yes to the video.)
+
+---
+
+## 6. cadence + scoreboard
+
+- day 0: email (or DM if no email). day 3: one-line bump ("worth a
+  look?" + the video link directly this time). day 10: value-add
+  close ("keeping one [niche] slot open through [date], then I'm
+  filling it") — then stop. never more than 3 touches.
+- send ~10-15/week (agent-drafted, founder-reviewed, founder-sent)
+  in batches of 20 so learnings improve the next batch.
+- log per prospect: opened? replied? watched video? call? yes/no +
+  stated objection. objections are the product roadmap (D20: the
+  promotion bar for parked features is creators ASKING).
+- kill-test math: 100 prospects, 3 touches each, 8-10 weeks.
+  expect ~30-40% reply rate on DMs with their own numbers in line
+  one, less on email → ~20-40 video watches → ~5-15 calls →
+  1-5 closes at the assumed 1/20. one yes = M2 begins. zero yeses
+  after 100 sends WITH a meaningful watch count = the thesis has
+  a problem — that's the signal, don't soften it. (20 sends is
+  NOT a verdict: 0.95^20 ≈ 36% false-kill risk.)
+
+---
+
+## 7. objection cheat sheet
+
+- "how is this different from rumble/locals?" — those are platforms
+  you still don't own; they can throttle or drop you too. this is
+  YOUR site on YOUR domain. if we disappear tomorrow, your site and
+  audience remain.
+- "i don't want to run servers." — you don't. founding creators get
+  it run for them (hosted), and you can take it anywhere later —
+  that portability is the point.
+- "i'm not moving my livelihood." — you're not moving anything.
+  you post to five platforms today; this is a sixth. 24 hours of
+  onboarding, then it's one more surface in the routine you
+  already have — the only one you own.
+- "my audience won't move." — they don't have to. the diehards
+  join your home base, everyone else keeps watching where they
+  already do, and the back-catalog import means day one isn't
+  empty.
+- "what does it cost?" — founding creators: free setup + hosting for
+  [period]; after that, hosting at cost + ~3% of revenue through the
+  platform. no revenue, no cut.
+- "is this crypto?" — no. no tokens, no chains. it's your own
+  website with delivery guarantees.
+- story ammo (use sparingly, they're devastating): onlyfans takes
+  20% and in aug 2021 announced a ban on its own creators' content
+  — even THE creator-money platform proved you were renting.
+  youtube's 2017 adpocalypse, twitch's 2023 branded-content rules,
+  x's rev-share payouts paused/reformulated under creators + link
+  throttling + "freedom of speech not freedom of reach" (the shadow
+  ban as stated policy), every TOS massacre: same story, pick the
+  one from THEIR world. we take ~3% + hosting, and eviction is
+  architecturally impossible.

--- a/parallel execution.txt
+++ b/parallel execution.txt
@@ -85,6 +85,12 @@ LANE A — api / backend        (owns: api/**, docker-compose, settings)
   [✓ 1.0.38] A4. P6 aggregate endpoint (the 5th verb, sandbox validator;
       per-stage metering through charge(); wapi.aggregate in legacy sdk)
   [ ] A5. P4 metering events (per-request event records for analytics)
+  [ ] A6. D21 strip user billing → quotas: remove user-facing
+      plans/subscriptions/per-account stripe; repurpose credits/
+      space + charge() as OPERATOR-SET per-user quotas (credits =
+      rate/abuse throttle, space = storage caps incl. imports).
+      stripe stays for the creator economy only (memberships,
+      rails). keep the permission-matrix tests green through it.
 
 LANE B — ui / frontend        (owns: auth2->ui/**, auth/**)
   [✓ 1.0.12-1.0.14] B1. P0 js: auth2 -> vite + bun + typescript
@@ -98,6 +104,19 @@ LANE B — ui / frontend        (owns: auth2->ui/**, auth/**)
   [✓ 1.0.40] B4. P4 admin panel: policy config, ad records crud, analytics
       views (analytics needs A5 merged; build ui against fixtures
       until then)
+  [ ] B4.5. P4 the STUDIO respec (post-B2.5, on the new stack):
+      youtube-studio frame, monetization menu as one-button cards
+      with the YPP-style unlock ladder, amazon adapter v1 (tag
+      card, render-time tagging, compliance chips, 3-sales
+      countdown), memberships/tiers wiring to stripe rails.
+      composer monetization affordances land in D4's composer
+      (coordinate, don't reach into lane D files). this screen is
+      the M2 demo -- highest-stakes ui in the repo.
+      M0 SLICE OF THIS (D21): the menu SCREEN with rung-0 cards
+      (memberships, amazon tag, direct deals) ships inside the M0
+      window so the demo video shows the money screen -- visually
+      complete + rung-0 functional; deeper wiring (unlock ladder,
+      adapters) follows in weeks 5-10.
 
 LANE C — greenfield services  (owns: sdk/, mcp/, new dirs)
   [✓ 1.0.25] C1. P5 media service (presigned urls, minio profile,
@@ -124,14 +143,18 @@ LANE D — docs / apps / mobile (owns: mobile/**, marketing/, examples/
       folders removed. 35 new tests, shared mock factory.
   [ ] D2.5. P2.5 ui makeover in web10-social: rectangles-npm ->
       mainstream stack (match B2.5's pick + design tokens), story-
-      first pass (empty states, lens/chatbox forward). pairs with
-      D4 -- the M0 demo screens are the acceptance bar.
+      first pass (empty states point at exporters; kick/twitch-grade
+      slick is the visual bar -- THE STORY beat 5, D20). pairs with
+      D4 -- credible-in-a-creator-pitch is the acceptance bar.
   [✓ 1.0.27] D3. P11 mobile encryptor: complete rebuild landed —
       expo 52, crypto core (hkdf, ed25519/x25519, xchacha20), wallet
       persistence, tabbed UI, 55 tests. the rtc key channel + sdk
       crypto integration still waits for A/C (phase 11 proper).
-  [ ] D4. P8 killer app M0 slice: post + feed + lens chatbox. starts
-      on the current wapi if needed; swaps to C2 sdk when it lands.
+  [ ] D4. P8 killer app M0 slice: post + feed (chronological + sort
+      dropdown ONLY -- lens/chatbox is CUT to later.md, D20) +
+      profile + dms. starts on the current wapi if needed; swaps to
+      C2 sdk when it lands. acceptance: stands on its own as a plain
+      good social app, credible in a creator pitch.
   [✓ 1.0.27] D5. P9 exporter core + instagram mapping (needs D1 conventions;
        client-side, so no api deps) — also includes Facebook + YouTube
        mapping, multi-platform UI with takeout checklists, 57 tests
@@ -180,7 +203,7 @@ WHAT MUST STAY SEQUENTIAL (don't try to parallelize these)
 
 INTEGRATION MOMENTS (when lanes must sync)
 ------------------------------------------
-M0 "reconfig your feed"  = A3 + B3 + D4 converge. first real
+M0 "stands on its own"   = A3 + B3 + D4 converge. first real
                            cross-lane assembly; expect a dedicated
                            integration branch + a day of glue.
 M1 "import your life"    = C1 + C4 + D5 + M0 node.

--- a/plan.txt
+++ b/plan.txt
@@ -2,21 +2,174 @@ web10 plan
 ==========
 
 the thesis (why this plan):
-- users own their data in mongo-model collections. apps are just lenses.
-- influencers/creators run nodes. accounts are free for users, paid for by the
-  node operator's marketing revenue. web10 takes a small % of revenue flowing
-  through its rails (dev pay already works this way in stripe.py).
-- the self-host escape hatch has to be EASY or the ownership story isn't
-  credible. one person should be able to stand up a node in minutes with a
-  setup UI, no settings.py copying, no README archaeology.
-- multi-service is fine. it's modular, it's good design. the problem was never
-  the number of services, it's the lack of a setup experience.
-- the stack is years old. fix up first, build features on modern ground.
-- none of it comes together without a killer app: an all-in-one social lens
-  (instagram-shaped, with video + streaming) over services the user owns,
-  and exporters that dump your facebook/insta/youtube life into those
-  services so day one isn't empty. the app proves the thesis; the
-  exporters seed it.
+- THIS IS A PRODUCT FOR INFLUENCERS. the proposition is OWNERSHIP ON
+  THE INTERNET: own your node, your brand, your domain, your audience
+  relationship, your revenue. no platform between you and your
+  followers. (D4: the customer is the creator; D20: this is the pitch.)
+- NO SHADOW BAN, structurally: the inbox pattern (fan-out on write)
+  delivers a post to 100% of followers. no reach throttling, no
+  algorithm demoting you, no deplatforming. email-newsletter delivery
+  semantics for social. this is architecture, not a policy promise --
+  it cannot be quietly revoked.
+- users own their data in mongo-model collections; apps are just
+  lenses. sovereignty is what makes the creator pitch TRUE -- it
+  rides along invisibly, it is not the lead pitch.
+- the killer app must STAND ON ITS OWN as a plain good social app
+  (instagram-shaped: post, feed, dms, media, video). no gimmicks.
+  the feed is chronological + a sort dropdown -- "no algorithm" IS
+  the feed feature (D20; customizability/lens/chatbox: later.md).
+- exporters dump your facebook/insta/youtube life into your services
+  so day one isn't empty. the app proves the thesis; the exporters
+  seed it; the creator brings the audience.
+- influencers/creators run nodes. accounts are free for users, paid
+  for by the node operator's marketing revenue. web10 takes a small %
+  of revenue flowing through its rails (dev pay already works this
+  way in stripe.py).
+- the self-host escape hatch has to be EASY or the ownership story
+  isn't credible. one person should be able to stand up a node in
+  minutes with a setup UI, no settings.py copying, no README
+  archaeology.
+- multi-service is fine. it's modular, it's good design. the problem
+  was never the number of services, it's the lack of a setup
+  experience.
+- the stack is years old. fix up first, build features on modern
+  ground. (largely done -- see phase 0 ticks.)
+
+
+THE STORY (the pitch to influencers -- M0 must make this credible)
+------------------------------------------------------------------
+this is largely a story business: a killer pitch that lands as
+"oh shit... this is the only way." the beats:
+
+  1. you already don't own your audience -- and you have the number
+     that proves it. 1m subscribers, and the video does 300k. subs
+     are not delivery; they're permission for the platform to MAYBE
+     show you. the reach gap IS the shadow ban, visible in your own
+     analytics, and the rent goes up every year (organic decay,
+     pay-to-boost, throttles you can't even see).
+  2. and time is running out: AI influencers are arriving in volume.
+     infinitely prolific synthetic creators that never sleep, never
+     charge, never negotiate -- and the algorithm has no loyalty to
+     humans. it optimizes engagement, and synthetic content is
+     cheaper engagement. the platform doesn't need YOU anymore.
+     own your persona and your channel NOW, before you're competing
+     with fakes of everyone -- eventually including fakes of you.
+  3. the only defense is ownership: your node, your domain, your
+     brand, your audience relationship. a post reaches 100% of your
+     followers BY ARCHITECTURE (inbox pattern, fan-out on write) --
+     nobody can throttle you, demote you, or replace you on your own
+     node. it cannot be quietly revoked, because it isn't a policy.
+  4. and the ask is ADD, not MOVE. creators already post to 5
+     platforms -- this is #6, except they own it. the exporters
+     make onboarding a 24-hour thing: whole back catalog imported
+     in one shot, then it's just one more surface in the posting
+     routine they already have. nobody is asked to move their
+     livelihood; the home base fills up while everything else
+     continues. platforms become distribution, not landlord.
+  5. and it's THE COOL THING. kick/twitch-grade slick, not fediverse
+     jank. a creator's node reads as an upgrade to their brand --
+     their name, their look, a place their audience brags about
+     being early to -- never a protest app the audience tolerates
+     out of loyalty. production quality IS part of the story; if it
+     looks like peertube, the pitch dies on the first screenshot.
+     (this is what phase 2.5 is for.)
+
+the fear is real and the fear is the wedge. every month of AI-slop
+growth makes this story stronger. M0's job is a product real enough
+that the "oh shit" survives contact with the demo.
+
+the user's side (not a second wedge -- a CONVERSION MULTIPLIER on
+the creator sale. the number the creator watches is "what % of my
+audience joined." the fan's hell-yeah moves it):
+  - the fan's first sentence: "never miss a post from [creator]
+    again -- you see 100% of what they make, always" (the same
+    delivery guarantee, felt from the fan side), plus inner-circle
+    status: founding member of the creator's OWN place, closer to
+    them than any platform allows. status + proximity is what
+    converts diehards, and diehards convert first.
+  - the quiet second sentence (safety -- retains, never acquires):
+    delete actually deletes; posts can default to expiring unless
+    pinned (the honest answer to old-posts-ruining-lives -- D16's
+    timed access, user-facing); your data isn't mined or sold, and
+    post-phase-11 not even the operator can read what's private.
+  - the wannabe-creator segment (most active users ARE aspiring
+    creators, and the platforms jerk them on purpose: one post
+    randomly hits, the next ten get 200 views -- a slot machine).
+    honest position: we can NEVER out-dopamine tiktok and must not
+    try (rebuilding the lottery = rebuilding the algorithm = thesis
+    deleted). the wannabe pitch is the LADDER: keep playing the
+    lottery on the platforms -- best discovery engines ever built --
+    but bank every win here, where the house can't take it back.
+    lottery reach resets at the platform's whim; banked followers
+    compound. beat 4, one rung down the ladder.
+  - and get the psychology right: users aren't fanboys, they're
+    aspirants (slightly delulu -- not everyone can be famous, but
+    everyone wants to be poppin, or at least have their 5k). the
+    deliverable version of poppin: (a) YOUR NUMBER IS REAL HERE --
+    the throttle hits small accounts hardest, so 100% delivery
+    flatters them MOST: 5k followers = 5k people actually see you,
+    vs. instagram showing you to 400 of them. status pitch, not
+    just fairness pitch. (b) local fame: status inside a 10k
+    community is legible and achievable (known regular, creator
+    spotlights -- curated by a human, same philosophy as the ad
+    records, never an algorithm). discord/subreddits prove people
+    chase local status hard. what we never promise: lottery fame
+    from strangers (see above -- no slot machine).
+  - onboarding consequence: joining must hand the fan THEIR OWN
+    space in the same breath ("you're not joining the crowd -- you
+    get your own page here too"). the aspirant identity is honored
+    at signup, not discovered later.
+  - the flywheel this buys: every account is already creator-shaped
+    (own space, own followers -- one collection per user gives this
+    free), so the user base is the CREATOR PIPELINE. today's 5k
+    wannabe is next year's 100k platform-burned prospect who is
+    already home. the wordpress flywheel exactly: nobodies start
+    blogs; the ones who get big never migrate.
+  - the ladder's top rung -- GRADUATION: grow to 100k on rogan's
+    node, then move to your own node with your data AND your
+    audience intact, zero friction. platforms hand you a takeout
+    zip and keep your followers; here followers auto-migrate
+    (phase 10 graduation item; full story lands with M3
+    federation). graduation is the ownership story proven from the
+    inside -- even the node you're on can't hold you -- and every
+    graduate mints a new node (a new hosting customer): the
+    pipeline literally converts.
+  - THE RISE (the aspirant's arc -- tell it as a story, because it
+    is one. the economics map to every step: people are too broke
+    to afford infra until fame pops off, so NOBODY PAYS BEFORE FAME
+    PAYS THEM FIRST):
+      1. start broke, start free: an account on your favorite
+         creator's node. their revenue pays for your infra -- a
+         free apartment in the coolest building in town.
+      2. post. your number is real: every follower you earn
+         actually sees you. no throttle, no lottery, no begging an
+         algorithm for your own audience.
+      3. get known in the scene: the regulars know your name, the
+         creator spotlights you, your 5k is really 5k.
+      4. pop off: your following outgrows the scene -- and by now
+         it's paying you (members, sponsors).
+         (the failure branch, and it's a feature: NOT popping off?
+         maybe you're just not getting famous in the framework you
+         subscribed to. switch nodes -- identity, content, and
+         followers come with you (same phase 10 move mechanism,
+         pointed sideways). scene-market fit becomes searchable.
+         on the platforms this option does not exist: one house,
+         one dealer, grind the same machine or quit. side effects:
+         nodes COMPETE for rising talent -- a node known for
+         launching people attracts the next wave -- and operators
+         stay honest, because mistreated members walk with their
+         followers.)
+      5. graduate: your own node, your own domain, your own
+         sponsors. your data AND your audience move with you, zero
+         friction (phase 10 graduation). now you're the landlord
+         hosting the next wave of broke kids. the flywheel turns.
+    every stage upgrades only when success pays for it. this arc is
+    the fan-facing story skeleton (manifesto, explanation pages,
+    onboarding) -- rise-to-fame is the product's hero's journey.
+  - shape consequence: M0 is CREATOR-COMMUNITY-shaped (the
+    creator's space, feed, comments, members) -- not friend-graph
+    shaped. your 150 real people aren't here yet; the private-life
+    story is what a node grows into, never the day-one pitch.
 
 
 MILESTONES (the route through the map)
@@ -25,12 +178,27 @@ the phases below are the map. this is the route -- wedge first, prove
 things in an order that generates demos, users, and revenue. each
 milestone is a stopping point that stands on its own.
 
-M0 "reconfig your feed" (the demo, ~90 days of focused work):
+M0 "stands on its own" (the demo + the pitch):
     phase 0 toolchain + one-container node + setup wizard + a vertical
-    slice of the killer app on ONE node: post, feed, and the lens
-    chatbox. no federation, no payments, no encryption yet.
-    deliverable: a 2-minute video of someone telling an llm to fix
-    their feed and watching it happen. that video is the company.
+    slice of the killer app on ONE node: post, feed (chronological +
+    sort dropdown, D20), profile, dms -- PLUS the studio's
+    monetization-menu screen (rung-0 cards: memberships, amazon tag,
+    direct deals -- the pitch is money, so the video shows the money
+    screen, D21). no federation, no encryption, no llm anything.
+    deliverable: (a) a node you'd show a creator without apologizing;
+    (b) the pitch: THE STORY above as a deck + a 2-minute demo video
+    shaped for a creator and their manager, not hacker news -- post
+    once, watch it reach 100% of followers. the kill test is ONE
+    HUNDRED creator pitches, not a viral video (D20) -- run in
+    batches of 20 (batch one iterates the pitch; the verdict needs
+    the full 100: at a true 1-in-20 close rate, 20 sends produce
+    zero closes ~36% of the time -- too noisy to kill a thesis on;
+    100 sends make zero closes a real verdict, ~0.6%). stratify
+    across creator segments (platform-burned right-coded, platform-
+    burned left-coded, wildcard niches incl. paid-community
+    sellers) -- segmentation happens at the PITCH and NODE level,
+    one codebase, themed per node. never fork the app per
+    audience; inc's rails stay neutral (D20).
 
 M1 "import your life" (self-host launch / show hn):
     + media service, conventions doc, instagram exporter, drive/
@@ -46,7 +214,55 @@ M3 "the network" (the protocol earns its name):
     + federation polish (cross-node follows + inbox delivery), e2e
     encryption tiers, sponsor marketplace rails, protocol spec +
     conformance suite public. deliverable: two unrelated nodes,
-    friends across them, private content the operators can't read.
+    friends across them, private content the operators can't read
+    -- and a GRADUATION demo: an account moves nodes and its
+    followers come along automatically (phase 10 graduation item).
+
+KNOWN GAPS on the route (executional, tracked so they're not vibes):
+  - the video gap: THE STORY's bar is kick/twitch but M0 ships
+    posts/feed/dms -- video lands later in phase 8, streaming later
+    still. consequence: founding creators #1-3 must be ones M0's
+    format SERVES (photo/text/community-first, podcasters with
+    clips), or the pitch scopes video honestly as roadmap. never
+    pitch a pure video creator a product that can't hold their life.
+  - memberships before creator #1: owned revenue in month one is
+    what keeps a white-glove yes alive (the retention lever). the
+    phase 4 tiers item + stripe rails must be live BEFORE the first
+    founding creator onboards. hard M2 prerequisite.
+  - hosted ops floor: white-glove hosting = inc runs production
+    infra for a real community (uptime, backups, support). the
+    proxmox homelab is staging, not that. pick the boring hosted
+    floor (a $40 vps + the one-container node + caddy is enough)
+    before the first yes.
+  - t&s gate: the dmca/csam decisions (phase 12) are a PRE-CREATOR-
+    #1 gate under white-glove hosting, not an M1 nicety. vendors +
+    process decided before any hosted community posts media.
+  - exporter battle-testing: D5's mappers are FIXTURE-tested (57
+    tests), not mess-tested -- real takeouts are where parsers
+    die, and meta churns formats constantly. week 3's real-takeout
+    seeding is the first battle test (run the founder's own IG +
+    YT exports; log every break). promote phase 9's llm-assisted
+    mapping the FIRST time a real takeout breaks a mapper. white-
+    glove absorbs the mess through M2 (founder-operated imports);
+    consumer-grade robustness is an M1/show-hn bar, not M0.
+    facts to keep pitches honest: youtube takeout DOES export
+    videos + metadata but arrives as 50GB chunks from days-long
+    jobs (the 24h onboarding clock starts when the takeout
+    arrives); the AUDIENCE never ports from any platform (no
+    export includes reachable subscriber identities) -- content
+    ports, audiences are POINTED (story beat 4); imported video
+    plays direct-mp4 off minio/R2 until the phase 8 transcode
+    pipeline exists. imported-identity relinking is a TWO-TIER
+    tradeoff, accepted: (1) now -- ghosts with provenance
+    ("@sarah_k · from instagram", the origin field doing its
+    job; archival comments are content, not live graph); (2)
+    later, lazy, zero identity infra -- CLAIM-BY-MATCHING: when
+    a commenter joins and imports their OWN takeout, their
+    export contains the comments they made; match origin +
+    timestamp + text against existing ghosts and link
+    automatically (both parties' takeouts agreeing IS the
+    proof; stakes don't justify more). a nice onboarding
+    moment: your old words light up with your name.
 
 
 PHASE 0 — fix up (modernize the toolchain)
@@ -138,6 +354,12 @@ the makeover flips them story-first: every screen answers "what does
 this let ME do with MY data", and the protocol machinery recedes into
 the walls. think product in a way we never have before.
 
+the visual bar (THE STORY, beat 5): kick/twitch-grade slick. a
+creator's node must read as an upgrade to their brand -- the cool
+thing their audience brags about being early to -- never fediverse
+jank (and the whole fediverse is jank: peertube, even mastodon).
+if a screen would look at home in any of them, it isn't done.
+
 sequencing: do this BEFORE the phase 3 wizard screens and phase 4
 admin panel are built, so those get written on the new stack once
 instead of on rectangles and then rewritten.
@@ -165,11 +387,12 @@ the makeover (story-first, not a screen-by-screen reskin):
     contracts. this is what apps may touch.") -- not admin CRUD.
 [ ] narrative pass on web10-social: it has to feel like a place
     you'd live. first-run empty states that point at the exporters
-    ("import your life"), the lens/chatbox front and center. this
-    app IS the pitch; it has to look like one.
+    ("import your life"). this app IS the pitch; it has to look
+    like one -- a plain good social app that stands on its own (D20).
 [ ] the demo test: every M0-facing screen is judged by "would this
-    look credible in the 2-minute video" (M0 deliverable). a screen
-    that can't appear in the demo isn't done.
+    look credible in front of a creator and their manager" (M0
+    deliverable: THE STORY + demo video). a screen that can't
+    appear in the pitch isn't done.
 
 
 PHASE 3 — setup wizard (the missing piece)
@@ -218,11 +441,23 @@ packaging:
     wordpress moment -- the brand is theirs, the address is theirs.
 
 
-PHASE 4 — admin panel (creator console + analytics)
----------------------------------------------------
+PHASE 4 — the STUDIO (creator console + analytics + monetization)
+------------------------------------------------------------------
 the node operator's console, inside the ui. this is where "how the creator
 makes money" becomes visible product instead of thesis. this page is the
 thing you demo to an influencer's manager -- make it GOOD.
+
+the mental model is YOUTUBE STUDIO (call it the studio): one pane
+where the creator posts, watches their audience numbers, sees
+revenue, and sees the monetization MENU as an unlock ladder --
+youtube's YPP screen trained every creator alive to read "X more
+to unlock Y" progress bars, so rungs 0-4 render as exactly that,
+except thresholds unlock MORE money, not permission to earn at
+all. two personas share the pane: the CREATOR studio (post,
+analytics, revenue, menu) and the OPERATOR console (policy,
+signup gates, moderation queues) -- same person on a creator
+node, but design them as separable tabs from day one (the
+white-label future has managers in the operator seat).
 
 access:
 [✓] admin role: node operator account(s) flagged at setup
@@ -244,6 +479,21 @@ audience analytics (the numbers a sponsor asks for):
     inventory, keep it bright.
 
 monetization controls:
+[ ] membership tiers / ranked communities (the skool/whop model,
+    natively): terms ACLs already express ranked access -- a
+    member-only service, an inner-circle service, an officers
+    service; a "rank" is just which services your token can read.
+    the paid hierarchical community (hustlers-university shape:
+    ranks, climbing, belonging -- THE RISE as a product) runs on
+    existing permission machinery at ~97% payout vs skool/whop's
+    cut. paid-community sellers are also a founding-creator
+    segment: they already charge members, already live off-platform,
+    and are the most ban-prone creator category alive (their
+    deplatforming fear includes payment rails). serve the MECHANICS
+    (tiers, ranks, paid inner circles), never the aesthetic -- inc
+    stays neutral infrastructure (D20), and this segment imports
+    the phase 12 t&s burden fastest. gamification layers (xp,
+    leaderboards) are post-M2 product, not now.
 [ ] ad/sponsorship slots: define sponsored placements that node-default
     lenses render. operator controls what's promoted.
 [ ] ads are RECORDS the operator owns (creative, link, schedule,
@@ -253,11 +503,109 @@ monetization controls:
 [ ] works at an audience of 100: hand-entered direct deals, affiliate
     links (operator picks exact products), community/patron slots
     (a fan or local business buys a slot, operator approves).
-[ ] third-party networks are optional FILL, not the foundation:
-    adapters later for approval-flow marketplaces (passionfroot,
-    beehiiv-ad-network, paved, podcorn are the shape to match --
-    nothing mainstream does exact curation at small scale, which is
-    the gap the web10 sponsor marketplace eventually fills at 3%)
+[ ] the monetization MENU (the weakest point, researched 07.2026:
+    easy instant deals for a self-hosted node, as a ladder that
+    unlocks as the node grows -- the networks already gate by
+    traffic/revenue, so the unlock ladder maps to reality):
+      rung 0, day one, any size: memberships/tips (own rails, 3%),
+        affiliate adapters (amazon associates; levanta-class --
+        amazon/shopify/walmart unified, 10k-follower min, 24h
+        review), operator-entered direct deals. the instant-money
+        star: AUTO-AFFILIATE EVERYTHING (skimlinks/sovrn-commerce
+        pattern) -- paste your associates tag / connect once, and
+        every product link posted on the node rewrites to earn at
+        render time. zero per-link work, first dollar in minutes.
+        AMAZON ADAPTER v1 spec (researched 07.2026):
+          - the card: one field, paste your associates tag.
+            stored as a record in the creator's own collection.
+          - render-time tagging: amazon links normalize to
+            canonical /dp/ASIN form + ?tag= appended. NEVER
+            cloaked/shortened (amazon prohibits hiding the
+            destination); amazon.com stays visible.
+          - whose tag wins (revenue routing, RISE-aligned): the
+            POSTER's own tag if they set one -- members earn on
+            their own links at any size -- else the node
+            operator's tag as house fallback.
+          - composer "attach product" v1 needs NO pa-api: paste
+            an amazon url -> normalized product card. the rich
+            search-based picker is a later rung: pa-api access
+            is gated on an account with sales history.
+          - compliance baked into the adapter, not left to the
+            creator: auto "affiliate link" disclosure chip (ftc +
+            amazon), NO tag rewriting in email digests (amazon
+            prohibits affiliate links in email), no stale price
+            display (prices only via api, else none), and the
+            card tracks the 3-QUALIFYING-SALES-IN-180-DAYS
+            countdown (miss it and amazon closes the account --
+            surface it, don't let creators get silently banned).
+          - upgrade rungs: levanta-class (10k followers, better
+            rates, shopify/walmart too), amazon influencer
+            program storefront where eligible.
+        AI PRODUCT SUGGESTER (the first ai feature in the product
+        is the MONEY assistant -- passes the D20 oracle where the
+        feed chatbox didn't):
+          - an llm under a READ-ONLY scoped token on posts (I5;
+            never dms/contacts) profiles the account's niche and
+            suggests relevant products: a suggestions feed in the
+            studio + the killer version, COMPOSER-TIME chips
+            ("this post mentions your pre-workout -- attach it as
+            a product?"). one tap, tagged, disclosed, earning.
+          - always human-approved, never auto-inserted: curation
+            by architecture holds; no temu-slop, no amazon
+            placement violations. suggestions resolve v1 as
+            tagged search links / normalized ASINs (no pa-api);
+            levanta's catalog becomes the better source at 10k+.
+          - works from follower #1: every wannabe gets an ai
+            revenue manager that platforms reserve for the big
+            (THE RISE stage 2 gets guided to its first dollar).
+          - the same profiling engine is the M3 marketplace's
+            matching brain: brands book 1,000 relevant $20 nano
+            promos without reading 1,000 profiles.
+          - funding: hosted-tier feature; self-hosters byok
+            (D19 pattern -- never a free api proxy).
+      rung 1, ~1k sessions: contextual display FILL via privacy-
+        safe adapters (ethicalads-class: zero cookies, pure
+        contextual -- manifesto-compatible). mediavine journey now
+        accepts from ~1k sessions (2026 -- the old 50k wall fell).
+      rung 2, ~10k: sponsor-marketplace adapters (paved / kit /
+        beehiiv shape). NOTE the takes: paved 30%, kit 23.5-30%,
+        passionfroot $199/mo -- incumbents trained creators that
+        marketplaces cost 20-30%. our marketplace at 3% undercuts
+        by 10x in a market with proven willingness to pay.
+      rung 3, ~25k+: premium programmatic (raptive-class, dropped
+        to 25k in 2025) -- ONLY as clearly-disclosed operator
+        opt-in, if ever: tracking-based programmatic breaks the
+        manifesto ("nobody is mining you") and the ad-records
+        rule (nothing renders unapproved). contextual/server-side
+        fill is the default; tracking is not.
+      rung 4, the endgame (M3): the web10 sponsor marketplace at
+        3% -- cross-node inventory, curation by architecture. its
+        killer segment is the NANO TIER nothing serves natively:
+        $20 promos for 5k-follower members (brands love nano
+        engagement rates; today this only exists as platform-
+        locked ugc-gig sites). plugs into THE RISE: stage 3 gets
+        a paycheck -- fame starts paying at 5k followers here,
+        not 100k. every aspirant is future marketplace inventory
+        a sponsor can book in bulk, operator-curated.
+    third-party networks stay optional FILL, never the foundation.
+    ZERO-FRICTION rule (the studio's bar for every rung): each
+    option is a CARD with ONE BUTTON, and the adapter does the
+    paperwork. the node owns its analytics, so the studio (a)
+    shows only options the node already qualifies for, (b)
+    prefills third-party applications with verified stats (an
+    auto-generated media kit), (c) tracks application status in
+    the pane. the metric is TIME-TO-FIRST-DOLLAR: memberships =
+    minutes (stripe connect onboarding), auto-affiliate = one
+    paste, direct deal = type it and publish. an option that
+    needs a tutorial isn't done.
+    AND IT ATTACHES TO CONTENT: the composer (phase 8 posting
+    flow) carries one-tap monetization affordances on the post
+    itself -- attach a product (auto-affiliated, above), mark as
+    sponsored (renders disclosure + feeds sponsor reporting),
+    gate to a member tier (a terms ACL on the record -- phase 4
+    tiers), enable tips. the youtube-product-tags / ig-shopping
+    pattern: earning is part of the posting habit, not a
+    settings page you remember to visit.
 [ ] sponsor reporting: impressions/interactions per placement, per
     campaign, exportable (this is what justifies podcast-grade CPMs)
 [ ] traffic routing controls: which apps/nodes get promoted placement
@@ -354,9 +702,8 @@ mcp server (promoted from LATER -- it ships with the sdk):
 [ ] scoped tokens per mcp connection: user picks which services the
     llm can touch, same terms machinery as any app
 [ ] high configurability + mcp is the wordpress lesson applied to
-    the llm era: users config via lens, operators via policy/ads,
-    devs via real queries, llms via mcp. every layer talks to the
-    same records.
+    the llm era: operators config via policy/ads, devs via real
+    queries, llms via mcp. every layer talks to the same records.
 
 
 PHASE 6.5 — the dev on-ramp (create-web10)
@@ -384,8 +731,7 @@ how it ships (be realistic about how devs start projects now):
         zero framework noise: login -> create a record -> read it.
       - react (the default): vite + react + the phase 6 hooks
         (useRecords live query).
-      later, by demand: a lens-app template (reads/writes a lens
-      record -- the phase 8 chatbox pattern as a starter kit).
+      later, by demand: more templates as devs ask for them.
     every template: sdk login(), one service round-trip, and the
     consent screen appears on FIRST run -- terms are the product,
     the hello-world should show them.
@@ -425,7 +771,7 @@ PHASE 7 — reorganize the apps (monorepo, but tidy)
 revised thinking: the killer app STAYS IN THIS REPO. it's not "an app"
 -- it's the default lens. it ships with every node, renders the
 operator's ad slots, embodies the conventions doc, and during the
-build it's what drives the protocol (aggregate, inbox, lens record
+build it's what drives the protocol (aggregate, inbox, conventions
 all get discovered by building against them). schema + api + sdk +
 app need atomic commits. wordpress ships its default theme; mastodon
 ships its web client. same logic.
@@ -486,9 +832,11 @@ the app:
 [ ] feed via the INBOX PATTERN: friends' nodes deliver new posts into
     your inbox service at post time (fan-out on write, a create on a
     service whose terms whitelist them). reading your feed = one indexed
-    query on your own node. fast, offline-capable, sovereign -- and
-    re-rankable by the user (or their llm. "my feed algorithm is my
-    prompt" lives right here.)
+    query on your own node. fast, offline-capable, sovereign. THIS is
+    the no-shadowban guarantee from THE STORY: delivery to 100% of
+    followers is architecture, not policy. feed order: chronological
+    + a sort dropdown (newest / oldest / most-reacted). nothing else
+    ranks the feed (D20; customizability parked in later.md).
 [ ] follows across nodes: follow alice@othernode -> terms handshake ->
     her posts land in your inbox. federation made visible + trivial.
 [ ] comments/reactions on posts (cross-node via same terms machinery)
@@ -500,8 +848,7 @@ the app:
 the boring plumbing social apps die without:
 [ ] notifications: web push first (pwa), mobile push later. new post
     from a follow, comment on your post, dm, key request (phase 11).
-    notification prefs live in the lens record -- reconfigurable in
-    the chatbox like everything else ("only notify me about dms")
+    notification prefs are an ordinary settings record the user owns
 [ ] realtime: db change streams -> websocket push, surfaced in the
     sdk as live queries (useRecords with live refresh, phase 6).
     feed/dms update without refreshing.
@@ -517,42 +864,14 @@ the boring plumbing social apps die without:
     controls) -- this app is where the node operator's monetization
     actually displays. default lens = monetized lens. users can swap.
 
-the chatbox (the craziest part -- lead every demo with this):
-your social media experience is totally configurable, in english.
-rotting your brain? reconfig.
-
-[ ] a "lens" service in the user's collection: the feed algorithm +
-    experience config AS A RECORD THE USER OWNS. ranking rules, topic
-    mutes, people-first weights, engagement-bait filters, time budgets,
-    ui toggles (hide like counts, chronological only, grayscale after
-    30 min, whatever). the app reads its behavior from this record.
-[ ] the chatbox: talk to an llm, it edits your lens record. "less
-    politics, more of my actual friends, hide anything that smells
-    like ragebait, cut me off after 20 minutes" -> config diff ->
-    shown to user -> applied. the feed re-ranks instantly because
-    the algorithm was always just your data.
-[ ] the llm's token is scoped to the lens service ONLY (maybe read on
-    posts to help it understand). it can never touch dms/contacts.
-    scoped tokens make "an ai rewrites my feed" safe -- this is the
-    token model earning its keep, say so in the demo.
-[ ] llm backing: bring-your-own-key ONLY. v1: user pastes a key, it
-    stays client-side (localStorage), chatbox calls go browser ->
-    provider directly -- the node never sees the key or the chat.
-    never store the key as a plain record (operator-readable until
-    e2e). presets need zero llm, so "own your algorithm" works
-    without a key. phase 11 upgrade: the key lives in the phone
-    wallet as an e2e-encrypted record and the phone BEAMS it to the
-    web10 apps the user picks at provisioning (per-app; true
-    revocation = rotate the key at the provider). node-provided
-    inference is at most a later operator OPT-IN with hard per-user
-    caps, never the default: a free-signup node with a server-side
-    llm endpoint is a free api proxy, and the abuse lands on the
-    operator's bill. (D19)
-[ ] preset lenses to start from: chronological, close-friends-only,
-    detox mode, creator mode. chatbox edits from there.
-[ ] the lens record is portable like everything else: your algorithm
-    moves nodes with you. nobody has ever owned their algorithm before.
-    that's the whole pitch in one feature.
+the lens chatbox + feed customizability: CUT (D20, 18.07.2026):
+moved to later.md in full (lens record, llm chatbox, preset lenses,
+customization surface). the feed ships chronological + a sort
+dropdown -- "no algorithm" is itself the feature, and the pitch is
+ownership/no-shadowban (THE STORY), not configurability. the killer
+app stands on its own or it isn't killer. D19's byok architecture
+stands ready if the chatbox ever earns its way back; the promotion
+bar is in later.md.
 
 PHASE 9 — the exporters (fill the collections)
 ----------------------------------------------
@@ -603,6 +922,14 @@ ownership story, in a folder a normal person can see.
 [ ] restore/import flow: point a fresh node (or a new account on
     another node) at your backup -> your life comes back. this is
     node migration, demoable.
+[ ] GRADUATION (account migration with your audience): a signed
+    "moved" record on the old node + followers' nodes auto-re-follow
+    at the new address (the mastodon Move-activity pattern -- adopt,
+    don't invent). data comes via the restore flow above; this item
+    is the FOLLOWERS coming too. needs federation (M3) to be fully
+    live. this is the ladder's top rung in THE STORY: grow on a
+    creator's node, graduate to your own, audience intact -- the
+    ownership story proven from the inside.
 [ ] backups of encrypted content stay encrypted (phase 11) -- drive/
     dropbox hold ciphertext, never plaintext private data
 
@@ -650,7 +977,7 @@ the key hierarchy (what's in the wallet):
     wrapped at rest otherwise (ios secure enclave won't do x25519 --
     wrap the sodium keys under an enclave key, don't fight it).
 [ ] the wallet guards opaque secrets too, not just derived keys: the
-    byok llm api key (phase 8 chatbox) is an e2e-encrypted record
+    byok llm api key (D19; chatbox parked in later.md) is an e2e-encrypted record
     the phone beams only to the apps the user picks -- the node
     holds ciphertext, the operator can never read or exfiltrate it,
     and it moves nodes with you like any record. (D19)
@@ -858,6 +1185,22 @@ federation abuse (the pingback lesson):
 [ ] rate limits on cross-node delivery + per-sender caps
 [ ] new-node reputation: throttle until proven (age, volume shape)
 
+adult content (decide BEFORE the first adult creator emails -- they
+will be among the most motivated early knockers, being the most
+deplatformed + payment-rail-burned segment alive):
+[ ] the wordpress answer, forced by the rails anyway: stripe
+    prohibits adult content and inc's rails are stripe connect, so
+    INC-HOSTED nodes + inc rails are clean-only (survival, not
+    morality). the software stays neutral: a SELF-HOSTED node with
+    its own processor (ccbill-class) is the operator's business
+    under D10 node policy. onlyfans context for the pitch, not the
+    positioning: OF proved fans pay creators directly at ~$6B+/yr
+    scale, takes 20% (we take ~3% + hosting), and in aug 2021 tried
+    to evict its own creators -- the ultimate "you were renting"
+    story. never market as "sfw onlyfans" (fanhouse/oftv died
+    fighting that brand); market ownership, let the phase 4
+    membership mechanics quietly BE the onlyfans economics.
+
 operator legal kit (part of the white-label product):
 [ ] tos + privacy policy templates per node
 [ ] gdpr story -- and say it loud: right-to-erasure and data export
@@ -970,7 +1313,7 @@ other known issues, fix early (phase 0/1, before any real users):
     in the data volume, never in git. same for stripe/twilio keys.
 [ ] token revocation story: jwts expire but can't be revoked today.
     decide: short expiry + refresh, or a jti denylist. matters more
-    once agents/llms hold tokens (lens chatbox, mcp).
+    once agents/llms hold tokens (mcp, future agents).
 [ ] backups that restore: automated node backup + a scheduled restore
     drill. a backup you've never restored is a rumor.
 [ ] before the first creator-node pitch: external security review /
@@ -1068,6 +1411,20 @@ habit (annotate as you go), and one website that waits. split by
 AUDIENCE, not by tool. generated wherever possible -- generated
 docs can't rot.
 
+site architecture (D20 -- settles the two-sites question): there is
+ONE marketing site (marketing-ui, web10.app) and it is CREATOR-FIRST:
+hero = THE STORY (the subs-vs-views gap, own your audience), primary
+cta = "become a founding creator" (demo video + call). fans are NOT
+a tab there -- fans never google web10; they click a link in their
+creator's bio and land on the CREATOR'S NODE, where the manifesto
+join page (manifesto.md) is the entire user-facing pitch. this is
+the wordpress/shopify pattern: wordpress.org sells to site owners,
+readers never visit it; shopify sells to merchants, shoppers never
+see shopify.com. the only fan-facing corporate page is a thin
+"powered by web10 -- what is this?" reassurance explainer linked
+from node footers (trust, not acquisition). devs get the docs
+section (below); self-hosters get the setup story. no users tab.
+
 for everyone -- explanation (lives in marketing-ui, phase 7):
 the missing quadrant: guides say HOW, reference says WHAT, nothing
 says WHY. the architecture (records, tokens, terms, federation)
@@ -1092,7 +1449,7 @@ don't wait on milestones. they are the marketing site's core copy.
 
 for users + creators (lives in marketing-ui, phase 7):
 [ ] guides ARE the marketing content for a saas: get an account,
-    reconfig your feed, import your instagram, run a node, monetize
+    own your audience, import your instagram, run a node, monetize
     as a creator. write each guide when its milestone (M0-M3)
     ships, not before -- docs for unshipped features are fiction.
     (the fiction rule gates GUIDES only -- explanation pages above

--- a/timeline.md
+++ b/timeline.md
@@ -1,0 +1,90 @@
+# timeline.md — M0 → M2 execution schedule (v1, dated 18.07.2026)
+
+the dated companion to plan.txt (map) and business-plan.md (money).
+two tracks run in parallel the whole way: the MACHINE track (agent
+lanes, conductor 4-wide) and the FOUNDER track (taste, sends, video
+— the gating resource). dates assume current velocity (~50
+commits/wk) and slip ONLY on the founder taste loop — budget
+attention, not tokens.
+
+## week 0 — now (jul 18-20)
+machine: kick off B2.5 (stack pick tailwind+shadcn, record in
+  decisions.md; design tokens). kick off D4 data layer on current
+  wapi (posts/feed/profile/dm services against docs/schemas).
+  repoint ws2 (C2 sdk is NOT on the M0 critical path) at D4.
+founder (30 min): register dmca designated agent ($6). approve the
+  stack pick. agents start list batch 1 (20 names, enriched).
+
+## week 1 (jul 20-27)
+machine: B2.5 tokens + ui/ core screens. D4 logic complete
+  (post via media router, chronological feed + sort dropdown,
+  profile, records-dms). D2.5 starts as tokens land.
+founder (~2 hrs): review token/theme direction once. list batch 1
+  review.
+
+## week 2 (jul 27 - aug 3)
+machine: D4 screens on the new stack. manifesto join page. composer
+  v1 (post + photo). empty states pointing at exporters. B2.5
+  finishes ui/. STUDIO MONETIZATION SCREEN (D21 M0 slice): rung-0
+  cards — memberships, amazon tag, direct deals — visually complete,
+  rung-0 functional (the video shows the money screen). A6 in
+  parallel: strip user billing → operator-set quotas (credits =
+  abuse throttle, space = storage caps), tests stay green.
+founder (~3 hrs): first taste pass on social screens. video
+  storyboard (beats: the story → post → 100% delivery → import).
+
+## week 3 (aug 3-10)
+machine: M0 INTEGRATION branch (A3+B3+D4 converge — the board
+  predicts a day of glue). theme a demo node with a fake creator
+  brand. seed it via a real takeout import (the video feed must be
+  a lived-in life, not lorem ipsum). deploy to the colo box behind
+  a real domain. off-box backup + restore drill (KNOWN GAPS).
+founder (~4 hrs): taste pass 2 against the demo test ("credible in
+  front of a creator's manager").
+
+## week 4 (aug 10-17) — M0 GATE WEEK
+machine: polish queue from founder notes. list of 100 finalized
+  (~35/35/30).
+founder (the big week, ~2 evenings + a weekend): final demo-test
+  judgment, SHOOT + CUT THE VIDEO.
+GATE M0: slice stands on its own + video exists. nothing proceeds
+  to sends without both.
+
+## weeks 5-10 (aug 17 - sep 28) — the rule of 100
+founder (~2 hrs/wk): send 10-15/wk, agent-drafted, founder-sent.
+  batch 1 (wk 5) iterates the pitch; batches 2-5 run the improved
+  copy. log everything (outreach.md §6). calls as they come.
+machine (parallel, what creator #1 needs on day one): memberships/
+  tiers wired to stripe rails + the amazon tag card (B4.5 minimum
+  slice — memberships BEFORE creator #1, per KNOWN GAPS). hosted
+  ops floor: second-box/DR decision. m1 exporter polish as needed.
+GATE (rolling): first yes = white-glove onboarding sprint starts
+  immediately (don't wait for the remaining batches).
+
+## ~oct 1 — THE VERDICT
+- ≥1 signed AND posting within 4 weeks → M2 is real: onboard,
+  measure %-audience-joined, get first revenue on the dashboard.
+- 100 sent, meaningful watch count, zero closes → stop building,
+  diagnose with the objection log, decide (pivot segment /
+  consumer wedge from later.md / wind down to dope-project mode).
+  do not soften the signal.
+
+## oct-nov 2026 — M2 (if green)
+creator #1 live, branded, earning (memberships + tag card).
+"why i left" moment = the flywheel's first turn. founding
+creators #2-3 from the remaining pipeline. raise window OPENS
+(business-plan §8c) — evaluate, don't default to yes.
+
+## dec 2026 - apr 2027 — grind to breakeven
+5-6 paying creators ≈ breakeven (~month 9, business-plan §6).
+starter tier opens. M1 public (show hn) when self-host onboarding
+is one-command clean.
+
+## standing rules
+- the founder track is the schedule. taste passes and sends are
+  calendar events, not intentions.
+- slips happen in week 4 (taste loop) and weeks 5-10 (send
+  discipline). if week 4 becomes week 6, fine — but sends start
+  within 7 days of the video existing, no exceptions.
+- update this file with actuals as weeks close; stale timelines
+  are worse than none (same rule as the board).


### PR DESCRIPTION
Refactors the whole strategy layer around D20 — the proposition is creator ownership (own your audience, no shadow ban by architecture), social platform first / protocol second — with plan.txt gaining THE STORY (the influencer pitch) + THE RISE (the aspirant arc), M0 redefined as "stands on its own" (chronological feed + sort dropdown + the Studio money screen per D21), the lens/chatbox cut to a new later.md with promotion bars, and the kill test upgraded to the rule of 100.

New documents: business-plan.md (real cost numbers, ~$10k to breakeven at ~5 paying creators, 24-month bear/base/bull projections, funding triggers), outreach.md (the creator sales kit: templates, cadence, objection sheet), manifesto.md (the fan-facing join page), and timeline.md (dated 10-week M0→M2 schedule).

D21 also strips user billing (metering survives as operator-set anti-abuse quotas) and phase 4 becomes the STUDIO with a fully specced zero-friction monetization menu (Amazon adapter v1, AI product suggester, unlock ladder). Boards (parallel execution.txt: A6, B4.5, D4 rescope), GLOSSARY, CLAUDE.md orientation, and CHANGELOG (1.0.42–1.0.46) are kept true throughout. Docs-only change — no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)