### PR TITLE
1.0.54: rewrite README to match the current stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+1.0.54 || 19.07.2026
+README rewritten to match the current stack: dead references removed
+(auth/ dir, settings_example.py copying, skaffold/GKE deploy, hex-key
+website), replaced with the real quickstart (docker compose up --build →
+auth.localhost, env-var settings, FerretDB default + mongo profile),
+the creator-platform framing (D20: no shadow ban by architecture, inbox
+pattern), the actual repo map (ui/, marketing/*, ubuntu-deployment/),
+and pointers to plan.txt / GLOSSARY.md / decisions.md / SECURITY.md.
+
 1.0.53 || 19.07.2026
 outreach batch 1 fully enriched: 20 API-verified prospects via YouTube
 Data API v3 (outreach_sourcer.py). all burn events verified by video

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 web10 starts from one premise: **what you make is yours.**
 
 Every user gets their own database collection. Every record is
-`{service, body}`. Apps are stateless frontends — *lenses* — that borrow
+`{service, body}`. Apps are stateless frontends that borrow
 access through a scoped, expiring token, do their work, and step aside.
 The data outlives any app, because the data was never the app's to keep.
 
@@ -31,7 +31,7 @@ paid for value delivered, not for permission granted.
 | --- | --- |
 | **You own your data** | One collection per user — the record of your own life, held by you. Export it, move it, erase it. Delete means delete. |
 | **No shadow ban** | Every post reaches every follower, by construction (fan-out on write). The feed is chronological, because a feed should report — not editorialize. |
-| **Apps are lenses** | An app earns access through a scoped, expiring, revocable token. It never owns what it touches. |
+| **Apps are just frontends** | An app earns access through a scoped, expiring, revocable token. It never owns what it touches. |
 | **Federated identity** | Identity is `(username, provider)`, like email. No central registry to petition, no account that can be taken from you. |
 | **Private, not permanent** | Unlike a blockchain, your data can be private, temporary, and deletable. E2E encryption (phone-as-keychain) is in progress — we don't claim what isn't built. |
 | **Self-hostable** | One `docker compose up` runs a node on hardware you own. The escape hatch is real, and that is what makes the ownership real. |
@@ -84,7 +84,7 @@ at the box and the certificates provision themselves. See
 | `api/rtc/` | WebRTC signaling server. |
 | `ui/` | React admin/consent UI (signup, login, contracts, settings). |
 | `sdk/` | `wapi.js`, the frontend library web10 apps are built with. |
-| `marketing/web10-social/` | The killer app: all-in-one social lens (feed, profiles, DMs, media). CRM and Mail live here as sub-apps. |
+| `marketing/web10-social/` | The killer app: all-in-one social app (feed, profiles, DMs, media). CRM and Mail live here as sub-apps. |
 | `marketing/marketing-ui/` | web10 Inc.'s site: landing page, docs, App Store, Exporter UI. |
 | `marketing/marketing-api/` | Backend for the marketing site: ZIP import pipeline (bring your Instagram/Facebook/YouTube data), analytics. |
 | `marketing/web10-cli/` | CLI tool for web10. |
@@ -94,7 +94,7 @@ at the box and the certificates provision themselves. See
 ## Learn more
 
 - **[`plan.txt`](plan.txt)** — the roadmap and the why.
-- **[`GLOSSARY.md`](GLOSSARY.md)** — the vocabulary (node, provider, service, lens, token…).
+- **[`GLOSSARY.md`](GLOSSARY.md)** — the vocabulary (node, provider, service, record, token…).
 - **[`decisions.md`](decisions.md)** — why the big calls were made.
 - **[`manifesto.md`](manifesto.md)** — the fan-facing pitch that ships on every node.
 - **Developer docs** — protocol spec, conventions, schemas: `marketing/marketing-ui/public/docs/`.

--- a/README.md
+++ b/README.md
@@ -2,33 +2,39 @@
 
 <img src="ui/public/logo512.png" alt="web10 logo" height="75" />
 
-web10 is a system for users to **own their data** on the internet.
+web10 starts from one premise: **what you make is yours.**
 
 Every user gets their own database collection. Every record is
-`{service, body}`. Apps are stateless frontends — *lenses* — that hold a
-scoped, expiring token and talk to the user's collection over a tiny CRUD
-API. The data outlives any app.
+`{service, body}`. Apps are stateless frontends — *lenses* — that borrow
+access through a scoped, expiring token, do their work, and step aside.
+The data outlives any app, because the data was never the app's to keep.
 
-The product built on top of it is a **platform for creators**: run your own
-node, own your audience, and reach 100% of your followers by architecture —
-posts are delivered to every follower's inbox (fan-out on write), so there is
-no algorithm to throttle you and no shadow ban to fear. It's not a policy
-promise; it's how the system is built.
+On that protocol stands the product: **a platform for creators who refuse
+to rent their own audience.** Today a creator with a million subscribers
+reaches three hundred thousand — not by accident, but by design. The
+platform withholds your reach so it can sell it back to you. web10 removes
+the landlord. On your own node, a post reaches 100% of your followers,
+delivered to each one's inbox the moment you publish. There is no algorithm
+to please, no throttle to buy your way past, no shadow ban to fear. This
+is not a promise written in a policy that can be revised. It is the
+architecture, and architecture cannot be quietly revoked.
 
-**Think: WordPress for social media.** Open, self-hostable nodes; creators
-run them and monetize; user accounts are free; web10 takes a small % of
-revenue through its payment rails.
+The model is WordPress, applied to social media: open, self-hostable
+nodes. Creators run them, under their own name and their own domain, and
+keep what they earn. Accounts are free for their audience. web10 takes a
+small percentage of the revenue that moves through its payment rails —
+paid for value delivered, not for permission granted.
 
-## Why it's different
+## The premise, made concrete
 
 | | |
 | --- | --- |
-| **You own your data** | One collection per user. Export it, delete it, take it to another node. Delete means delete. |
-| **No shadow ban** | The inbox pattern delivers every post to every follower. Chronological feed, no ranking algorithm. |
-| **Apps are lenses** | Any app can read/write your data — with your permission, under a scoped, expiring, revocable token. |
-| **Federated identity** | Identity is `(username, provider)`, like email. Nodes verify each other's tokens. |
-| **Private, not permanent** | Unlike blockchain: your data can be private, temporary, and deletable. E2E encryption (phone-as-keychain) is in progress. |
-| **Self-hostable** | One `docker compose up` runs a whole node on your own hardware or any cloud. |
+| **You own your data** | One collection per user — the record of your own life, held by you. Export it, move it, erase it. Delete means delete. |
+| **No shadow ban** | Every post reaches every follower, by construction (fan-out on write). The feed is chronological, because a feed should report — not editorialize. |
+| **Apps are lenses** | An app earns access through a scoped, expiring, revocable token. It never owns what it touches. |
+| **Federated identity** | Identity is `(username, provider)`, like email. No central registry to petition, no account that can be taken from you. |
+| **Private, not permanent** | Unlike a blockchain, your data can be private, temporary, and deletable. E2E encryption (phone-as-keychain) is in progress — we don't claim what isn't built. |
+| **Self-hostable** | One `docker compose up` runs a node on hardware you own. The escape hatch is real, and that is what makes the ownership real. |
 
 ## Run a node locally
 
@@ -40,11 +46,11 @@ cd web10
 docker compose up --build
 ```
 
-Then open **http://auth.localhost** to sign up on your local node.
+Then open **http://auth.localhost** and sign up on your own node.
 
-That's it — no config files to copy. Settings are environment variables
-(see `api/app/settings.py` for the full list and defaults). The compose
-stack includes:
+No config archaeology — settings are environment variables, with working
+defaults (see `api/app/settings.py` for the full list). The compose stack
+includes:
 
 - **api** — the node itself: data, auth, billing, media (`api.localhost`)
 - **ui** — signup/login, consent, contracts, admin (`auth.localhost`)
@@ -67,7 +73,7 @@ something else owns port 80 on your machine, set `WEB10_HTTP_PORT`.
 
 `ubuntu-deployment/` has a one-shot deploy script for a fresh Ubuntu VM:
 Docker, Caddy with automatic TLS, and the full node stack. Point your DNS
-at the box and certs provision themselves. See
+at the box and the certificates provision themselves. See
 [`ubuntu-deployment/README.md`](ubuntu-deployment/README.md).
 
 ## What's in this repo
@@ -99,4 +105,6 @@ at the box and certs provision themselves. See
 - Discord: https://discord.gg/Dbd4VEDznU
 - Live node: https://web10.app
 
-Have fun with web10, use it responsibly, and please give the repo a star.
+web10 is built for people whose work carries their name. If the idea
+earns your respect, star the repo. Better — run a node, and build
+something you'd sign.

--- a/README.md
+++ b/README.md
@@ -1,191 +1,102 @@
-# Introducing web10
+# web10
 
+<img src="ui/public/logo512.png" alt="web10 logo" height="75" />
 
+web10 is a system for users to **own their data** on the internet.
 
+Every user gets their own database collection. Every record is
+`{service, body}`. Apps are stateless frontends — *lenses* — that hold a
+scoped, expiring token and talk to the user's collection over a tiny CRUD
+API. The data outlives any app.
 
+The product built on top of it is a **platform for creators**: run your own
+node, own your audience, and reach 100% of your followers by architecture —
+posts are delivered to every follower's inbox (fan-out on write), so there is
+no algorithm to throttle you and no shadow ban to fear. It's not a policy
+promise; it's how the system is built.
 
-<img src="auth\public\logo_blue.jpg" alt="logo_black" style="height:75px;" />
+**Think: WordPress for social media.** Open, self-hostable nodes; creators
+run them and monetize; user accounts are free; web10 takes a small % of
+revenue through its payment rails.
 
+## Why it's different
 
+| | |
+| --- | --- |
+| **You own your data** | One collection per user. Export it, delete it, take it to another node. Delete means delete. |
+| **No shadow ban** | The inbox pattern delivers every post to every follower. Chronological feed, no ranking algorithm. |
+| **Apps are lenses** | Any app can read/write your data — with your permission, under a scoped, expiring, revocable token. |
+| **Federated identity** | Identity is `(username, provider)`, like email. Nodes verify each other's tokens. |
+| **Private, not permanent** | Unlike blockchain: your data can be private, temporary, and deletable. E2E encryption (phone-as-keychain) is in progress. |
+| **Self-hostable** | One `docker compose up` runs a whole node on your own hardware or any cloud. |
 
-web10 is a system for users to **own their data** on the internet. 
+## Run a node locally
 
-the **social experiences** of the future
-
-not public and permanent like blockchain, allows for **private and temporary**
-
-**demonopolizes the internet**, breaks it up into modules.
-
-bring your data with you **across apps**
-
-web10 provides **free** databases for developers [users pay for plans]
-
-**make money** as a web10 developer or web10 provider
-
-
-
-## Live Demo
-
-**Try a web10 app [contact manager]** : https://crm.web10.app
-
-The web10 inc. web10 node : https://web10.app 
-
-docs page [for developers] : https://docs.web10.app
-
-
-
-## Community / Resources
-
-web10 discord : https://discord.gg/Dbd4VEDznU
-
-web10 deployment video tutorial : https://www.youtube.com/watch?v=DgiiakMRRyQ
-
-
-
-## web10 deployment and practical use
-
-This guide will : 
-
-1. Explain how to run the web10 system locally
-
-2. Deploy the web10 system seamlessly to Google Cloud + MongoDB Atlas
-
-3. Specify the web10 protocol
-
-   
-
-## running web10 locally
-
-web10 is a system that any person can get running Locally + MongoDB Atlas in 15 minutes. 
-
-#### Cloning the repo
-
-Step 1 : give the web10 repo a star :) [ join the web10 discord too :0 ]
-
-Step 2 : fork the web10 repo
-
-Step 3 : clone your fork of the web10 GitHub repo locally.
-
-#### Set up the API
-
-Step 4 : Make a Mongo DB Atlas account. start a free cluster.
-
-Step 5 : Go to the /api/app directory. Duplicate settings_example.py file in the same location, and rename the duplicate to settings.py
-
-Step 6 : In your settings.py, change the DB_URL to your Mongo DB atlas DB URL
-
-```python
-# change this part in the settings.py file you made to your own DB_URL
-DB_URL = "mongodb+srv://web10:jSol....."
-```
-
-Step 7 : Go to https://seanwasere.com/generate-random-hex/
-
-Step 8 : Change PRIVATE_KEY to the number you generated on the website.
-
-```python
-# change this part in the settings.py file you made to your own PRIVATE_KEY
-PRIVATE_KEY = "8cbec8....."
-```
-
-Step 9 : Set BETA_REQUIRED, PAY_REQUIRED, and VERIFY REQUIRED How you please. If you set them all to "False", you can skip step 10.
-
-```python
-# try setting these all to false. [or however you would like]
-BETA_REQUIRED = False
-VERIFY_REQUIRED = False
-PAY_REQUIRED = False
-```
-
-Step 10 : Optionally, make Stripe and Twilio accounts for verification and payments and fill out the API keys. Optionally, set a beta code.
-
-```python
-BETA_CODE = "web10betacode"
-TWILIO_SERVICE = "VAbce...."
-TWILIO_ACCOUNT_SID = "AC3594...."
-TWILIO_AUTH_TOKEN = "460d....."
-STRIPE_STATUS = "live"
-STRIPE_TEST_KEY = "sk_test_51Khy....."
-STRIPE_TEST_CREDIT_SUB_ID = "price_1Kh...."
-STRIPE_TEST_SPACE_SUB_ID = "price_1Ki...."
-STRIPE_LIVE_KEY = "sk_live_51Khyui......"
-STRIPE_LIVE_CREDIT_SUB_ID = "price_1Kkb....."
-STRIPE_LIVE_SPACE_SUB_ID = "price_1Kkb7....."  
-```
-
-#### Set up the Authentication portal
-
-Step 12 : Go to the /auth/src directory. Duplicate config_example.js file in the same location, and rename the duplicate to config.js
-
-Step 13 : In your config.js, Set BETA_REQUIRED, PAY_REQUIRED, and VERIFY REQUIRED to the same values as you did in step 9 
-
-```javascript
-var config = {
-    DEFAULT_API: "api.localhost",
-    /* change these 3 variables to match step 9 */
-    BETA_REQUIRED: false,
-    VERIFY_REQUIRED: false,
-    PAY_REQUIRED: false,
-}
-
-```
-
-#### Running in Docker
-
-Step 12 : Install docker, in the main directory run 
+Requirements: Docker.
 
 ```bash
-docker-compose up --build
+git clone <your fork of this repo>
+cd web10
+docker compose up --build
 ```
 
-Step 13 : Try running the web10 example application crm.localhost
+Then open **http://auth.localhost** to sign up on your local node.
 
+That's it — no config files to copy. Settings are environment variables
+(see `api/app/settings.py` for the full list and defaults). The compose
+stack includes:
 
+- **api** — the node itself: data, auth, billing, media (`api.localhost`)
+- **ui** — signup/login, consent, contracts, admin (`auth.localhost`)
+- **ferretdb + postgres** — the default open database backend
+  (FerretDB speaks the MongoDB wire protocol on top of DocumentDB/postgres)
+- **minio** — S3-compatible blob storage for media
+- **rtc** — WebRTC signaling (`rtc.localhost`)
+- **sdk** — serves `wapi.js` and demos (`sdk.localhost`)
 
-## hosting your own web10 node
+Prefer real MongoDB? It's a supported backend:
 
-Once successfully running the web10 system successfully locally, you can get web10 running successfully from google cloud.
+```bash
+DB_URL=mongodb://mongo:27017 docker compose --profile mongo up
+```
 
-#### Getting google cloud and your PC initially set up
+Atlas or any external Mongo works the same way — just set `DB_URL`. If
+something else owns port 80 on your machine, set `WEB10_HTTP_PORT`.
 
-Step 1: Install KubeCTL
+## Deploy to a server
 
-Step 2 : Install Skaffold
+`ubuntu-deployment/` has a one-shot deploy script for a fresh Ubuntu VM:
+Docker, Caddy with automatic TLS, and the full node stack. Point your DNS
+at the box and certs provision themselves. See
+[`ubuntu-deployment/README.md`](ubuntu-deployment/README.md).
 
-Step 3 : Log into Google Cloud, Start a Google Cloud Kubernetes Autopilot Instance.
+## What's in this repo
 
-Step 4: Connect Google Cloud Kubernetes Autopilot to your computer's terminal by copy pasting the command from Google Cloud that they supply in the dashboard.
+| directory | what it is |
+| --- | --- |
+| `api/` | FastAPI — the node. All data + auth + billing + media. |
+| `api/rtc/` | WebRTC signaling server. |
+| `ui/` | React admin/consent UI (signup, login, contracts, settings). |
+| `sdk/` | `wapi.js`, the frontend library web10 apps are built with. |
+| `marketing/web10-social/` | The killer app: all-in-one social lens (feed, profiles, DMs, media). CRM and Mail live here as sub-apps. |
+| `marketing/marketing-ui/` | web10 Inc.'s site: landing page, docs, App Store, Exporter UI. |
+| `marketing/marketing-api/` | Backend for the marketing site: ZIP import pipeline (bring your Instagram/Facebook/YouTube data), analytics. |
+| `marketing/web10-cli/` | CLI tool for web10. |
+| `mobile/encryptor/` | Expo app — the seed of the phone-as-keychain (E2E encryption). |
+| `ubuntu-deployment/` | One-shot server deploy (Docker + Caddy + TLS). |
 
-#### Making the skaffold files and running skaffold
+## Learn more
 
-Step 5 : CD into the skaffold/folder
+- **[`plan.txt`](plan.txt)** — the roadmap and the why.
+- **[`GLOSSARY.md`](GLOSSARY.md)** — the vocabulary (node, provider, service, lens, token…).
+- **[`decisions.md`](decisions.md)** — why the big calls were made.
+- **[`manifesto.md`](manifesto.md)** — the fan-facing pitch that ships on every node.
+- **Developer docs** — protocol spec, conventions, schemas: `marketing/marketing-ui/public/docs/`.
+- **[`SECURITY.md`](SECURITY.md)** — how to report vulnerabilities, and the security invariants (I1–I5) that define what a break means.
 
-Step 6 : Make a copy of the run_example called run.
+## Community
 
-Step 7 : Change "pure-phalanx-344719" in the files of the run folder to match your google cloud project ID.
+- Discord: https://discord.gg/Dbd4VEDznU
+- Live node: https://web10.app
 
-Step 8 : Go into the run folder and run the command "skaffold run"
-
-#### Exposing the containers and configuring the skaffold files to the domain names / IP addresses of the containers.
-
-Step 9 : Expose all the docker containers in the Kubernetes dashboard.
-
-Step 10 : change the env vars in the yml files in the run folder to match the domains / IPs of the docker containers.
-
-## enjoy
-
-Have fun with web10, use it responsibly, and please give it a star!
-
-
-
-## What makes web10 cooler than web3 :)
-
-| feature                              | Description                                                  |
-| ------------------------------------ | ------------------------------------------------------------ |
-| Hosting Platform Portability         | It is designed entirely through Docker + Kubernetes + Skaffold deployment mechanisms, meaning it can be ported to any cloud provider with Kubernetes, or deployed on bare metal. |
-| Provider Self Sufficiency            | The web10 host has charging mechanisms to make sure that account holders pay the provider for the bandwidth and storage they use. |
-| Mongo DB Based                       | Web 10 nodes work off of the highly scalable mongo DB framework for Data storage. |
-| WebRTC                               | Web 10 makes it easy to use webRTC, and handles the initial identity verification needed to do webRTC properly. |
-| TBD [Phone as a Keychain encryption] | Encrypt data on web10 providers without those providers being able to access the data, because the keys are locally stored on your phone. |
-| Data interoperability                | Developers can use data from other apps with web10 user permission. |
-| Free for Developers                  | Users / web10 providers bear the cloud costs.                |
+Have fun with web10, use it responsibly, and please give the repo a star.


### PR DESCRIPTION
The README still described the skaffold/GKE era: the deleted `auth/` directory (broken logo path), copying `settings_example.py`, generating private keys on a random website, and a Kubernetes/Skaffold deploy that no longer exists in the repo. This rewrites it around the real quickstart — `docker compose up --build` → `auth.localhost`, env-var settings, FerretDB default backend with the `--profile mongo` alternative — plus the D20 creator-platform framing (100% delivery via the inbox pattern, no shadow ban by architecture, E2E marked in-progress). The repo map now reflects `ui/`, `marketing/*` (web10-social, marketing-ui, marketing-api, web10-cli), `mobile/encryptor`, and `ubuntu-deployment/`, with pointers to plan.txt, GLOSSARY.md, decisions.md, manifesto.md, and SECURITY.md. Dead links dropped rather than carried forward: `crm.web10.app` and the skaffold-era YouTube tutorial. CHANGELOG entry 1.0.54 added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)