### PR TITLE
1.0.51: CLAUDE.md hand-off convention (next lane item + paste-ready kickoff)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+1.0.51 || 18.07.2026
+CLAUDE.md: new working convention — "hand off the next task": after a merge,
+agents end their final message with the next unticked lane item and a
+paste-ready kickoff prompt (task verbatim, gates, owned dirs, acceptance
+bar) for a fresh workspace.
+
 1.0.50 || 18.07.2026
 D4: web10-social data layer — full conventions-schema stack for the M0
 killer app slice. new src/data/ with typed modules: posts (CRUD + media

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,14 @@ touches auth, the DB layer, or tokens, run those tests and keep them green.
   auth flow, update `CLAUDE.md`/`GLOSSARY.md` in the same branch. A big
   architectural decision gets an entry in `decisions.md`. Stale orientation
   docs are worse than none.
+- **Hand off the next task.** After your work merges (or the PR is up), end
+  your final message with the next unticked item in your lane from
+  `parallel execution.txt` AND a paste-ready kickoff prompt for a fresh
+  workspace: the task text verbatim, its gates (what must merge first —
+  check the lane file), the directories that lane owns, and the acceptance
+  bar. If the next item is gated on unmerged work, say so in the kickoff so
+  the next agent checks the gate before building. This keeps the parallel
+  conveyor moving without the operator re-deriving state.
 
 ## Running it
 `docker-compose.yml` brings the stack up locally (`*.localhost` vhosts).


### PR DESCRIPTION
Adds a working convention to CLAUDE.md: after work merges, agents end their final message with the next unticked item in their lane and a paste-ready kickoff prompt for a fresh workspace (task verbatim, gates, owned dirs, acceptance bar). CHANGELOG 1.0.51.

This turns the 'suggest the next lane task after merging' flow into a checked-in rule every parallel agent reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)