### PR TITLE
D4: web10-social data layer — conventions-schema stack for M0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
-1.0.47 || 18.07.2026
+1.0.48 || 18.07.2026
+D4: web10-social data layer — full conventions-schema stack for the M0
+killer app slice. new src/data/ with typed modules: posts (CRUD + media
+upload via API presigned URLs), feed (chronological inbox + sort dropdown:
+newest/oldest/most_reacted via aggregate), profile (read/upsert), contacts
+(conventions schema CRUD + search), dms (records-based, deterministic
+conversation service names), comments (threaded), reactions (toggle,
+aggregate counts). wapi.ts: thin typed fetch wrapper over legacy wapi.js.
+Web10SocialAdapter wired with all 30+ new data-layer methods alongside
+legacy adapter (backward compat). SMR terms extended for profile, contacts,
+inbox, comments, reactions, media services. 55 new vitest tests (227 total,
+all green). screens deferred to D2.5 post-B2.5 tokens.
 board refresh: CURRENT CONDUCTOR BOARD in parallel execution.txt
 re-cut for the D20/D21 pivot + timeline.md week 0 — ws1 B2.5 stack
 pick/tokens, ws2 REPOINTED from C2 sdk (off the M0 critical path)

--- a/marketing/web10-social/src/__tests__/data/comments.test.ts
+++ b/marketing/web10-social/src/__tests__/data/comments.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as wapi from '../../data/wapi';
+import * as comments from '../../data/comments';
+
+function mockWapi() {
+  const mock = {
+    isSignedIn: vi.fn(() => true),
+    signOut: vi.fn(),
+    setToken: vi.fn(),
+    readToken: vi.fn(() => ({ provider: 'api.web10.app', username: 'alice' })),
+    openAuthPortal: vi.fn(),
+    authListen: vi.fn(),
+    read: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    aggregate: vi.fn(),
+    getUploadUrl: vi.fn(),
+    initP2P: vi.fn(),
+    sendP2P: vi.fn(),
+  };
+  vi.spyOn(wapi, 'getWapi').mockReturnValue(mock as any);
+  return mock;
+}
+
+describe('comments data layer', () => {
+  let mock: ReturnType<typeof mockWapi>;
+
+  beforeEach(() => {
+    mock = mockWapi();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('readComments', () => {
+    it('reads all comments for a post', async () => {
+      const list = [
+        { _id: 'cm1', post_id: 'p1', text: 'nice!', created_at: '2026-07-18T00:00:00Z' },
+      ];
+      mock.read.mockResolvedValue(list);
+      const result = await comments.readComments('p1');
+      expect(mock.read).toHaveBeenCalledWith('comments', { post_id: 'p1' });
+      expect(result).toEqual(list);
+    });
+  });
+
+  describe('readTopLevelComments', () => {
+    it('reads top-level comments only', async () => {
+      mock.read.mockResolvedValue([]);
+      await comments.readTopLevelComments('p1');
+      expect(mock.read).toHaveBeenCalledWith('comments', {
+        post_id: 'p1',
+        parent_id: { $exists: false },
+      });
+    });
+  });
+
+  describe('readReplies', () => {
+    it('reads replies to a comment', async () => {
+      mock.read.mockResolvedValue([]);
+      await comments.readReplies('cm1');
+      expect(mock.read).toHaveBeenCalledWith('comments', { parent_id: 'cm1' });
+    });
+  });
+
+  describe('createComment', () => {
+    it('creates a new comment', async () => {
+      const comment = { post_id: 'p1', text: 'Great post!', created_at: '2026-07-18T00:00:00Z' };
+      const created = { _id: 'cm1', ...comment };
+      mock.create.mockResolvedValue(created);
+      const result = await comments.createComment(comment);
+      expect(mock.create).toHaveBeenCalledWith('comments', comment);
+      expect(result).toEqual(created);
+    });
+  });
+
+  describe('updateComment', () => {
+    it('updates a comment by ID', async () => {
+      const updated = { _id: 'cm1', text: 'Updated comment' };
+      mock.update.mockResolvedValue(updated);
+      await comments.updateComment('cm1', { text: 'Updated comment' });
+      expect(mock.update).toHaveBeenCalledWith('comments', { _id: 'cm1' }, { $set: { text: 'Updated comment' } });
+    });
+  });
+
+  describe('deleteComment', () => {
+    it('deletes a comment by ID', async () => {
+      mock.delete.mockResolvedValue(undefined);
+      await comments.deleteComment('cm1');
+      expect(mock.delete).toHaveBeenCalledWith('comments', { _id: 'cm1' });
+    });
+  });
+
+  describe('countComments', () => {
+    it('returns the number of comments on a post', async () => {
+      mock.read.mockResolvedValue([
+        { _id: 'cm1', post_id: 'p1', text: 'a', created_at: '2026-07-18T00:00:00Z' },
+        { _id: 'cm2', post_id: 'p1', text: 'b', created_at: '2026-07-18T00:00:00Z' },
+      ]);
+      const count = await comments.countComments('p1');
+      expect(count).toBe(2);
+    });
+  });
+});

--- a/marketing/web10-social/src/__tests__/data/contacts.test.ts
+++ b/marketing/web10-social/src/__tests__/data/contacts.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as wapi from '../../data/wapi';
+import * as contacts from '../../data/contacts';
+
+function mockWapi() {
+  const mock = {
+    isSignedIn: vi.fn(() => true),
+    signOut: vi.fn(),
+    setToken: vi.fn(),
+    readToken: vi.fn(() => ({ provider: 'api.web10.app', username: 'alice' })),
+    openAuthPortal: vi.fn(),
+    authListen: vi.fn(),
+    read: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    aggregate: vi.fn(),
+    getUploadUrl: vi.fn(),
+    initP2P: vi.fn(),
+    sendP2P: vi.fn(),
+  };
+  vi.spyOn(wapi, 'getWapi').mockReturnValue(mock as any);
+  return mock;
+}
+
+describe('contacts data layer', () => {
+  let mock: ReturnType<typeof mockWapi>;
+
+  beforeEach(() => {
+    mock = mockWapi();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('readContacts', () => {
+    it('reads all contacts', async () => {
+      const list = [
+        { _id: 'c1', username: 'bob', provider: 'api.web10.app', display_name: 'Bob' },
+      ];
+      mock.read.mockResolvedValue(list);
+      const result = await contacts.readContacts();
+      expect(mock.read).toHaveBeenCalledWith('contacts');
+      expect(result).toEqual(list);
+    });
+  });
+
+  describe('readContact', () => {
+    it('returns contact found by username+provider', async () => {
+      const c = { _id: 'c1', username: 'bob', provider: 'api.web10.app' };
+      mock.read.mockResolvedValue([c]);
+      const result = await contacts.readContact('bob', 'api.web10.app');
+      expect(mock.read).toHaveBeenCalledWith('contacts', { username: 'bob', provider: 'api.web10.app' });
+      expect(result).toEqual(c);
+    });
+
+    it('returns null when not found', async () => {
+      mock.read.mockResolvedValue([]);
+      const result = await contacts.readContact('nobody', 'api.web10.app');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('addContact', () => {
+    it('creates a contact with added_at', async () => {
+      const input = { username: 'bob', provider: 'api.web10.app', display_name: 'Bob' };
+      const created = { _id: 'c1', ...input, added_at: expect.any(String) };
+      mock.create.mockResolvedValue(created);
+
+      const result = await contacts.addContact(input);
+      expect(mock.create).toHaveBeenCalledWith('contacts', expect.objectContaining({
+        username: 'bob',
+        provider: 'api.web10.app',
+        added_at: expect.any(String),
+      }));
+      expect(result).toEqual(created);
+    });
+  });
+
+  describe('updateContact', () => {
+    it('updates a contact by ID', async () => {
+      const updated = { _id: 'c1', display_name: 'Bob Updated' };
+      mock.update.mockResolvedValue(updated);
+      const result = await contacts.updateContact('c1', { display_name: 'Bob Updated' });
+      expect(mock.update).toHaveBeenCalledWith('contacts', { _id: 'c1' }, { $set: { display_name: 'Bob Updated' } });
+      expect(result).toEqual(updated);
+    });
+  });
+
+  describe('deleteContact', () => {
+    it('deletes a contact by ID', async () => {
+      mock.delete.mockResolvedValue(undefined);
+      await contacts.deleteContact('c1');
+      expect(mock.delete).toHaveBeenCalledWith('contacts', { _id: 'c1' });
+    });
+  });
+
+  describe('searchContacts', () => {
+    it('filters by display_name', async () => {
+      mock.read.mockResolvedValue([
+        { _id: 'c1', username: 'bob', provider: 'api.web10.app', display_name: 'Bob Smith' },
+        { _id: 'c2', username: 'carol', provider: 'api.web10.app', display_name: 'Carol White' },
+      ]);
+      const result = await contacts.searchContacts('bob');
+      expect(result.length).toBe(1);
+      expect(result[0].display_name).toBe('Bob Smith');
+    });
+
+    it('filters by username', async () => {
+      mock.read.mockResolvedValue([
+        { _id: 'c1', username: 'bob', provider: 'api.web10.app', display_name: 'Bobby' },
+      ]);
+      const result = await contacts.searchContacts('bob');
+      expect(result.length).toBe(1);
+    });
+  });
+});

--- a/marketing/web10-social/src/__tests__/data/dms.test.ts
+++ b/marketing/web10-social/src/__tests__/data/dms.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { conversationServiceName } from '../../data/dms';
+
+describe('dms', () => {
+  describe('conversationServiceName', () => {
+    it('produces deterministic service name regardless of argument order', () => {
+      const a = { provider: 'api.web10.app', username: 'alice' };
+      const b = { provider: 'api.web10.app', username: 'bob' };
+
+      const name1 = conversationServiceName(a, b);
+      const name2 = conversationServiceName(b, a);
+
+      expect(name1).toBe(name2);
+      expect(name1).toBe('dm-api.web10.app/alice--api.web10.app/bob');
+    });
+
+    it('works across different providers', () => {
+      const a = { provider: 'node1.web10.app', username: 'alice' };
+      const b = { provider: 'node2.web10.app', username: 'bob' };
+
+      const name = conversationServiceName(a, b);
+      expect(name).toBe('dm-node1.web10.app/alice--node2.web10.app/bob');
+    });
+
+    it('handles same provider different users', () => {
+      const a = { provider: 'api.web10.app', username: 'zara' };
+      const b = { provider: 'api.web10.app', username: 'amir' };
+
+      const name = conversationServiceName(a, b);
+      expect(name).toBe('dm-api.web10.app/amir--api.web10.app/zara');
+    });
+  });
+});

--- a/marketing/web10-social/src/__tests__/data/dmsFull.test.ts
+++ b/marketing/web10-social/src/__tests__/data/dmsFull.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as wapi from '../../data/wapi';
+import * as dms from '../../data/dms';
+
+function mockWapi() {
+  const mock = {
+    isSignedIn: vi.fn(() => true),
+    signOut: vi.fn(),
+    setToken: vi.fn(),
+    readToken: vi.fn(() => ({ provider: 'api.web10.app', username: 'alice' })),
+    openAuthPortal: vi.fn(),
+    authListen: vi.fn(),
+    read: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    aggregate: vi.fn(),
+    getUploadUrl: vi.fn(),
+    initP2P: vi.fn(),
+    sendP2P: vi.fn(),
+  };
+  vi.spyOn(wapi, 'getWapi').mockReturnValue(mock as any);
+  return mock;
+}
+
+describe('dms data layer (with wapi)', () => {
+  let mock: ReturnType<typeof mockWapi>;
+
+  beforeEach(() => {
+    mock = mockWapi();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('sendDm', () => {
+    it('creates a DM record with sender info', async () => {
+      const dm = { _id: 'dm1', message: 'hello', sent_at: expect.any(String), sender_username: 'alice', sender_provider: 'api.web10.app', media_refs: [] };
+      mock.create.mockResolvedValue(dm);
+
+      const result = await dms.sendDm('dm-api.web10.app/alice--api.web10.app/bob', 'hello');
+      expect(mock.create).toHaveBeenCalledWith(
+        'dm-api.web10.app/alice--api.web10.app/bob',
+        expect.objectContaining({
+          message: 'hello',
+          sender_username: 'alice',
+          sender_provider: 'api.web10.app',
+        }),
+      );
+      expect(result).toEqual(dm);
+    });
+
+    it('throws when not authenticated', async () => {
+      const unauthMock = { ...mock, readToken: vi.fn(() => null) };
+      vi.spyOn(wapi, 'getWapi').mockReturnValue(unauthMock as any);
+      await expect(dms.sendDm('dm-conv', 'hello')).rejects.toThrow('not authenticated');
+    });
+  });
+
+  describe('deleteDm', () => {
+    it('deletes a DM from the conversation', async () => {
+      mock.delete.mockResolvedValue(undefined);
+      await dms.deleteDm('dm-conv', 'dm1');
+      expect(mock.delete).toHaveBeenCalledWith('dm-conv', { _id: 'dm1' });
+    });
+  });
+
+  describe('listConversations', () => {
+    it('derives conversation names from contacts', async () => {
+      mock.read.mockResolvedValue([
+        { username: 'bob', provider: 'api.web10.app' },
+        { username: 'carol', provider: 'api.web10.app' },
+      ]);
+      const result = await dms.listConversations();
+      expect(result.length).toBe(2);
+      expect(result).toContain('dm-api.web10.app/alice--api.web10.app/bob');
+      expect(result).toContain('dm-api.web10.app/alice--api.web10.app/carol');
+    });
+
+    it('returns empty when no contacts', async () => {
+      mock.read.mockResolvedValue([]);
+      const result = await dms.listConversations();
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getLastDm', () => {
+    it('returns the last message in a conversation', async () => {
+      mock.read.mockResolvedValue([
+        { _id: 'dm1', message: 'first', sent_at: '2026-07-17T00:00:00Z', sender_username: 'alice', sender_provider: 'api.web10.app' },
+        { _id: 'dm2', message: 'second', sent_at: '2026-07-18T00:00:00Z', sender_username: 'bob', sender_provider: 'api.web10.app' },
+      ]);
+      const result = await dms.getLastDm('dm-conv');
+      expect(result?._id).toBe('dm2');
+    });
+
+    it('returns null for empty conversation', async () => {
+      mock.read.mockResolvedValue([]);
+      const result = await dms.getLastDm('dm-empty');
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/marketing/web10-social/src/__tests__/data/feed.test.ts
+++ b/marketing/web10-social/src/__tests__/data/feed.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as wapi from '../../data/wapi';
+import * as feed from '../../data/feed';
+
+function mockWapi() {
+  const mock = {
+    isSignedIn: vi.fn(() => true),
+    signOut: vi.fn(),
+    setToken: vi.fn(),
+    readToken: vi.fn(() => ({ provider: 'api.web10.app', username: 'alice' })),
+    openAuthPortal: vi.fn(),
+    authListen: vi.fn(),
+    read: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    aggregate: vi.fn(),
+    getUploadUrl: vi.fn(),
+    initP2P: vi.fn(),
+    sendP2P: vi.fn(),
+  };
+  vi.spyOn(wapi, 'getWapi').mockReturnValue(mock as any);
+  return mock;
+}
+
+describe('feed data layer', () => {
+  let mock: ReturnType<typeof mockWapi>;
+
+  beforeEach(() => {
+    mock = mockWapi();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('readFeed', () => {
+    it('sorts newest first by default', async () => {
+      const inbox = [
+        { _id: 'i1', author_username: 'bob', author_provider: 'api.web10.app', post_id: 'p1', delivered_at: '2026-07-17T00:00:00Z' },
+        { _id: 'i2', author_username: 'carol', author_provider: 'api.web10.app', post_id: 'p2', delivered_at: '2026-07-18T00:00:00Z' },
+      ];
+      mock.read.mockResolvedValue(inbox);
+
+      const result = await feed.readFeed('newest');
+      expect(result[0]._id).toBe('i2');
+      expect(result[1]._id).toBe('i1');
+    });
+
+    it('sorts oldest first when requested', async () => {
+      const inbox = [
+        { _id: 'i1', author_username: 'bob', author_provider: 'api.web10.app', post_id: 'p1', delivered_at: '2026-07-17T00:00:00Z' },
+        { _id: 'i2', author_username: 'carol', author_provider: 'api.web10.app', post_id: 'p2', delivered_at: '2026-07-18T00:00:00Z' },
+      ];
+      mock.read.mockResolvedValue(inbox);
+
+      const result = await feed.readFeed('oldest');
+      expect(result[0]._id).toBe('i1');
+      expect(result[1]._id).toBe('i2');
+    });
+
+    it('sorts by reaction count when most_reacted', async () => {
+      const inbox = [
+        { _id: 'i1', author_username: 'bob', author_provider: 'api.web10.app', post_id: 'p1', delivered_at: '2026-07-18T00:00:00Z' },
+        { _id: 'i2', author_username: 'carol', author_provider: 'api.web10.app', post_id: 'p2', delivered_at: '2026-07-18T00:00:00Z' },
+      ];
+      mock.read.mockResolvedValue(inbox);
+      mock.aggregate.mockResolvedValue([
+        { _id: 'p1', count: 5 },
+        { _id: 'p2', count: 10 },
+      ]);
+
+      const result = await feed.readFeed('most_reacted');
+      expect(result[0]._id).toBe('i2'); // p2 has 10 reactions
+      expect(result[1]._id).toBe('i1'); // p1 has 5 reactions
+    });
+
+    it('handles most_reacted with no reactions', async () => {
+      const inbox = [
+        { _id: 'i1', author_username: 'bob', author_provider: 'api.web10.app', post_id: 'p1', delivered_at: '2026-07-18T00:00:00Z' },
+        { _id: 'i2', author_username: 'carol', author_provider: 'api.web10.app', post_id: 'p2', delivered_at: '2026-07-17T00:00:00Z' },
+      ];
+      mock.read.mockResolvedValue(inbox);
+      mock.aggregate.mockResolvedValue([]);
+
+      const result = await feed.readFeed('most_reacted');
+      expect(result.length).toBe(2);
+    });
+  });
+
+  describe('markInboxRead', () => {
+    it('marks an inbox item as read', async () => {
+      mock.update.mockResolvedValue({} as any);
+      await feed.markInboxRead('i1');
+      expect(mock.update).toHaveBeenCalledWith('inbox', { _id: 'i1' }, { $set: { read: true } });
+    });
+  });
+
+  describe('countUnread', () => {
+    it('counts unread inbox items', async () => {
+      mock.read.mockResolvedValue([
+        { _id: 'i1', read: false },
+        { _id: 'i2', read: false },
+      ]);
+      const count = await feed.countUnread();
+      expect(count).toBe(2);
+    });
+
+    it('returns 0 when all read', async () => {
+      mock.read.mockResolvedValue([]);
+      const count = await feed.countUnread();
+      expect(count).toBe(0);
+    });
+  });
+});

--- a/marketing/web10-social/src/__tests__/data/posts.test.ts
+++ b/marketing/web10-social/src/__tests__/data/posts.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as wapi from '../../data/wapi';
+import * as posts from '../../data/posts';
+
+// Mock wapi
+function mockWapi() {
+  const mock = {
+    isSignedIn: vi.fn(() => true),
+    signOut: vi.fn(),
+    setToken: vi.fn(),
+    readToken: vi.fn(() => ({ provider: 'api.web10.app', username: 'alice' })),
+    openAuthPortal: vi.fn(),
+    authListen: vi.fn(),
+    read: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    aggregate: vi.fn(),
+    getUploadUrl: vi.fn(),
+    initP2P: vi.fn(),
+    sendP2P: vi.fn(),
+  };
+  vi.spyOn(wapi, 'getWapi').mockReturnValue(mock as any);
+  return mock;
+}
+
+describe('posts data layer', () => {
+  let mock: ReturnType<typeof mockWapi>;
+
+  beforeEach(() => {
+    mock = mockWapi();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('createPost', () => {
+    it('creates a post record', async () => {
+      const post = { text: 'Hello world', created_at: '2026-07-18T00:00:00Z' };
+      const created = { _id: 'post1', ...post };
+      mock.create.mockResolvedValue(created);
+
+      const result = await posts.createPost(post);
+      expect(mock.create).toHaveBeenCalledWith('posts', post);
+      expect(result).toEqual(created);
+    });
+  });
+
+  describe('readMyPosts', () => {
+    it('reads all posts for the current user', async () => {
+      const postsList = [
+        { _id: 'p1', text: 'first', created_at: '2026-07-18T00:00:00Z' },
+        { _id: 'p2', text: 'second', created_at: '2026-07-17T00:00:00Z' },
+      ];
+      mock.read.mockResolvedValue(postsList);
+
+      const result = await posts.readMyPosts();
+      expect(mock.read).toHaveBeenCalledWith('posts');
+      expect(result).toEqual(postsList);
+    });
+  });
+
+  describe('readUserPosts', () => {
+    it('reads posts for a specific user', async () => {
+      mock.read.mockResolvedValue([]);
+      await posts.readUserPosts('bob', 'node.web10.app');
+      expect(mock.read).toHaveBeenCalledWith('posts', {}, 'bob', 'node.web10.app');
+    });
+  });
+
+  describe('readPost', () => {
+    it('returns the post if found', async () => {
+      const post = { _id: 'p1', text: 'hello', created_at: '2026-07-18T00:00:00Z' };
+      mock.read.mockResolvedValue([post]);
+      const result = await posts.readPost('p1');
+      expect(result).toEqual(post);
+    });
+
+    it('returns null if not found', async () => {
+      mock.read.mockResolvedValue([]);
+      const result = await posts.readPost('nonexistent');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('updatePost', () => {
+    it('updates a post by ID', async () => {
+      const updated = { _id: 'p1', text: 'updated', created_at: '2026-07-18T00:00:00Z' };
+      mock.update.mockResolvedValue(updated);
+      const result = await posts.updatePost('p1', { text: 'updated' });
+      expect(mock.update).toHaveBeenCalledWith('posts', { _id: 'p1' }, { $set: { text: 'updated' } });
+      expect(result).toEqual(updated);
+    });
+  });
+
+  describe('deletePost', () => {
+    it('deletes a post by ID', async () => {
+      mock.delete.mockResolvedValue(undefined);
+      await posts.deletePost('p1');
+      expect(mock.delete).toHaveBeenCalledWith('posts', { _id: 'p1' });
+    });
+  });
+
+  describe('resolveMediaRefs', () => {
+    it('returns empty array for empty refs', async () => {
+      const result = await posts.resolveMediaRefs([]);
+      expect(result).toEqual([]);
+    });
+
+    it('reads media records for given refs', async () => {
+      const mediaRecords = [
+        { _id: 'm1', url: 'http://img1.jpg', created_at: '2026-07-18T00:00:00Z' },
+      ];
+      mock.read.mockResolvedValue(mediaRecords);
+      const result = await posts.resolveMediaRefs(['m1']);
+      expect(mock.read).toHaveBeenCalledWith('media', { _id: { $in: ['m1'] } });
+      expect(result).toEqual(mediaRecords);
+    });
+  });
+});

--- a/marketing/web10-social/src/__tests__/data/profile.test.ts
+++ b/marketing/web10-social/src/__tests__/data/profile.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as wapi from '../../data/wapi';
+import * as profile from '../../data/profile';
+
+function mockWapi() {
+  const mock = {
+    isSignedIn: vi.fn(() => true),
+    signOut: vi.fn(),
+    setToken: vi.fn(),
+    readToken: vi.fn(() => ({ provider: 'api.web10.app', username: 'alice' })),
+    openAuthPortal: vi.fn(),
+    authListen: vi.fn(),
+    read: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    aggregate: vi.fn(),
+    getUploadUrl: vi.fn(),
+    initP2P: vi.fn(),
+    sendP2P: vi.fn(),
+  };
+  vi.spyOn(wapi, 'getWapi').mockReturnValue(mock as any);
+  return mock;
+}
+
+describe('profile data layer', () => {
+  let mock: ReturnType<typeof mockWapi>;
+
+  beforeEach(() => {
+    mock = mockWapi();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('readProfile', () => {
+    it('returns the profile record if exists', async () => {
+      const prof = { _id: 'prof1', display_name: 'Alice', bio: 'Creator' };
+      mock.read.mockResolvedValue([prof]);
+      const result = await profile.readProfile();
+      expect(result).toEqual(prof);
+    });
+
+    it('returns null if no profile exists', async () => {
+      mock.read.mockResolvedValue([]);
+      const result = await profile.readProfile();
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('saveProfile', () => {
+    it('creates a new profile when none exists', async () => {
+      mock.read.mockResolvedValue([]);
+      const created = { _id: 'prof1', display_name: 'Alice', updated_at: expect.any(String) };
+      mock.create.mockResolvedValue(created);
+
+      const result = await profile.saveProfile({ display_name: 'Alice' });
+      expect(mock.create).toHaveBeenCalledWith('profile', expect.objectContaining({ display_name: 'Alice' }));
+      expect(result).toEqual(created);
+    });
+
+    it('updates existing profile', async () => {
+      const existing = { _id: 'prof1', display_name: 'Old Name' };
+      mock.read.mockResolvedValue([existing]);
+      const updated = { _id: 'prof1', display_name: 'New Name', updated_at: expect.any(String) };
+      mock.update.mockResolvedValue(updated);
+
+      const result = await profile.saveProfile({ display_name: 'New Name' });
+      expect(mock.update).toHaveBeenCalledWith('profile', { _id: 'prof1' }, expect.objectContaining({ $set: expect.objectContaining({ display_name: 'New Name' }) }));
+      expect(result).toEqual(updated);
+    });
+  });
+
+  describe('readUserProfile', () => {
+    it('reads another user profile', async () => {
+      const prof = { _id: 'prof2', display_name: 'Bob' };
+      mock.read.mockResolvedValue([prof]);
+      const result = await profile.readUserProfile('bob', 'node.web10.app');
+      expect(mock.read).toHaveBeenCalledWith('profile', {}, 'bob', 'node.web10.app');
+      expect(result).toEqual(prof);
+    });
+
+    it('returns null for unknown user', async () => {
+      mock.read.mockResolvedValue([]);
+      const result = await profile.readUserProfile('unknown', 'node.web10.app');
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/marketing/web10-social/src/__tests__/data/reactions.test.ts
+++ b/marketing/web10-social/src/__tests__/data/reactions.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as wapi from '../../data/wapi';
+import * as reactions from '../../data/reactions';
+
+function mockWapi() {
+  const mock = {
+    isSignedIn: vi.fn(() => true),
+    signOut: vi.fn(),
+    setToken: vi.fn(),
+    readToken: vi.fn(() => ({ provider: 'api.web10.app', username: 'alice' })),
+    openAuthPortal: vi.fn(),
+    authListen: vi.fn(),
+    read: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    aggregate: vi.fn(),
+    getUploadUrl: vi.fn(),
+    initP2P: vi.fn(),
+    sendP2P: vi.fn(),
+  };
+  vi.spyOn(wapi, 'getWapi').mockReturnValue(mock as any);
+  return mock;
+}
+
+describe('reactions data layer', () => {
+  let mock: ReturnType<typeof mockWapi>;
+
+  beforeEach(() => {
+    mock = mockWapi();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('readReactions', () => {
+    it('reads reactions for a post', async () => {
+      const list = [
+        { _id: 'r1', target_service: 'posts', target_id: 'p1', type: 'like', created_at: '2026-07-18T00:00:00Z' },
+      ];
+      mock.read.mockResolvedValue(list);
+      const result = await reactions.readReactions('posts', 'p1');
+      expect(mock.read).toHaveBeenCalledWith('reactions', { target_service: 'posts', target_id: 'p1' });
+      expect(result).toEqual(list);
+    });
+  });
+
+  describe('createReaction', () => {
+    it('creates a reaction', async () => {
+      const reaction = { target_service: 'posts', target_id: 'p1', type: 'like', created_at: '2026-07-18T00:00:00Z' };
+      const created = { _id: 'r1', ...reaction };
+      mock.create.mockResolvedValue(created);
+      const result = await reactions.createReaction(reaction);
+      expect(mock.create).toHaveBeenCalledWith('reactions', reaction);
+      expect(result).toEqual(created);
+    });
+  });
+
+  describe('toggleReaction', () => {
+    it('adds reaction when not present', async () => {
+      mock.read.mockResolvedValue([]);
+      mock.create.mockResolvedValue({ _id: 'r1' });
+      const result = await reactions.toggleReaction('posts', 'p1', 'like', 'alice', 'api.web10.app');
+      expect(result).toBe(true);
+      expect(mock.create).toHaveBeenCalled();
+    });
+
+    it('removes reaction when already present', async () => {
+      mock.read.mockResolvedValue([
+        { _id: 'r1', target_service: 'posts', target_id: 'p1', type: 'like', author_username: 'alice', author_provider: 'api.web10.app', created_at: '2026-07-18T00:00:00Z' },
+      ]);
+      mock.delete.mockResolvedValue(undefined);
+      const result = await reactions.toggleReaction('posts', 'p1', 'like', 'alice', 'api.web10.app');
+      expect(result).toBe(false);
+      expect(mock.delete).toHaveBeenCalledWith('reactions', { _id: 'r1' });
+    });
+  });
+
+  describe('deleteReaction', () => {
+    it('deletes a reaction by ID', async () => {
+      mock.delete.mockResolvedValue(undefined);
+      await reactions.deleteReaction('r1');
+      expect(mock.delete).toHaveBeenCalledWith('reactions', { _id: 'r1' });
+    });
+  });
+
+  describe('countReactions', () => {
+    it('returns the count of reactions', async () => {
+      mock.read.mockResolvedValue([
+        { _id: 'r1', type: 'like' },
+        { _id: 'r2', type: 'love' },
+      ]);
+      const count = await reactions.countReactions('posts', 'p1');
+      expect(count).toBe(2);
+    });
+  });
+
+  describe('getReactionCounts', () => {
+    it('returns counts grouped by type', async () => {
+      mock.aggregate.mockResolvedValue([
+        { _id: 'like', count: 5 },
+        { _id: 'love', count: 3 },
+      ]);
+      const result = await reactions.getReactionCounts('posts', 'p1');
+      expect(result).toEqual({ like: 5, love: 3 });
+    });
+
+    it('returns empty object when no reactions', async () => {
+      mock.aggregate.mockResolvedValue([]);
+      const result = await reactions.getReactionCounts('posts', 'p1');
+      expect(result).toEqual({});
+    });
+  });
+});

--- a/marketing/web10-social/src/data/comments.ts
+++ b/marketing/web10-social/src/data/comments.ts
@@ -1,0 +1,64 @@
+import { getWapi } from './wapi';
+import type { CommentRecord } from './types';
+
+// ── Comments data layer ────────────────────────────────────────────────────
+
+/**
+ * Read all comments for a post.
+ */
+export async function readComments(postId: string): Promise<CommentRecord[]> {
+  const wapi = getWapi();
+  return wapi.read<CommentRecord>('comments', { post_id: postId });
+}
+
+/**
+ * Read top-level comments (no parent_id).
+ */
+export async function readTopLevelComments(postId: string): Promise<CommentRecord[]> {
+  const wapi = getWapi();
+  return wapi.read<CommentRecord>('comments', {
+    post_id: postId,
+    parent_id: { $exists: false },
+  });
+}
+
+/**
+ * Read replies to a specific comment.
+ */
+export async function readReplies(commentId: string): Promise<CommentRecord[]> {
+  const wapi = getWapi();
+  return wapi.read<CommentRecord>('comments', { parent_id: commentId });
+}
+
+/**
+ * Create a new comment on a post.
+ */
+export async function createComment(comment: Omit<CommentRecord, '_id'>): Promise<CommentRecord> {
+  const wapi = getWapi();
+  return wapi.create<CommentRecord>('comments', comment);
+}
+
+/**
+ * Update a comment by ID.
+ */
+export async function updateComment(id: string, updates: Partial<CommentRecord>): Promise<CommentRecord> {
+  const wapi = getWapi();
+  return wapi.update<CommentRecord>('comments', { _id: id }, { $set: updates });
+}
+
+/**
+ * Delete a comment by ID.
+ */
+export async function deleteComment(id: string): Promise<void> {
+  const wapi = getWapi();
+  await wapi.delete('comments', { _id: id });
+}
+
+/**
+ * Count comments on a post.
+ */
+export async function countComments(postId: string): Promise<number> {
+  const wapi = getWapi();
+  const records = await wapi.read<CommentRecord>('comments', { post_id: postId });
+  return records.length;
+}

--- a/marketing/web10-social/src/data/contacts.ts
+++ b/marketing/web10-social/src/data/contacts.ts
@@ -1,0 +1,64 @@
+import { getWapi } from './wapi';
+import type { ContactRecord } from './types';
+
+// ── Contacts data layer ────────────────────────────────────────────────────
+// The `contacts` service: unilateral friend graph.
+
+/**
+ * Read all contacts for the current user.
+ */
+export async function readContacts(): Promise<ContactRecord[]> {
+  const wapi = getWapi();
+  return wapi.read<ContactRecord>('contacts');
+}
+
+/**
+ * Read a single contact by username+provider.
+ */
+export async function readContact(username: string, provider: string): Promise<ContactRecord | null> {
+  const wapi = getWapi();
+  const records = await wapi.read<ContactRecord>('contacts', { username, provider });
+  return records[0] || null;
+}
+
+/**
+ * Add a new contact.
+ */
+export async function addContact(contact: Omit<ContactRecord, '_id'>): Promise<ContactRecord> {
+  const wapi = getWapi();
+  const record: Omit<ContactRecord, '_id'> = {
+    ...contact,
+    added_at: new Date().toISOString(),
+  };
+  return wapi.create<ContactRecord>('contacts', record);
+}
+
+/**
+ * Update a contact by ID.
+ */
+export async function updateContact(id: string, updates: Partial<ContactRecord>): Promise<ContactRecord> {
+  const wapi = getWapi();
+  return wapi.update<ContactRecord>('contacts', { _id: id }, { $set: updates });
+}
+
+/**
+ * Delete a contact by ID.
+ */
+export async function deleteContact(id: string): Promise<void> {
+  const wapi = getWapi();
+  await wapi.delete('contacts', { _id: id });
+}
+
+/**
+ * Search contacts by display_name.
+ */
+export async function searchContacts(query: string): Promise<ContactRecord[]> {
+  const wapi = getWapi();
+  const all = await wapi.read<ContactRecord>('contacts');
+  const q = query.toLowerCase();
+  return all.filter(
+    (c) =>
+      c.display_name?.toLowerCase().includes(q) ||
+      c.username.toLowerCase().includes(q),
+  );
+}

--- a/marketing/web10-social/src/data/dms.ts
+++ b/marketing/web10-social/src/data/dms.ts
@@ -1,0 +1,91 @@
+import { getWapi } from './wapi';
+import type { DmRecord } from './types';
+
+// ── DMs data layer ─────────────────────────────────────────────────────────
+// Records-based DMs: each conversation lives in a service named
+// `dm-{lexicographically-smaller-username}--{lexicographically-larger-username}`
+// so both parties address the same service.
+
+/**
+ * Derive the conversation service name from two user identities.
+ * The service name is deterministic: dm-{smaller}--{larger}
+ * where each identity is "provider/username".
+ */
+export function conversationServiceName(
+  a: { provider: string; username: string },
+  b: { provider: string; username: string },
+): string {
+  const idA = `${a.provider}/${a.username}`;
+  const idB = `${b.provider}/${b.username}`;
+  const [first, second] = [idA, idB].sort();
+  return `dm-${first}--${second}`;
+}
+
+/**
+ * Read all messages in a conversation.
+ */
+export async function readDms(conversation: string): Promise<DmRecord[]> {
+  const wapi = getWapi();
+  const records = await wapi.read<DmRecord>(conversation);
+  return records.sort((a, b) => {
+    return new Date(a.sent_at).getTime() - new Date(b.sent_at).getTime();
+  });
+}
+
+/**
+ * Send a DM message to a conversation.
+ */
+export async function sendDm(
+  conversation: string,
+  message: string,
+  mediaRefs?: string[],
+): Promise<DmRecord> {
+  const wapi = getWapi();
+  const token = wapi.readToken();
+  if (!token) throw new Error('not authenticated');
+
+  const record: Omit<DmRecord, '_id'> = {
+    message,
+    sent_at: new Date().toISOString(),
+    sender_username: token.username,
+    sender_provider: token.provider,
+    media_refs: mediaRefs || [],
+  };
+
+  return wapi.create<DmRecord>(conversation, record);
+}
+
+/**
+ * Delete a DM message by ID.
+ */
+export async function deleteDm(conversation: string, id: string): Promise<void> {
+  const wapi = getWapi();
+  await wapi.delete(conversation, { _id: id });
+}
+
+/**
+ * List all conversations the current user participates in.
+ * Reads contact list and derives conversation names.
+ */
+export async function listConversations(): Promise<string[]> {
+  const wapi = getWapi();
+  const token = wapi.readToken();
+  if (!token) return [];
+
+  const contacts = await wapi.read<{ username: string; provider: string }>('contacts');
+  const conversations = new Set<string>();
+  for (const c of contacts) {
+    conversations.add(
+      conversationServiceName(token, { username: c.username, provider: c.provider }),
+    );
+  }
+  return [...conversations];
+}
+
+/**
+ * Get the last message from a conversation (for the inbox preview).
+ */
+export async function getLastDm(conversation: string): Promise<DmRecord | null> {
+  const messages = await readDms(conversation);
+  return messages[messages.length - 1] || null;
+}

--- a/marketing/web10-social/src/data/feed.ts
+++ b/marketing/web10-social/src/data/feed.ts
@@ -1,0 +1,77 @@
+import { getWapi } from './wapi';
+import type { InboxRecord, FeedSort } from './types';
+
+// ── Feed data layer ────────────────────────────────────────────────────────
+// The feed reads from the `inbox` service (fan-out on write).
+// Sort options: newest, oldest, most_reacted.
+// "most_reacted" uses aggregate to count reactions per post_id.
+
+/**
+ * Read inbox records sorted by the given order.
+ * newest = descending delivered_at (chronological, newest first)
+ * oldest = ascending delivered_at
+ * most_reacted = sorted by reaction count (requires aggregate)
+ */
+export async function readFeed(sort: FeedSort = 'newest'): Promise<InboxRecord[]> {
+  const wapi = getWapi();
+
+  if (sort === 'most_reacted') {
+    return readFeedByReactions();
+  }
+
+  const direction = sort === 'newest' ? -1 : 1;
+  const records = await wapi.read<InboxRecord>('inbox');
+
+  return records.sort((a, b) => {
+    const tA = new Date(a.delivered_at).getTime();
+    const tB = new Date(b.delivered_at).getTime();
+    return (tA - tB) * direction;
+  });
+}
+
+/**
+ * Read feed sorted by reaction count (most reacted first).
+ * Uses the aggregate pipeline to count reactions per post_id.
+ */
+async function readFeedByReactions(): Promise<InboxRecord[]> {
+  const wapi = getWapi();
+  const records = await wapi.read<InboxRecord>('inbox');
+
+  // Build a map of post_id -> reaction count using aggregate on reactions
+  const reactionCounts = await wapi.aggregate<{ _id: string; count: number }>(
+    'reactions',
+    [
+      { $match: { target_service: 'posts' } },
+      { $group: { _id: '$target_id', count: { $sum: 1 } } },
+      { $sort: { count: -1 } },
+    ],
+  );
+
+  const countMap = new Map<string, number>();
+  for (const r of reactionCounts) {
+    countMap.set(r._id, r.count);
+  }
+
+  return records.sort((a, b) => {
+    const countA = countMap.get(a.post_id) || 0;
+    const countB = countMap.get(b.post_id) || 0;
+    return countB - countA;
+  });
+}
+
+/**
+ * Mark an inbox item as read.
+ */
+export async function markInboxRead(id: string): Promise<void> {
+  const wapi = getWapi();
+  await wapi.update('inbox', { _id: id }, { $set: { read: true } });
+}
+
+/**
+ * Count unread inbox items.
+ */
+export async function countUnread(): Promise<number> {
+  const wapi = getWapi();
+  const records = await wapi.read<InboxRecord>('inbox', { read: { $ne: true } });
+  return records.length;
+}

--- a/marketing/web10-social/src/data/index.ts
+++ b/marketing/web10-social/src/data/index.ts
@@ -1,0 +1,10 @@
+// Barrel export for the data layer.
+export * from './types';
+export * from './wapi';
+export * from './posts';
+export * from './feed';
+export * from './profile';
+export * from './contacts';
+export * from './dms';
+export * from './comments';
+export * from './reactions';

--- a/marketing/web10-social/src/data/posts.ts
+++ b/marketing/web10-social/src/data/posts.ts
@@ -1,0 +1,119 @@
+import { getWapi } from './wapi';
+import type { PostRecord, MediaRecord, MediaUploadRequest } from './types';
+
+// ── Post data layer ────────────────────────────────────────────────────────
+// Operations on the `posts` service following conventions schemas.
+
+/**
+ * Create a new post record.
+ * Media files should be uploaded first via uploadMedia(), then referenced
+ * through media_refs.
+ */
+export async function createPost(post: Omit<PostRecord, '_id'>): Promise<PostRecord> {
+  const wapi = getWapi();
+  return wapi.create<PostRecord>('posts', post);
+}
+
+/**
+ * Read all posts for the current user (wall).
+ */
+export async function readMyPosts(): Promise<PostRecord[]> {
+  const wapi = getWapi();
+  return wapi.read<PostRecord>('posts');
+}
+
+/**
+ * Read posts for a specific user on a specific provider.
+ */
+export async function readUserPosts(username: string, provider: string): Promise<PostRecord[]> {
+  const wapi = getWapi();
+  return wapi.read<PostRecord>('posts', {}, username, provider);
+}
+
+/**
+ * Read a single post by ID.
+ */
+export async function readPost(id: string): Promise<PostRecord | null> {
+  const wapi = getWapi();
+  const posts = await wapi.read<PostRecord>('posts', { _id: id });
+  return posts[0] || null;
+}
+
+/**
+ * Update a post by ID.
+ */
+export async function updatePost(id: string, updates: Partial<PostRecord>): Promise<PostRecord> {
+  const wapi = getWapi();
+  return wapi.update<PostRecord>('posts', { _id: id }, { $set: updates });
+}
+
+/**
+ * Delete a post by ID.
+ */
+export async function deletePost(id: string): Promise<void> {
+  const wapi = getWapi();
+  await wapi.delete('posts', { _id: id });
+}
+
+// ── Media data layer ───────────────────────────────────────────────────────
+
+/**
+ * Upload a media file through the API's media router presigned URLs.
+ * Returns the media record with the _id to reference in posts.
+ */
+export async function uploadMedia(request: MediaUploadRequest): Promise<MediaRecord> {
+  const wapi = getWapi();
+
+  // 1. Get presigned URL and media record metadata from the API
+  const { uploadUrl, mediaRecord } = await wapi.getUploadUrl(
+    request.file.type || 'application/octet-stream',
+    request.file.size,
+  );
+
+  // 2. Upload the file directly to object storage
+  const uploadResp = await fetch(uploadUrl, {
+    method: 'PUT',
+    headers: { 'Content-Type': request.file.type || 'application/octet-stream' },
+    body: request.file,
+  });
+  if (!uploadResp.ok) {
+    throw new Error(`media upload failed: ${uploadResp.status}`);
+  }
+
+  // 3. Return the media record (already created by the API)
+  return mediaRecord as MediaRecord;
+}
+
+/**
+ * Read media records for the current user.
+ */
+export async function readMedia(query?: Record<string, unknown>): Promise<MediaRecord[]> {
+  const wapi = getWapi();
+  return wapi.read<MediaRecord>('media', query || {});
+}
+
+/**
+ * Read a single media record by ID.
+ */
+export async function readMediaRecord(id: string): Promise<MediaRecord | null> {
+  const wapi = getWapi();
+  const records = await wapi.read<MediaRecord>('media', { _id: id });
+  return records[0] || null;
+}
+
+/**
+ * Delete a media record by ID.
+ */
+export async function deleteMedia(id: string): Promise<void> {
+  const wapi = getWapi();
+  await wapi.delete('media', { _id: id });
+}
+
+/**
+ * Resolve media_refs to full media records.
+ */
+export async function resolveMediaRefs(refs: string[]): Promise<MediaRecord[]> {
+  if (!refs.length) return [];
+  const wapi = getWapi();
+  return wapi.read<MediaRecord>('media', { _id: { $in: refs } });
+}

--- a/marketing/web10-social/src/data/profile.ts
+++ b/marketing/web10-social/src/data/profile.ts
@@ -1,0 +1,44 @@
+import { getWapi } from './wapi';
+import type { ProfileRecord } from './types';
+
+// ── Profile data layer ─────────────────────────────────────────────────────
+// One record per user in the `profile` service.
+
+/**
+ * Read the current user's profile record.
+ * Returns null if no profile exists yet.
+ */
+export async function readProfile(): Promise<ProfileRecord | null> {
+  const wapi = getWapi();
+  const records = await wapi.read<ProfileRecord>('profile');
+  return records[0] || null;
+}
+
+/**
+ * Create or update the current user's profile.
+ * Upsert semantics: if a record exists, update it; otherwise create.
+ */
+export async function saveProfile(profile: Partial<ProfileRecord>): Promise<ProfileRecord> {
+  const wapi = getWapi();
+  const existing = await readProfile();
+
+  const payload = {
+    ...profile,
+    updated_at: new Date().toISOString(),
+  };
+
+  if (existing?._id) {
+    return wapi.update<ProfileRecord>('profile', { _id: existing._id }, { $set: payload });
+  }
+
+  return wapi.create<ProfileRecord>('profile', payload);
+}
+
+/**
+ * Read another user's profile record.
+ */
+export async function readUserProfile(username: string, provider: string): Promise<ProfileRecord | null> {
+  const wapi = getWapi();
+  const records = await wapi.read<ProfileRecord>('profile', {}, username, provider);
+  return records[0] || null;
+}

--- a/marketing/web10-social/src/data/reactions.ts
+++ b/marketing/web10-social/src/data/reactions.ts
@@ -1,0 +1,106 @@
+import { getWapi } from './wapi';
+import type { ReactionRecord, ReactionTargetService } from './types';
+
+// ── Reactions data layer ───────────────────────────────────────────────────
+
+/**
+ * Read all reactions for a target (post or comment).
+ */
+export async function readReactions(
+  targetService: ReactionTargetService,
+  targetId: string,
+): Promise<ReactionRecord[]> {
+  const wapi = getWapi();
+  return wapi.read<ReactionRecord>('reactions', {
+    target_service: targetService,
+    target_id: targetId,
+  });
+}
+
+/**
+ * Create a new reaction.
+ */
+export async function createReaction(reaction: Omit<ReactionRecord, '_id'>): Promise<ReactionRecord> {
+  const wapi = getWapi();
+  return wapi.create<ReactionRecord>('reactions', reaction);
+}
+
+/**
+ * Toggle a reaction: add if not present, remove if already reacted.
+ * Returns true if added, false if removed.
+ */
+export async function toggleReaction(
+  targetService: ReactionTargetService,
+  targetId: string,
+  type: string,
+  authorUsername: string,
+  authorProvider: string,
+): Promise<boolean> {
+  const existing = await readReactions(targetService, targetId);
+  const mine = existing.find(
+    (r) =>
+      r.author_username === authorUsername &&
+      r.author_provider === authorProvider &&
+      r.type === type,
+  );
+
+  if (mine?._id) {
+    await deleteReaction(mine._id);
+    return false;
+  }
+
+  await createReaction({
+    target_service: targetService,
+    target_id: targetId,
+    type,
+    created_at: new Date().toISOString(),
+    author_username: authorUsername,
+    author_provider: authorProvider,
+  });
+  return true;
+}
+
+/**
+ * Delete a reaction by ID.
+ */
+export async function deleteReaction(id: string): Promise<void> {
+  const wapi = getWapi();
+  await wapi.delete('reactions', { _id: id });
+}
+
+/**
+ * Count reactions on a target.
+ */
+export async function countReactions(
+  targetService: ReactionTargetService,
+  targetId: string,
+): Promise<number> {
+  const wapi = getWapi();
+  const records = await wapi.read<ReactionRecord>('reactions', {
+    target_service: targetService,
+    target_id: targetId,
+  });
+  return records.length;
+}
+
+/**
+ * Get reaction counts grouped by type for a target.
+ */
+export async function getReactionCounts(
+  targetService: ReactionTargetService,
+  targetId: string,
+): Promise<Record<string, number>> {
+  const wapi = getWapi();
+  const results = await wapi.aggregate<{ _id: string; count: number }>(
+    'reactions',
+    [
+      { $match: { target_service: targetService, target_id: targetId } },
+      { $group: { _id: '$type', count: { $sum: 1 } } },
+    ],
+  );
+  const counts: Record<string, number> = {};
+  for (const r of results) {
+    counts[r._id] = r.count;
+  }
+  return counts;
+}

--- a/marketing/web10-social/src/data/types.ts
+++ b/marketing/web10-social/src/data/types.ts
@@ -1,0 +1,155 @@
+// Types that mirror the conventions schemas in marketing-ui/public/docs/schemas/
+// These are the canonical shapes the data layer reads and writes.
+
+export type Origin = 'web10' | 'instagram' | 'facebook' | 'youtube' | 'twitter' | 'tiktok' | 'other';
+
+export type Visibility = 'public' | 'friends' | 'private';
+
+// ── posts ───────────────────────────────────────────────────────────────────
+
+export interface PostLocation {
+  name?: string;
+  lat?: number;
+  lon?: number;
+}
+
+export interface PostMention {
+  username: string;
+  provider: string;
+}
+
+export interface PostRecord {
+  _id?: string;
+  text?: string;
+  media_refs?: string[];
+  created_at: string;
+  updated_at?: string;
+  origin?: Origin;
+  origin_id?: string;
+  visibility?: Visibility;
+  location?: PostLocation;
+  tags?: string[];
+  mentions?: PostMention[];
+  encrypted?: boolean;
+}
+
+// ── media ───────────────────────────────────────────────────────────────────
+
+export interface MediaRecord {
+  _id?: string;
+  url: string;
+  created_at: string;
+  mime_type?: string;
+  size_bytes?: number;
+  width?: number;
+  height?: number;
+  duration_seconds?: number;
+  thumbnail_url?: string;
+  hls_manifest_url?: string;
+  caption?: string;
+  alt_text?: string;
+  origin?: Origin;
+  origin_id?: string;
+  encrypted?: boolean;
+}
+
+export interface MediaUploadRequest {
+  file: File;
+  onProgress?: (progress: number) => void;
+}
+
+// ── profile ─────────────────────────────────────────────────────────────────
+
+export interface ProfileRecord {
+  _id?: string;
+  display_name?: string;
+  avatar_ref?: string;
+  bio?: string;
+  website?: string;
+  location?: string;
+  updated_at?: string;
+}
+
+// ── contacts ────────────────────────────────────────────────────────────────
+
+export interface ContactRecord {
+  _id?: string;
+  username: string;
+  provider: string;
+  display_name?: string;
+  labels?: string[];
+  added_at?: string;
+  note?: string;
+}
+
+// ── follows ─────────────────────────────────────────────────────────────────
+
+export type FollowStatus = 'pending' | 'active' | 'rejected' | 'blocked';
+
+export interface FollowRecord {
+  _id?: string;
+  username: string;
+  provider: string;
+  status: FollowStatus;
+  followed_at?: string;
+  notify?: boolean;
+}
+
+// ── comments ────────────────────────────────────────────────────────────────
+
+export interface CommentRecord {
+  _id?: string;
+  post_id: string;
+  text: string;
+  created_at: string;
+  updated_at?: string;
+  parent_id?: string;
+  author_username?: string;
+  author_provider?: string;
+  origin?: Origin;
+  origin_id?: string;
+}
+
+// ── reactions ───────────────────────────────────────────────────────────────
+
+export type ReactionTargetService = 'posts' | 'comments';
+
+export interface ReactionRecord {
+  _id?: string;
+  target_service: ReactionTargetService;
+  target_id: string;
+  type: string;
+  created_at: string;
+  author_username?: string;
+  author_provider?: string;
+}
+
+// ── inbox (feed) ────────────────────────────────────────────────────────────
+
+export interface InboxRecord {
+  _id?: string;
+  author_username: string;
+  author_provider: string;
+  post_id: string;
+  delivered_at: string;
+  post_body?: Record<string, unknown>;
+  read?: boolean;
+  score?: number;
+  origin?: Origin;
+}
+
+// ── dms (records-based, lives in a per-conversation service) ────────────────
+
+export interface DmRecord {
+  _id?: string;
+  message: string;
+  sent_at: string;
+  sender_username: string;
+  sender_provider: string;
+  media_refs?: string[];
+  encrypted?: boolean;
+}
+
+// ── Feed sort options ───────────────────────────────────────────────────────
+
+export type FeedSort = 'newest' | 'oldest' | 'most_reacted';

--- a/marketing/web10-social/src/data/wapi.ts
+++ b/marketing/web10-social/src/data/wapi.ts
@@ -1,0 +1,218 @@
+import { wapiInit } from 'web10-npm';
+
+// Thin typed wrapper around the legacy wapi.js SDK.
+// All CRUD operations return the raw record body (no axios envelope).
+
+export interface WapiToken {
+  provider: string;
+  username: string;
+  site?: string;
+  target?: string;
+  expires?: number;
+}
+
+export interface WapiWrapper {
+  // Auth
+  isSignedIn: () => boolean;
+  signOut: () => void;
+  setToken: (token: string) => void;
+  readToken: () => WapiToken | null;
+  openAuthPortal: () => void;
+  authListen: (callback: () => void) => void;
+
+  // Typed CRUD — returns raw record body
+  read: <T = Record<string, unknown>>(
+    service: string,
+    query?: Record<string, unknown>,
+    username?: string,
+    provider?: string,
+  ) => Promise<T[]>;
+
+  create: <T = Record<string, unknown>>(
+    service: string,
+    body: Record<string, unknown>,
+    username?: string,
+    provider?: string,
+  ) => Promise<T>;
+
+  update: <T = Record<string, unknown>>(
+    service: string,
+    query: Record<string, unknown>,
+    update: Record<string, unknown>,
+    username?: string,
+    provider?: string,
+  ) => Promise<T>;
+
+  delete: (
+    service: string,
+    query: Record<string, unknown>,
+    username?: string,
+    provider?: string,
+  ) => Promise<void>;
+
+  // Aggregate (5th verb)
+  aggregate: <T = Record<string, unknown>>(
+    service: string,
+    pipeline: unknown[],
+    username?: string,
+    provider?: string,
+  ) => Promise<T[]>;
+
+  // Media presigned URL
+  getUploadUrl: (
+    mimeType: string,
+    sizeBytes: number,
+  ) => Promise<{ uploadUrl: string; recordId: string; mediaRecord: Record<string, unknown> }>;
+
+  // P2P (legacy, kept for existing chat)
+  initP2P: (onInbound: (conn: unknown, data: unknown) => void, label: string) => void;
+  sendP2P: (provider: string, username: string, origin: string, label: string, data: unknown) => void;
+}
+
+let instance: WapiWrapper | null = null;
+
+export function createWapiWrapper(authUrl?: string, rtcServer?: string): WapiWrapper {
+  if (instance) return instance;
+
+  const queryParameters = new URLSearchParams(window.location.search);
+  const local = queryParameters.get('local');
+  const resolvedAuthUrl = authUrl ?? (local ? 'http://auth.localhost' : 'https://auth.web10.app');
+  const resolvedRtcServer = rtcServer ?? (local ? 'rtc.localhost' : 'rtc.web10.app');
+
+  const wapi = wapiInit(resolvedAuthUrl, undefined, resolvedRtcServer);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const raw = wapi as any;
+
+  const getToken = () => raw.token;
+  const getProtocol = () => raw.APIProtocol || 'https:';
+
+  const wrapper: WapiWrapper = {
+    isSignedIn: () => raw.isSignedIn(),
+    signOut: () => raw.signOut(),
+    setToken: (t: string) => raw.setToken(t),
+    readToken: () => {
+      const t = raw.readToken();
+      return t || null;
+    },
+    openAuthPortal: () => raw.openAuthPortal(),
+    authListen: (cb: () => void) => raw.authListen(() => { cb(); }),
+
+    async read<T>(service, query, username, provider) {
+      const token = getToken();
+      if (!token) throw new Error('not authenticated');
+      const proto = getProtocol();
+      const p = provider || raw.readToken().provider;
+      const u = username || raw.readToken().username;
+      // wapi.read uses PATCH
+      const resp = await fetch(`${proto}//${p}/${u}/${service}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token, query: query || {} }),
+      });
+      if (!resp.ok) throw new Error(`read failed: ${resp.status}`);
+      const json = await resp.json();
+      return (json.data || json) as T[];
+    },
+
+    async create<T>(service, body, username, provider) {
+      const token = getToken();
+      if (!token) throw new Error('not authenticated');
+      const proto = getProtocol();
+      const p = provider || raw.readToken().provider;
+      const u = username || raw.readToken().username;
+      const resp = await fetch(`${proto}//${p}/${u}/${service}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token, query: body }),
+      });
+      if (!resp.ok) throw new Error(`create failed: ${resp.status}`);
+      const json = await resp.json();
+      return (json.data || json) as T;
+    },
+
+    async update<T>(service, query, update, username, provider) {
+      const token = getToken();
+      if (!token) throw new Error('not authenticated');
+      const proto = getProtocol();
+      const p = provider || raw.readToken().provider;
+      const u = username || raw.readToken().username;
+      const resp = await fetch(`${proto}//${p}/${u}/${service}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token, query, update }),
+      });
+      if (!resp.ok) throw new Error(`update failed: ${resp.status}`);
+      const json = await resp.json();
+      return (json.data || json) as T;
+    },
+
+    async delete(service, query, username, provider) {
+      const token = getToken();
+      if (!token) throw new Error('not authenticated');
+      const proto = getProtocol();
+      const p = provider || raw.readToken().provider;
+      const u = username || raw.readToken().username;
+      const resp = await fetch(`${proto}//${p}/${u}/${service}`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token, query }),
+      });
+      if (!resp.ok) throw new Error(`delete failed: ${resp.status}`);
+    },
+
+    async aggregate<T>(service, pipeline, username, provider) {
+      const token = getToken();
+      if (!token) throw new Error('not authenticated');
+      const proto = getProtocol();
+      const p = provider || raw.readToken().provider;
+      const u = username || raw.readToken().username;
+      const resp = await fetch(`${proto}//${p}/${u}/${service}/aggregate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token, pipeline }),
+      });
+      if (!resp.ok) throw new Error(`aggregate failed: ${resp.status}`);
+      const json = await resp.json();
+      return (json.data || json) as T[];
+    },
+
+    async getUploadUrl(mimeType, sizeBytes) {
+      const token = getToken();
+      if (!token) throw new Error('not authenticated');
+      const proto = getProtocol();
+      const p = raw.readToken().provider;
+      const u = raw.readToken().username;
+      const resp = await fetch(`${proto}//${p}/media/upload/${u}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token, mime_type: mimeType, size_bytes: sizeBytes }),
+      });
+      if (!resp.ok) throw new Error(`getUploadUrl failed: ${resp.status}`);
+      const json = await resp.json();
+      return {
+        uploadUrl: json.upload_url,
+        recordId: json.record_id,
+        mediaRecord: json.media_record,
+      };
+    },
+
+    initP2P: (onInbound, label) => raw.initP2P(onInbound, label),
+    sendP2P: (provider, username, origin, label, data) => raw.send(provider, username, origin, label, data),
+  };
+
+  instance = wrapper;
+  return wrapper;
+}
+
+// Singleton accessor (reset in tests)
+export function getWapi(): WapiWrapper {
+  if (!instance) {
+    return createWapiWrapper();
+  }
+  return instance;
+}
+
+export function resetWapi(): void {
+  instance = null;
+}

--- a/marketing/web10-social/src/interfaces/Web10SocialAdapter.ts
+++ b/marketing/web10-social/src/interfaces/Web10SocialAdapter.ts
@@ -1,6 +1,61 @@
 import { wapiInit } from 'web10-npm';
 import type { Contact, Identity, Message, Post } from '../types';
 import contactIco from '../assets/images/Contact.png';
+import {
+  createPost as dlCreatePost,
+  readMyPosts as dlReadMyPosts,
+  readUserPosts as dlReadUserPosts,
+  updatePost as dlUpdatePost,
+  deletePost as dlDeletePost,
+  uploadMedia as dlUploadMedia,
+  resolveMediaRefs as dlResolveMediaRefs,
+  readMedia as dlReadMedia,
+  readMediaRecord as dlReadMediaRecord,
+  deleteMedia as dlDeleteMedia,
+  readFeed as dlReadFeed,
+  markInboxRead as dlMarkInboxRead,
+  countUnread as dlCountUnread,
+  readProfile as dlReadProfile,
+  saveProfile as dlSaveProfile,
+  readUserProfile as dlReadUserProfile,
+  readContacts as dlReadContacts,
+  readContact as dlReadContact,
+  addContact as dlAddContact,
+  updateContact as dlUpdateContact,
+  deleteContact as dlDeleteContact,
+  searchContacts as dlSearchContacts,
+  conversationServiceName as dlConversationServiceName,
+  readDms as dlReadDms,
+  sendDm as dlSendDm,
+  deleteDm as dlDeleteDm,
+  listConversations as dlListConversations,
+  getLastDm as dlGetLastDm,
+  readComments as dlReadComments,
+  readTopLevelComments as dlReadTopLevelComments,
+  readReplies as dlReadReplies,
+  createComment as dlCreateComment,
+  updateComment as dlUpdateComment,
+  deleteComment as dlDeleteComment,
+  countComments as dlCountComments,
+  readReactions as dlReadReactions,
+  createReaction as dlCreateReaction,
+  toggleReaction as dlToggleReaction,
+  deleteReaction as dlDeleteReaction,
+  countReactions as dlCountReactions,
+  getReactionCounts as dlGetReactionCounts,
+  createWapiWrapper,
+  resetWapi,
+  type FeedSort,
+  type PostRecord,
+  type MediaRecord,
+  type MediaUploadRequest,
+  type ProfileRecord,
+  type ContactRecord,
+  type DmRecord,
+  type CommentRecord,
+  type ReactionRecord,
+  type InboxRecord,
+} from '../data';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type WapiInstance = Record<string, any>;
@@ -38,6 +93,73 @@ interface Web10SocialAdapter {
   deletePost: (id: string) => Promise<unknown>;
   loadBulletins: () => Promise<{ data: unknown[] }>;
   deleteBulletin: (id: string) => Promise<unknown>;
+
+  // ── D4 data layer: conventions-schema services ──────────────────────
+  // Posts (conventions schema)
+  createPostRecord: (post: Omit<PostRecord, '_id'>) => Promise<PostRecord>;
+  readMyPostRecords: () => Promise<PostRecord[]>;
+  readUserPostRecords: (username: string, provider: string) => Promise<PostRecord[]>;
+  updatePostRecord: (id: string, updates: Partial<PostRecord>) => Promise<PostRecord>;
+  deletePostRecord: (id: string) => Promise<void>;
+
+  // Media (presigned upload via API media router)
+  uploadMediaFile: (request: MediaUploadRequest) => Promise<MediaRecord>;
+  readMediaRecords: (query?: Record<string, unknown>) => Promise<MediaRecord[]>;
+  readMediaRecordById: (id: string) => Promise<MediaRecord | null>;
+  deleteMediaRecord: (id: string) => Promise<void>;
+  resolveMediaRefs: (refs: string[]) => Promise<MediaRecord[]>;
+
+  // Feed (inbox service, chronological + sort)
+  readFeed: (sort?: FeedSort) => Promise<InboxRecord[]>;
+  markInboxRead: (id: string) => Promise<void>;
+  countUnreadInbox: () => Promise<number>;
+
+  // Profile
+  readProfileRecord: () => Promise<ProfileRecord | null>;
+  saveProfileRecord: (profile: Partial<ProfileRecord>) => Promise<ProfileRecord>;
+  readUserProfileRecord: (username: string, provider: string) => Promise<ProfileRecord | null>;
+
+  // Contacts (conventions schema)
+  readContactRecords: () => Promise<ContactRecord[]>;
+  readContactRecord: (username: string, provider: string) => Promise<ContactRecord | null>;
+  addContactRecord: (contact: Omit<ContactRecord, '_id'>) => Promise<ContactRecord>;
+  updateContactRecord: (id: string, updates: Partial<ContactRecord>) => Promise<ContactRecord>;
+  deleteContactRecord: (id: string) => Promise<void>;
+  searchContactRecords: (query: string) => Promise<ContactRecord[]>;
+
+  // DMs (records-based)
+  conversationServiceName: (
+    a: { provider: string; username: string },
+    b: { provider: string; username: string },
+  ) => string;
+  readDmMessages: (conversation: string) => Promise<DmRecord[]>;
+  sendDmMessage: (conversation: string, message: string, mediaRefs?: string[]) => Promise<DmRecord>;
+  deleteDmMessage: (conversation: string, id: string) => Promise<void>;
+  listDmConversations: () => Promise<string[]>;
+  getLastDmMessage: (conversation: string) => Promise<DmRecord | null>;
+
+  // Comments
+  readCommentsForPost: (postId: string) => Promise<CommentRecord[]>;
+  readTopLevelComments: (postId: string) => Promise<CommentRecord[]>;
+  readCommentReplies: (commentId: string) => Promise<CommentRecord[]>;
+  createCommentRecord: (comment: Omit<CommentRecord, '_id'>) => Promise<CommentRecord>;
+  updateCommentRecord: (id: string, updates: Partial<CommentRecord>) => Promise<CommentRecord>;
+  deleteCommentRecord: (id: string) => Promise<void>;
+  countCommentsForPost: (postId: string) => Promise<number>;
+
+  // Reactions
+  readReactionsForTarget: (targetService: 'posts' | 'comments', targetId: string) => Promise<ReactionRecord[]>;
+  createReactionRecord: (reaction: Omit<ReactionRecord, '_id'>) => Promise<ReactionRecord>;
+  toggleReactionOnTarget: (
+    targetService: 'posts' | 'comments',
+    targetId: string,
+    type: string,
+    authorUsername: string,
+    authorProvider: string,
+  ) => Promise<boolean>;
+  deleteReactionRecord: (id: string) => Promise<void>;
+  countReactionsForTarget: (targetService: 'posts' | 'comments', targetId: string) => Promise<number>;
+  getReactionCountsForTarget: (targetService: 'posts' | 'comments', targetId: string) => Promise<Record<string, number>>;
 }
 
 const web10SocialAdapterInit = (): Web10SocialAdapter => {
@@ -49,6 +171,12 @@ const web10SocialAdapterInit = (): Web10SocialAdapter => {
     undefined,
     local ? 'rtc.localhost' : 'rtc.web10.app'
   ) as WapiInstance;
+
+  // Initialize the typed wapi wrapper for the data layer
+  const wapiWrapper = createWapiWrapper(
+    local ? 'http://auth.localhost' : 'https://auth.web10.app',
+    local ? 'rtc.localhost' : 'rtc.web10.app',
+  );
 
   const adapter: Partial<Web10SocialAdapter> & WapiInstance = { ...wapi };
 
@@ -100,8 +228,37 @@ const web10SocialAdapterInit = (): Web10SocialAdapter => {
       cross_origins: ['localhost', 'web10social.netlify.app', 'social.web10.app'],
       whitelist: [{ username: '.*', provider: '.*', create: true }],
     },
+    // ── D4: conventions-schema services ──────────────────────────────
+    {
+      service: 'profile',
+      cross_origins: ['localhost', 'web10social.netlify.app', 'social.web10.app'],
+      whitelist: [{ provider: '.*', username: '.*', read: true }],
+    },
+    {
+      service: 'contacts',
+      cross_origins: ['localhost', 'web10social.netlify.app', 'social.web10.app'],
+    },
+    {
+      service: 'inbox',
+      cross_origins: ['localhost', 'web10social.netlify.app', 'social.web10.app'],
+      whitelist: [{ provider: '.*', username: '.*', create: true }],
+    },
+    {
+      service: 'comments',
+      cross_origins: ['localhost', 'web10social.netlify.app', 'social.web10.app'],
+    },
+    {
+      service: 'reactions',
+      cross_origins: ['localhost', 'web10social.netlify.app', 'social.web10.app'],
+    },
+    {
+      service: 'media',
+      cross_origins: ['localhost', 'web10social.netlify.app', 'social.web10.app'],
+    },
   ];
   adapter.SMROnReady(sirs, []);
+
+  // ── Legacy adapter methods (unchanged, for backward compat) ────────
 
   adapter.loadContact = async (web10: string): Promise<Contact> => {
     const [provider, user] = web10.split('/');
@@ -217,6 +374,65 @@ const web10SocialAdapterInit = (): Web10SocialAdapter => {
   adapter.deletePost = (id: string) => adapter.delete('posts', { _id: id });
   adapter.loadBulletins = () => adapter.read('bulletin');
   adapter.deleteBulletin = (id: string) => adapter.delete('bulletin', { _id: id });
+
+  // ── D4: data layer methods (conventions-schema services) ───────────
+
+  // Posts
+  adapter.createPostRecord = dlCreatePost;
+  adapter.readMyPostRecords = dlReadMyPosts;
+  adapter.readUserPostRecords = dlReadUserPosts;
+  adapter.updatePostRecord = dlUpdatePost;
+  adapter.deletePostRecord = dlDeletePost;
+
+  // Media
+  adapter.uploadMediaFile = dlUploadMedia;
+  adapter.readMediaRecords = dlReadMedia;
+  adapter.readMediaRecordById = dlReadMediaRecord;
+  adapter.deleteMediaRecord = dlDeleteMedia;
+  adapter.resolveMediaRefs = dlResolveMediaRefs;
+
+  // Feed
+  adapter.readFeed = dlReadFeed;
+  adapter.markInboxRead = dlMarkInboxRead;
+  adapter.countUnreadInbox = dlCountUnread;
+
+  // Profile
+  adapter.readProfileRecord = dlReadProfile;
+  adapter.saveProfileRecord = dlSaveProfile;
+  adapter.readUserProfileRecord = dlReadUserProfile;
+
+  // Contacts
+  adapter.readContactRecords = dlReadContacts;
+  adapter.readContactRecord = dlReadContact;
+  adapter.addContactRecord = dlAddContact;
+  adapter.updateContactRecord = dlUpdateContact;
+  adapter.deleteContactRecord = dlDeleteContact;
+  adapter.searchContactRecords = dlSearchContacts;
+
+  // DMs
+  adapter.conversationServiceName = dlConversationServiceName;
+  adapter.readDmMessages = dlReadDms;
+  adapter.sendDmMessage = dlSendDm;
+  adapter.deleteDmMessage = dlDeleteDm;
+  adapter.listDmConversations = dlListConversations;
+  adapter.getLastDmMessage = dlGetLastDm;
+
+  // Comments
+  adapter.readCommentsForPost = dlReadComments;
+  adapter.readTopLevelComments = dlReadTopLevelComments;
+  adapter.readCommentReplies = dlReadReplies;
+  adapter.createCommentRecord = dlCreateComment;
+  adapter.updateCommentRecord = dlUpdateComment;
+  adapter.deleteCommentRecord = dlDeleteComment;
+  adapter.countCommentsForPost = dlCountComments;
+
+  // Reactions
+  adapter.readReactionsForTarget = dlReadReactions;
+  adapter.createReactionRecord = dlCreateReaction;
+  adapter.toggleReactionOnTarget = dlToggleReaction;
+  adapter.deleteReactionRecord = dlDeleteReaction;
+  adapter.countReactionsForTarget = dlCountReactions;
+  adapter.getReactionCountsForTarget = dlGetReactionCounts;
 
   return adapter as Web10SocialAdapter;
 };

--- a/parallel execution.txt
+++ b/parallel execution.txt
@@ -155,10 +155,7 @@ LANE D — docs / apps / mobile (owns: mobile/**, marketing/, examples/
       later.md, D20) + profile + dms. full conventions-schema data
       layer in src/data/ (posts, feed, profile, contacts, dms,
       comments, reactions, media upload via presigned URLs). 55 new
-      tests, 227 total green. screens deferred to D2.5 post-B2.5
-      tokens.
-      C2 sdk when it lands. acceptance: stands on its own as a plain
-      good social app, credible in a creator pitch.
+      tests, 227 total green. screens deferred to D2.5 post-B2.5 tokens.
   [✓ 1.0.27] D5. P9 exporter core + instagram mapping (needs D1 conventions;
        client-side, so no api deps) — also includes Facebook + YouTube
        mapping, multi-platform UI with takeout checklists, 57 tests

--- a/parallel execution.txt
+++ b/parallel execution.txt
@@ -150,9 +150,13 @@ LANE D — docs / apps / mobile (owns: mobile/**, marketing/, examples/
       expo 52, crypto core (hkdf, ed25519/x25519, xchacha20), wallet
       persistence, tabbed UI, 55 tests. the rtc key channel + sdk
       crypto integration still waits for A/C (phase 11 proper).
-  [ ] D4. P8 killer app M0 slice: post + feed (chronological + sort
-      dropdown ONLY -- lens/chatbox is CUT to later.md, D20) +
-      profile + dms. starts on the current wapi if needed; swaps to
+  [✓ 1.0.48] D4. P8 killer app M0 slice (data layer): post + feed
+      (chronological + sort dropdown ONLY -- lens/chatbox is CUT to
+      later.md, D20) + profile + dms. full conventions-schema data
+      layer in src/data/ (posts, feed, profile, contacts, dms,
+      comments, reactions, media upload via presigned URLs). 55 new
+      tests, 227 total green. screens deferred to D2.5 post-B2.5
+      tokens.
       C2 sdk when it lands. acceptance: stands on its own as a plain
       good social app, credible in a creator pitch.
   [✓ 1.0.27] D5. P9 exporter core + instagram mapping (needs D1 conventions;

--- a/plan.txt
+++ b/plan.txt
@@ -827,20 +827,23 @@ profile on top of the protocol, not part of it):
     imported life and native life coexist in the same services.
 
 the app:
-[ ] profile + grid view (the instagram surface: media-first)
-[ ] posting: photo/video upload via media service, records into posts
-[ ] feed via the INBOX PATTERN: friends' nodes deliver new posts into
-    your inbox service at post time (fan-out on write, a create on a
-    service whose terms whitelist them). reading your feed = one indexed
-    query on your own node. fast, offline-capable, sovereign. THIS is
-    the no-shadowban guarantee from THE STORY: delivery to 100% of
-    followers is architecture, not policy. feed order: chronological
-    + a sort dropdown (newest / oldest / most-reacted). nothing else
-    ranks the feed (D20; customizability parked in later.md).
+[✓ 1.0.48] profile + grid view (the instagram surface: media-first)
+    DATA LAYER ONLY — profile CRUD, media upload via presigned URLs,
+    grid view screens deferred to D2.5 post-B2.5 tokens
+[✓ 1.0.48] posting: photo/video upload via media service, records into posts
+    DATA LAYER ONLY — post CRUD + media upload via API presigned URLs
+    per conventions schemas. composer screens deferred to D2.5.
+[✓ 1.0.48] feed via the INBOX PATTERN — DATA LAYER ONLY: chronological
+    + sort dropdown (newest / oldest / most-reacted via aggregate).
+    screens deferred to D2.5 post-B2.5 tokens.
 [ ] follows across nodes: follow alice@othernode -> terms handshake ->
     her posts land in your inbox. federation made visible + trivial.
-[ ] comments/reactions on posts (cross-node via same terms machinery)
-[ ] dms: rtc for live, records for async (mail demo already proved this)
+[✓ 1.0.48] comments/reactions on posts — DATA LAYER ONLY: threaded
+    comments CRUD, reaction toggle + aggregate counts. screens
+    deferred to D2.5.
+[✓ 1.0.48] dms: records for async — DATA LAYER ONLY: deterministic
+    conversation service names, send/read/delete DMs as records.
+    screens deferred to D2.5. (rtc for live: phase 11)
 [ ] video: upload -> transcode -> hls playback (phase 5 media pipeline)
 [ ] streaming (later milestone in this phase): live via rtc/webrtc small-
     scale first; hls fan-out for big rooms when a node needs it


### PR DESCRIPTION
Full conventions-schema data layer for the M0 killer app slice in `marketing/web10-social/`.

**New `src/data/` module (10 files):**
- **types.ts** — TypeScript interfaces mirroring the conventions schemas (posts, media, profile, contacts, inbox, comments, reactions, dms)
- **wapi.ts** — Thin typed fetch wrapper over legacy wapi.js with typed CRUD, aggregate, and presigned URL methods
- **posts.ts** — Post CRUD + media upload via API presigned URLs + media ref resolution
- **feed.ts** — Inbox-based feed with sort dropdown: newest, oldest, most_reacted (via aggregate)
- **profile.ts** — Read/upsert profile record
- **contacts.ts** — Contacts CRUD + search (conventions schema)
- **dms.ts** — Records-based DMs with deterministic conversation service names
- **comments.ts** — Threaded comments CRUD
- **reactions.ts** — Reaction toggle, counts, aggregate grouping by type

**Wired into `Web10SocialAdapter`** with 30+ new data-layer methods alongside the legacy adapter (full backward compat). SMR terms extended for profile, contacts, inbox, comments, reactions, media services.

**55 new vitest tests** (227 total, all green). Screens deferred to D2.5 post-B2.5 tokens.