### PR TITLE
A6: strip user billing → operator-set quotas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+1.0.55 || 19.07.2026
+A6: D21 strip user billing → operator quotas. Removed user-facing billing
+surface: /manage_space, /manage_credits, /manage_subscriptions endpoints
+(payments.py), /get_plan endpoint (system.py), credit_space/manage_subscription/
+create_checkout_session/create_portal_session functions (stripe.py), PAY_REQUIRED
+and per-plan Stripe price IDs (settings.py). Repurposed credits/space as
+operator-set per-user quotas enforced in crud.py check() — credits = rate/abuse
+throttle, space = storage caps (including imports). Stripe retained only for
+creator economy: dev_pay (Stripe Connect transfer_data + amount_percent),
+business onboarding/login. Updated metering tests to use operator quotas
+directly (no more PAY_REQUIRED gating). GLOSSARY.md updated (Billing → Quotas
+section). 274 api tests green (6 user-billing tests removed).
+
 1.0.54 || 19.07.2026
 README rewritten to match the current stack: dead references removed
 (auth/ dir, settings_example.py copying, skaffold/GKE deploy, hex-key

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -18,7 +18,7 @@ in `api/app/main.py` and `api/app/mongo.py` is the source of truth.
 - **record** — one document, stored as `{service, body}`. `body` is the
   user-facing content; the wrapper is internal.
 - **star record (`*`)** — the special account record in the `services`
-  service. Holds password hash, plan/credits/space, phone, stripe ids.
+  service. Holds password hash, credits/space quotas, phone, stripe ids.
   **Star protection** blocks normal CRUD from reading/writing it.
 - **services record** — a terms/ACL record (its service is `services`).
   Defines who may access a given service and how.
@@ -54,11 +54,16 @@ in `api/app/main.py` and `api/app/mongo.py` is the source of truth.
 - **aggregate (the 5th verb)** — planned: sandboxed MongoDB aggregation so
   devs get real query power without breaking scope (plan.txt phase 6).
 
-## Billing
-- **credits / space** — metered usage limits on the star record. **charge**
-  increments spend per request; **replenish** resets monthly.
-- **dev pay** — Stripe Connect flow letting developers charge users, with
-  web10 taking a percentage cut (`stripe.py`). The seed of the node revenue rail.
+## Quotas (operator-set, not user-facing billing)
+- **credits / space** — operator-set per-user quotas on the star record.
+  Credits = rate/abuse throttle. Space = storage cap (also caps import
+  storage from exporters). **charge** increments spend per request;
+  **replenish** resets monthly. Set by the node operator via policy config
+  (setup/admin panel), not by any user subscription.
+- **dev pay** — Stripe Connect flow for the creator economy: memberships,
+  tips, and marketplace rails. Creators charge their audience; web10 takes
+  a percentage cut (`stripe.py`). Stripe is NOT used for user-facing plans
+  or subscriptions.
 
 ## Vision-era terms (not all built yet — see plan.txt)
 - **lens** — an app is a "lens" over data the user owns. (The **lens

--- a/api/app/endpoints/crud.py
+++ b/api/app/endpoints/crud.py
@@ -7,18 +7,8 @@ from app.models.auth import Token
 import app.settings as settings
 from app.services import documentdb as db
 from app.services.auth import check_admin, decode_token, is_permitted
-from app.services import stripe as pay
 
 router = APIRouter()
-
-
-def subscription_update(user):
-    if settings.PAY_REQUIRED:
-        credit, space = pay.credit_space(mget_customer_id(user))
-    else:
-        credit, space = 100000000, 100000000
-    db.subscription_update(user, credit, space)
-    return credit, space
 
 
 def check(user):
@@ -26,29 +16,13 @@ def check(user):
     if settings.VERIFY_REQUIRED and not star["verified"]:
         raise exceptions.VERIFY
     if star["last_replenish"].month != datetime.now().month:
-        subscription_update(user)
+        db.subscription_update(user, settings.FREE_CREDITS, settings.FREE_SPACE)
         db.replenish(user)
-    if settings.PAY_REQUIRED and star["credit_limit"] < star["credits_spent"]:
+    if star["credit_limit"] < star["credits_spent"]:
         raise exceptions.TIME
-    if settings.PAY_REQUIRED and star["space_limit"] < db.get_collection_size(user):
+    if star["space_limit"] < db.get_collection_size(user):
         raise exceptions.SPACE
     return True
-
-
-def mget_customer_id(username):
-    customer_id = db.get_customer_id(username)
-    if not customer_id:
-        customer_id = pay.make_customer()
-        db.set_customer_id(username, customer_id)
-    return customer_id
-
-
-def mget_business_id(username):
-    business_id = db.get_business_id(username)
-    if not business_id:
-        business_id = pay.make_business()
-        db.set_business_id(username, business_id)
-    return business_id
 
 
 @router.post("/{user}/{service}", tags=["web10"])
@@ -78,7 +52,6 @@ async def read_records(user: str, service: str, token: Token, b_t: BackgroundTas
 
 @router.post("/{user}/{service}/aggregate", tags=["web10"])
 async def aggregate_records(user: str, service: str, token: Token, b_t: BackgroundTasks):
-    # read-only by construction; terms treat it as a read.
     if not is_permitted(token, user, service, "read"):
         raise exceptions.CRUD
     check(user)

--- a/api/app/endpoints/payments.py
+++ b/api/app/endpoints/payments.py
@@ -3,10 +3,9 @@ from fastapi import APIRouter
 import app.exceptions as exceptions
 from app.models.auth import Token
 from app.models.payment import PayData
-import app.settings as settings
 from app.services import documentdb as db
 from app.services import stripe as pay
-from app.services.auth import check_admin, certify, decode_token
+from app.services.auth import certify, decode_token
 
 router = APIRouter()
 
@@ -27,32 +26,9 @@ def mget_business_id(username):
     return business_id
 
 
-@router.post("/manage_space", include_in_schema=False)
-async def manage_space(token: Token):
-    check_admin(token)
-    username = decode_token(token.token).username
-    customer_id = mget_customer_id(username)
-    return pay.manage_space(customer_id)
-
-
-@router.post("/manage_credits", include_in_schema=False)
-async def manage_credits(token: Token):
-    check_admin(token)
-    username = decode_token(token.token).username
-    customer_id = mget_customer_id(username)
-    return pay.manage_credits(customer_id)
-
-
-@router.post("/manage_subscriptions", include_in_schema=False)
-async def manage_subscription(token: Token):
-    check_admin(token)
-    decoded = decode_token(token.token)
-    customer_id = mget_customer_id(decoded.username)
-    return pay.create_portal_session(customer_id)
-
-
 @router.post("/manage_business", include_in_schema=False)
 async def manage_business(token: Token):
+    from app.services.auth import check_admin
     check_admin(token)
     username = decode_token(token.token).username
     bus_id = mget_business_id(username)
@@ -61,6 +37,7 @@ async def manage_business(token: Token):
 
 @router.post("/business_login", include_in_schema=False)
 async def business_login(token: Token):
+    from app.services.auth import check_admin
     check_admin(token)
     username = decode_token(token.token).username
     bus_id = mget_business_id(username)

--- a/api/app/endpoints/system.py
+++ b/api/app/endpoints/system.py
@@ -7,8 +7,7 @@ from app.models.auth import Token
 from app.models.config import ConfigUpdate, SetupRequest, SetupStatus
 from app.services import config as config_svc
 from app.services import documentdb as db
-from app.services import stripe as pay
-from app.services.auth import check_admin, decode_token, get_password_hash
+from app.services.auth import check_admin, get_password_hash
 
 router = APIRouter()
 
@@ -128,28 +127,3 @@ async def register_app(info: dict):
         if fragment in info["url"]:
             return
     db.register_app(info)
-
-
-def mget_customer_id(username):
-    customer_id = db.get_customer_id(username)
-    if not customer_id:
-        customer_id = pay.make_customer()
-        db.set_customer_id(username, customer_id)
-    return customer_id
-
-
-def subscription_update(user):
-    if settings.PAY_REQUIRED:
-        credit, space = pay.credit_space(mget_customer_id(user))
-    else:
-        credit, space = 100000000, 100000000
-    db.subscription_update(user, credit, space)
-    return credit, space
-
-
-@router.post("/get_plan", include_in_schema=False)
-async def get_plan(token: Token):
-    check_admin(token)
-    user = decode_token(token.token).username
-    credit, space = subscription_update(user)
-    return {"space": space, "credits": credit, "used_space": db.get_collection_size(user)}

--- a/api/app/services/records.py
+++ b/api/app/services/records.py
@@ -11,10 +11,10 @@ def star_record():
         "phone_number": "PHONE_NUMBER",
         "verified":False,
         "customer_id": None,
-        "business_id":None,
-        "credit_limit": settings.FREE_CREDITS,
-        "space_limit": settings.FREE_SPACE,
-        "credits_spent":0,
+        "business_id": None,
+        "credit_limit": settings.FREE_CREDITS,  # operator-set quota: rate/abuse throttle
+        "space_limit": settings.FREE_SPACE,     # operator-set quota: storage cap (incl. imports)
+        "credits_spent": 0,
         "last_replenish": datetime.datetime(1997,12,28),
     }
 

--- a/api/app/services/stripe.py
+++ b/api/app/services/stripe.py
@@ -5,202 +5,110 @@ import app.settings as settings
 
 if settings.STRIPE_STATUS=="live":
     stripe.api_key = settings.STRIPE_LIVE_KEY
-    CREDIT_SUB_ID = settings.STRIPE_LIVE_CREDIT_SUB_ID
-    SPACE_SUB_ID = settings.STRIPE_LIVE_SPACE_SUB_ID
 else:
     stripe.api_key = settings.STRIPE_TEST_KEY
-    CREDIT_SUB_ID = settings.STRIPE_TEST_CREDIT_SUB_ID
-    SPACE_SUB_ID = settings.STRIPE_TEST_SPACE_SUB_ID
-
-################
-# Prices objects
-################
-subscription = [{
-    "price":CREDIT_SUB_ID,"quantity":1,'adjustable_quantity': {
-        'enabled': True,}
-    },
-    {
-    "price":SPACE_SUB_ID,"quantity":1,"adjustable_quantity": {
-        'enabled': True}
-    }]
-
-############################################
-# customer payment / subscription management
-############################################
-def make_customer():
-    customer = stripe.Customer.create(
-        description="New Customer",
-    )
-    return customer["id"]
-
-def make_business():
-    bus = stripe.Account.create(type="express")
-    return bus["id"]
-
-def get_active_subscriptions(customer_id):
-    customer = stripe.Customer.retrieve(customer_id, expand=['subscriptions'])
-    if "subscriptions" not in customer : return []
-    subscriptions = customer["subscriptions"]
-    return subscriptions
-
-def get_subscription_price_ids(subscriptions):
-    return [sub["items"]["data"][0]["price"]["id"] for sub in subscriptions]
 
 ###############################################
 #### Session URL creation
 ###############################################
 
 def create_business_session(bus_id):
-    print(bus_id)
     bus_session = stripe.AccountLink.create(
     account=bus_id,
     refresh_url="https://auth.web10.app",
     return_url="https://auth.web10.app",
     type="account_onboarding",
-)
-    print(bus_session["url"])
+    )
     return bus_session["url"]
 
 def business_login_session(bus_id):
     return stripe.Account.create_login_link(bus_id)["url"]
 
-def create_checkout_session(customer_id,price_id,item_type="plan"):
-    # for web10 plans
-    if (item_type=="plan"):
-        line_items = [{
-    "price":price_id,"quantity":1,'adjustable_quantity': {
-        'enabled': True,}
-    }]
-
-    # for devPay items
-    else: line_items=[{
-    "price":price_id,"quantity":1}]
-
-    checkout_session = stripe.checkout.Session.create(
-        success_url="https://auth.web10.app",
-        cancel_url="https://auth.web10.app",
-        customer=customer_id,
-        payment_method_types=["card"],
-        mode="subscription",
-        line_items= line_items
-    )
-    return checkout_session["url"]
-
-def create_portal_session(customer_id):
-    session = stripe.billing_portal.Session.create(
-        customer=customer_id,
-    )
-    return session["url"]
-
-##############################
-# button functions
-##############################
-
-# helper function for subscriptions [devPay too]
-def manage_subscription(customer_id,price,item_type="plan"):
-    prices = get_subscription_price_ids(get_active_subscriptions(customer_id))
-    if price in prices:
-        return create_portal_session(customer_id)
-    return create_checkout_session(customer_id,price,item_type)
-
-def manage_space(customer_id):
-    return manage_subscription(customer_id,SPACE_SUB_ID)
-
-def manage_credits(customer_id):
-    return manage_subscription(customer_id,CREDIT_SUB_ID)
-
-##################################
-# payment registration functions
-##################################
-
-# get credits and space in customers plans
-def credit_space(customer_id):
-    subscriptions = get_active_subscriptions(customer_id)
-    prices = get_subscription_price_ids(subscriptions)
-    subscription_data = [s["items"]["data"][0] for s in subscriptions]
-    cidx = -1
-    if CREDIT_SUB_ID in prices:
-        cidx = prices.index(CREDIT_SUB_ID)
-        c = subscription_data[cidx]["quantity"]  + settings.FREE_CREDITS
-    if cidx == -1 : c = settings.FREE_CREDITS
-
-    sidx = -1
-    if SPACE_SUB_ID in prices:
-        sidx = prices.index(SPACE_SUB_ID)
-        s = subscription_data[sidx]["quantity"] * 1024 + settings.FREE_SPACE
-    if sidx == -1 : s = settings.FREE_SPACE
-
-    return c,s
-
 #################################
-### Dev Pay
+### Dev Pay (creator economy)
 #################################
+
+def make_customer():
+    return stripe.Customer.create(description="Customer")["id"]
+
+def make_business():
+    return stripe.Account.create(type="express")["id"]
+
+def get_active_subscriptions(customer_id):
+    customer = stripe.Customer.retrieve(customer_id, expand=['subscriptions'])
+    if "subscriptions" not in customer:
+        return []
+    return customer["subscriptions"]
+
+def get_subscription_price_ids(subscriptions):
+    return [sub["items"]["data"][0]["price"]["id"] for sub in subscriptions]
 
 # create dev pay subscription checkout session
-def create_dev_pay_session(customer_id,bus_id,pay_data):
-
+def create_dev_pay_session(customer_id, bus_id, pay_data):
     success_url = "https://auth.web10.app"
-    if pay_data.success_url is not None :
+    if pay_data.success_url is not None:
         success_url = pay_data.success_url
     cancel_url = "https://auth.web10.app"
-    if pay_data.cancel_url is not None :
+    if pay_data.cancel_url is not None:
         cancel_url = pay_data.cancel_url
 
-    try :
+    try:
         checkout_session = stripe.checkout.Session.create(
             success_url=success_url,
             cancel_url=cancel_url,
             customer=customer_id,
             payment_method_types=["card"],
             mode="subscription",
-            line_items= [{
-                "price_data":{
-                    "currency":"usd",
-                    "unit_amount":pay_data.price,
-                    "recurring":{
-                        "interval":"month",
+            line_items=[{
+                "price_data": {
+                    "currency": "usd",
+                    "unit_amount": pay_data.price,
+                    "recurring": {
+                        "interval": "month",
                     },
-                    "product_data":{
-                        "name":pay_data.title
+                    "product_data": {
+                        "name": pay_data.title,
                     },
                 },
-                "quantity":1,
-                }],
-            subscription_data= {
-                "metadata":{
-                    "title":pay_data.title,
-                    "seller":pay_data.seller,
-                    "price":pay_data.price,
-                    },
-                "transfer_data":{
-                    "destination":bus_id,
-                    "amount_percent":settings.DEV_PAY_PCT
-                }
-            }
+                "quantity": 1,
+            }],
+            subscription_data={
+                "metadata": {
+                    "title": pay_data.title,
+                    "seller": pay_data.seller,
+                    "price": pay_data.price,
+                },
+                "transfer_data": {
+                    "destination": bus_id,
+                    "amount_percent": settings.DEV_PAY_PCT,
+                },
+            },
         )
     except stripe.error.StripeError:
         raise exceptions.BUSINESS_NOT_READY
     return checkout_session["url"]
 
 # gets the metadata json from customers devpay subscription with the title.
-def get_dev_pay_subscription(customer_id,pay_data):
+def get_dev_pay_subscription(customer_id, pay_data):
     subs = get_active_subscriptions(customer_id)
     def f(sub):
-        print(sub)
-        if "title" not in sub["metadata"] or "seller" not in sub["metadata"]: return False
+        if "title" not in sub["metadata"] or "seller" not in sub["metadata"]:
+            return False
         return sub["metadata"]["title"] == pay_data.title and sub["metadata"]["seller"] == pay_data.seller
     subs = list(filter(f, subs))
-    if len(subs) == 0: return None
-    else : return subs[0]
+    if len(subs) == 0:
+        return None
+    return subs[0]
 
-def get_dev_pay_metadata(customer_id,pay_data):
+def get_dev_pay_metadata(customer_id, pay_data):
     sub = get_dev_pay_subscription(customer_id, pay_data)
-    if sub is None: return None
-    else : return sub["metadata"]
+    if sub is None:
+        return None
+    return sub["metadata"]
 
 # cancels the customers devpay subscription of given title
 def cancel_dev_pay_subscription(customer_id, pay_data):
     sub = get_dev_pay_subscription(customer_id, pay_data)
     if sub is None:
         raise exceptions.NO_SUB
-    stripe.Subscription.delete(sub["id"],prorate=True)
+    stripe.Subscription.delete(sub["id"], prorate=True)

--- a/api/app/settings.py
+++ b/api/app/settings.py
@@ -27,7 +27,6 @@ FREE_CREDITS = 0.10
 FREE_SPACE = 8
 BETA_REQUIRED = False
 VERIFY_REQUIRED = False
-PAY_REQUIRED = False
 BETA_CODE = "web10betacode"
 TWILIO_SERVICE = "VAbce...."
 TWILIO_ACCOUNT_SID = "AC3594...."
@@ -35,11 +34,7 @@ TWILIO_AUTH_TOKEN = "460d....."
 TWILIO_NUMBER = "+12764004437"
 STRIPE_STATUS = "live"
 STRIPE_TEST_KEY = "sk_test_51Khy....."
-STRIPE_TEST_CREDIT_SUB_ID = "price_1Kh...."
-STRIPE_TEST_SPACE_SUB_ID = "price_1Ki...."
 STRIPE_LIVE_KEY = "sk_live_51Khyui......"
-STRIPE_LIVE_CREDIT_SUB_ID = "price_1Kkb....."
-STRIPE_LIVE_SPACE_SUB_ID = "price_1Kkb7....."
 DEV_PAY_PCT = 98
 
 # S3-compatible object storage (media service)

--- a/api/tests/test_endpoints.py
+++ b/api/tests/test_endpoints.py
@@ -540,7 +540,7 @@ class TestScopedTokens:
 
 
 # ---------------------------------------------------------------------------
-# 7. METERING / BILLING
+# 7. METERING / QUOTAS
 # ---------------------------------------------------------------------------
 
 class TestMetering:
@@ -594,11 +594,8 @@ class TestMetering:
              patch("app.services.documentdb.read", return_value=[{"_id": "1"}]), \
              patch("app.services.documentdb.charge"), \
              patch("app.services.documentdb.subscription_update"), \
-             patch("app.endpoints.crud.pay") as m_pay, \
              patch("app.endpoints.crud.settings") as m_settings:
-            m_settings.PAY_REQUIRED = True
             m_settings.VERIFY_REQUIRED = False
-            m_pay.credit_space.return_value = (0, 1000000)
             m_star.return_value = {**MOCK_STAR, "credit_limit": 0, "credits_spent": 1}
             resp = client.patch(
                 "/alice/posts",
@@ -613,11 +610,8 @@ class TestMetering:
              patch("app.services.documentdb.read", return_value=[{"_id": "1"}]), \
              patch("app.services.documentdb.charge"), \
              patch("app.services.documentdb.subscription_update"), \
-             patch("app.endpoints.crud.pay") as m_pay, \
              patch("app.endpoints.crud.settings") as m_settings:
-            m_settings.PAY_REQUIRED = True
             m_settings.VERIFY_REQUIRED = False
-            m_pay.credit_space.return_value = (1000000, 1)
             m_star.return_value = {**MOCK_STAR, "space_limit": 1}
             resp = client.patch(
                 "/alice/posts",
@@ -685,16 +679,3 @@ class TestSystem:
         assert "apps" in data
         assert "users" in data
         assert "storage" in data
-
-    def test_get_plan(self, client):
-        with patch("app.services.documentdb.get_star", return_value=MOCK_STAR), \
-             patch("app.services.documentdb.get_collection_size", return_value=1), \
-             patch("app.services.documentdb.subscription_update"), \
-             patch("app.services.documentdb.get_customer_id", return_value=None):
-            resp = client.post(
-                "/get_plan",
-                json={"token": _owner_token("alice")},
-            )
-        assert resp.status_code == 200
-        assert "space" in resp.json()
-        assert "credits" in resp.json()

--- a/api/tests/test_stripe.py
+++ b/api/tests/test_stripe.py
@@ -1,4 +1,4 @@
-"""Tests for stripe pure logic (credit_space, get_subscription_price_ids, dev_pay helpers)."""
+"""Tests for stripe pure logic (dev_pay helpers only — user billing stripped per D21)."""
 
 from unittest.mock import patch
 
@@ -20,45 +20,6 @@ class TestGetSubscriptionPriceIds:
         ]
         result = stripe.get_subscription_price_ids(subs)
         assert result == ["price_1", "price_2"]
-
-
-class TestCreditSpace:
-
-    def test_no_subscriptions_returns_free(self):
-        with patch.object(stripe, "get_active_subscriptions", return_value=[]):
-            c, s = stripe.credit_space("cus_123")
-            assert c == stripe.settings.FREE_CREDITS
-            assert s == stripe.settings.FREE_SPACE
-
-    def test_with_credit_subscription(self):
-        mock_subs = [
-            {
-                "items": {
-                    "data": [
-                        {"price": {"id": stripe.CREDIT_SUB_ID}, "quantity": 5}
-                    ]
-                }
-            }
-        ]
-        with patch.object(stripe, "get_active_subscriptions", return_value=mock_subs):
-            c, s = stripe.credit_space("cus_123")
-            assert c == 5 + stripe.settings.FREE_CREDITS
-            assert s == stripe.settings.FREE_SPACE
-
-    def test_with_space_subscription(self):
-        mock_subs = [
-            {
-                "items": {
-                    "data": [
-                        {"price": {"id": stripe.SPACE_SUB_ID}, "quantity": 2}
-                    ]
-                }
-            }
-        ]
-        with patch.object(stripe, "get_active_subscriptions", return_value=mock_subs):
-            c, s = stripe.credit_space("cus_123")
-            assert c == stripe.settings.FREE_CREDITS
-            assert s == 2 * 1024 + stripe.settings.FREE_SPACE
 
 
 class TestGetDevPaySubscription:
@@ -119,29 +80,3 @@ class TestGetDevPayMetadata:
         with patch.object(stripe, "get_dev_pay_subscription", return_value=None):
             result = stripe.get_dev_pay_metadata("cus_123", pay_data)
             assert result is None
-
-
-class TestManageSubscription:
-
-    def test_existing_subscription_returns_portal(self):
-        mock_subs = [
-            {
-                "items": {
-                    "data": [
-                        {"price": {"id": stripe.CREDIT_SUB_ID}}
-                    ]
-                }
-            }
-        ]
-        with patch.object(stripe, "get_active_subscriptions", return_value=mock_subs):
-            with patch.object(stripe, "create_portal_session", return_value="https://portal.url") as mock_portal:
-                result = stripe.manage_subscription("cus_123", stripe.CREDIT_SUB_ID)
-                assert result == "https://portal.url"
-                mock_portal.assert_called_once_with("cus_123")
-
-    def test_new_subscription_returns_checkout(self):
-        with patch.object(stripe, "get_active_subscriptions", return_value=[]):
-            with patch.object(stripe, "create_checkout_session", return_value="https://checkout.url") as mock_checkout:
-                result = stripe.manage_subscription("cus_123", stripe.CREDIT_SUB_ID)
-                assert result == "https://checkout.url"
-                mock_checkout.assert_called_once()

--- a/parallel execution.txt
+++ b/parallel execution.txt
@@ -88,7 +88,7 @@ LANE A — api / backend        (owns: api/**, docker-compose, settings)
   [✓ 1.0.38] A4. P6 aggregate endpoint (the 5th verb, sandbox validator;
       per-stage metering through charge(); wapi.aggregate in legacy sdk)
   [ ] A5. P4 metering events (per-request event records for analytics)
-  [ ] A6. D21 strip user billing → quotas: remove user-facing
+  [✓ 1.0.55] A6. D21 strip user billing → quotas: remove user-facing
       plans/subscriptions/per-account stripe; repurpose credits/
       space + charge() as OPERATOR-SET per-user quotas (credits =
       rate/abuse throttle, space = storage caps incl. imports).


### PR DESCRIPTION
Removes the user-facing billing surface: /manage_space, /manage_credits, /manage_subscriptions endpoints, /get_plan, credit_space/manage_subscription/checkout/portal functions, PAY_REQUIRED, and per-plan Stripe price IDs.

Repurposes credits/space as operator-set per-user quotas enforced in crud.py check() — credits = rate/abuse throttle, space = storage caps (including imports). Stripe retained only for the creator economy (dev pay via Stripe Connect, business onboarding).

Updated metering tests to use operator quotas directly, GLOSSARY.md (Billing → Quotas section). 274 api tests green.