### PR TITLE
1.0.61: design.md — binding UI/brand standard + B5/D12/D13 beautification lanes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,17 @@ Now read `CLAUDE.md`. Despite the name it is the orientation file for
 ALL agents working on this repo — architecture, security invariants,
 and working conventions. Everything there applies to you.
 
+## Before starting ANY UI task: read design.md
+
+If your task touches anything a user sees — `ui/`,
+`marketing/marketing-ui/`, `marketing/web10-social/`, any screen or
+component — read `design.md` BEFORE writing code, every time. It is
+the binding standard: the quality bar (the screenshot test), the
+canonical brand assets (the files named `logo*.png` are NOT the
+logos — §3 names the real ones), the shared design tokens (§13), and
+the UI definition of done (§12: PR screenshots at desktop + 375px
+mobile, tokens-only colors, all states designed).
+
 ## Before starting ANY task: check it isn't already done
 
 Task completion state lives in three places. Check all three before

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+1.0.61 || 19.07.2026
+design.md: the binding UI/brand standard for all user-facing surfaces —
+brand essence (keys mark, dark-first, restrained voice), canonical asset
+inventory (logo_white.png lockup + alternative.png square mark ARE the
+logos; logo512/192.png are the React atom, hub.png is Apple's App Store
+glyph — purge list + asset debt queued), full token spec (zinc + violet
+#8b5cf6, Tailwind v4 @theme block in §13), type (self-hosted Inter /
+Space Grotesk / JetBrains Mono — never Google CDN), spacing/radius/
+elevation/motion rules, component + responsive standards, a11y, and the
+UI definition of done (§12: screenshot test, PR screenshots at desktop +
+375px, tokens-only colors). CLAUDE.md + AGENTS.md now gate every UI task
+on reading design.md first. New parallel beautification items queued:
+B5 (ui/ level-up), D12 (web10-social level-up), D13 (marketing-ui
+rebuild, Bulma out — per D22/D23) in plan.txt phase 2.5 + lane queues;
+conductor board refreshed (ws4 = execute E1 staging deploy, blocked on
+SSH + Cloudflare creds). decisions.md D23 records the design-language
+call.
+
 1.0.60 || 19.07.2026
 E1: staging node deployment infrastructure — Portainer + Nginx Proxy
 Manager approach. ubuntu-deploy.sh replaced by prep-vm.sh (installs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+1.0.62 || 19.07.2026
+environments + ops + e2e depth. plan.txt CROSS-CUTTING deployment now
+specs TWO full-ecosystem environments on the ubuntu-deployment box:
+PROD (public: marketing-ui + marketing-api + node incl. social, CF DNS
+→ forwarded 80/443 → NPM TLS) and DEV (same stack, VPN-only: cloudflare
+DNS pointing at the INTERNAL LAN ip — resolves publicly, unreachable
+off-VPN, no dev port-forwards, TLS via DNS-01) with a documented
+dev→prod promotion flow; lane items E3 (prod) recast + E5 (dev) added.
+New C6 (lane C): e2e deep sweep + bug hunt — expand C5's playwright
+harness across money paths and lane seams, signup-as-a-test (fresh
+accounts every run) + persona seed fixtures (creator, fans, granted/
+revoked terms) that also power dev-env wipe+reseed; deliverable = the
+enlarged suite AND the honest bug list. Staging went LIVE and was
+triaged remotely: api healthy at staging.web10.app, auth UI broken by
+hardcoded origins (authAdapter.ts/config.ts bake api.web10.app into
+prod builds — env-parameterization fix queued into B5, urgent),
+rtc/minio DNS records missing, marketing/social not in the stack.
+New ubuntu-deployment/AGENT-OPS.md: field manual for (weaker) ops
+agents — SSH-in procedure off the gitignored .env, box map, ordered
+diagnosis sequence with symptom table, KNOWN ISSUES from the live
+triage, redeploy + CF DNS procedures, may/may-not boundaries — plus
+OPS-LOG.md, an append-only coordination ledger seeded with the triage;
+README.md points agents at both. Conductor board: ws4 = staging
+triage + E5/E3, ws5 = C6.
+
 1.0.61 || 19.07.2026
 design.md: the binding UI/brand standard for all user-facing surfaces —
 brand essence (keys mark, dark-first, restrained voice), canonical asset

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,8 @@
 Read this first. Then read `plan.txt` (what/why) and `parallel execution.txt`
 (how work splits across parallel branches). `GLOSSARY.md` decodes the jargon;
 `decisions.md` records why big calls were made so you don't re-litigate them.
+If your task touches ANY user-facing surface, also read `design.md` — the
+UI/brand standard — before writing code (see conventions below).
 
 ## What web10 is
 A system for users to **own their data**. Each user gets their own database
@@ -74,6 +76,13 @@ touches auth, the DB layer, or tokens, run those tests and keep them green.
       revocable token. Least privilege.
 
 ## Working conventions for parallel agents
+- **UI work reads `design.md` first — every time, no exceptions.** Any
+  change under `ui/`, `marketing/marketing-ui/`, or `marketing/web10-social/`
+  (or any new user-facing surface) is judged against `design.md`: the
+  quality bar (the screenshot test), the canonical brand assets (the files
+  named `logo*.png` are NOT the logos — design.md §3 names the real ones),
+  the shared tokens (§13), and the UI definition of done (§12, PR
+  screenshots included). Hardcoded colors/fonts are a review rejection.
 - **Check it isn't already done.** Before starting a plan/lane item, check
   the lane queues in `parallel execution.txt` (`[✓ x.y.z]` = merged,
   `[~]` = in flight elsewhere), the `[✓]` ticks in plan.txt, and the top

--- a/decisions.md
+++ b/decisions.md
@@ -9,6 +9,30 @@ Status legend: [decided] intent set · [in-progress] · [open] still debating.
 
 ---
 
+### D23 — One design language, dark-first violet, design.md is the law [decided]
+The three frontends had drifted into three styling worlds (ui/: light-first
+blue Tailwind + inline styles; web10-social: dark shadcn violet; marketing-ui:
+Bulma with hardcoded hex), the "shared tokens" existed only as a comment, and
+the repo shipped boilerplate as brand — the React atom as logo512.png and
+Apple's App Store glyph as hub.png (a trademark problem, not a taste problem).
+Decision: a single binding standard, `design.md` at the repo root, that every
+agent must read before touching any user-facing surface (gated in CLAUDE.md +
+AGENTS.md). Its calls: dark-first everywhere (the only real logos are
+white-on-transparent; the creator world — Kick/Twitch/OBS/Discord — lives
+dark; D20's bar is Kick/Twitch-grade slick); brand accent is the violet
+already in web10-social (#8b5cf6 on zinc #09090b); canonical marks are the
+keys lockup (`marketing-ui/.../logo_white.png`) and square keys mark
+(`web10-social/public/alternative.png`) — files named `logo*.png` are NOT
+logos and get purged; type is self-hosted Inter (UI) + Space Grotesk
+(display) + JetBrains Mono (code), never Google-CDN'd; tokens are one
+Tailwind v4 @theme block (design.md §13) copied verbatim per app; marketing-ui
+migrates off Bulma entirely (already rejected in D22); quality is enforced by
+the screenshot test + PR screenshots (desktop + 375px) in design.md §12.
+Rejects: per-app palettes, light-first defaults, a shared npm package for
+tokens (premature — verbatim copies with a sync header), FontAwesome (CDN
+kit = privacy leak; Lucide only), and treating brand assets as "just images"
+— shipping someone else's trademark is a legal bug.
+
 ### D22 — UI stack: Tailwind CSS + shadcn/ui, replacing rectangles-npm [decided]
 rectangles-npm is a homemade layout framework only one person understands;
 uis built on it read as engineering prototypes, not products. The replacement

--- a/design.md
+++ b/design.md
@@ -1,0 +1,449 @@
+# design.md — the web10 design standard
+
+**If your change touches anything a user sees — `ui/`,
+`marketing/marketing-ui/`, `marketing/web10-social/`, any screen, any
+component, any color — you read this file first, every time, before
+writing code.** CLAUDE.md and AGENTS.md point here; PRs that touch UI
+are judged against this document. It is the law for how web10 looks,
+the same way plan.txt is the law for what gets built.
+
+Why it exists: three frontends grew three independent styling worlds
+(Tailwind-with-CSS-vars in `ui/`, shadcn-dark in `web10-social`, Bulma
+in `marketing-ui`), the "shared" token file was shared only in a
+comment, and the repo shipped the React atom and Apple's App Store
+glyph as its own logos. This file ends that. One brand, one token set,
+one quality bar.
+
+
+## 1. The bar
+
+D20 set it: **Kick/Twitch-grade slick, never fediverse jank.** The
+pitch to creators is "your node is an upgrade to your brand — the cool
+thing your audience brags about being early to." If a screen looks
+like a protest app, an engineering tool, or a Mastodon instance, the
+pitch dies on the first screenshot.
+
+The operational test for every screen, before it merges:
+
+> **The screenshot test.** Put a screenshot of this screen in a slide
+> deck between a Kick screenshot and a Twitch screenshot, in front of
+> a creator, their manager, and an a16z partner. Does it hold, or does
+> someone wince?
+
+That test is not rhetorical. The M0 deliverable is a pitch deck and a
+demo video; every M0-facing screen literally will be in that deck.
+A screen that can't appear in the pitch isn't done (plan.txt phase 2.5,
+final unticked item).
+
+What "slick" means in practice — the difference between a prototype
+and a product is never one big thing, it's the accumulation of small
+disciplines:
+
+- Every interactive element has ALL its states designed: default,
+  hover, focus-visible, active, disabled, loading. No browser-default
+  anything — no default-blue links, no default focus outlines, no
+  default form controls on showcase surfaces.
+- Every async surface has a designed loading state (skeletons, not
+  spinners), a designed error state, and a designed empty state.
+  Empty states are story beats, not gray voids — a fresh feed points
+  at the importer ("import your life"), an empty studio points at the
+  first monetization card.
+- Nothing shifts. Reserve space for images and async content; no
+  layout jump on load, ever.
+- Alignment is exact. Everything sits on the 4px grid (§6). "One
+  pixel off" is the texture of jank; a16z-pretty is mostly the
+  absence of one-pixel-offs.
+- No dead or placeholder anything: no lorem, no broken image icons,
+  no `fa fa-*` classes whose font never loads, no clipart.
+
+
+## 2. Brand essence
+
+The mark is **keys on a keyring**. That is not decoration — it is the
+entire thesis in one image: *you hold the keys to your own data.*
+Every visual choice should reinforce ownership, permanence, and
+self-possession. The brand is confident and quiet; it never begs.
+
+- **Dark-first.** The brand's native habitat is dark. The only logo
+  assets that exist are white-on-transparent; creator/streaming
+  culture (Kick, Twitch, OBS, Discord) lives in dark mode; and dark
+  is where the violet accent reads as electric instead of corporate.
+  Dark is the default on every surface. Light mode is a later opt-in
+  built from tokens, never a hardcode.
+- **Voice.** Declarative, restrained, no gush. The fan-facing voice
+  lives in `manifesto.md`, the creator pitch in `outreach.md` — match
+  them. Never claim what isn't built. Headlines state facts:
+  "Own your audience." beats "Unlock the future of social!!"
+- **Never fake it.** No stock photos of smiling people, no invented
+  testimonials, no logos of companies that don't use us. Real
+  screenshots, real numbers, real mechanics (the reach-gap chart is
+  more persuasive than any adjective).
+
+
+## 3. Brand assets — what the logos ARE and are NOT
+
+This is the canonical inventory. The files named like logos are mostly
+not the logos; the real marks have specific names. Get this right —
+a wrong logo is worse than no logo.
+
+### Canonical marks (the real ones)
+
+| Asset | File (today) | What it is | Use |
+|---|---|---|---|
+| **Full lockup** | `marketing/marketing-ui/public/layouts/images/logo_white.png` (1200×400) | Keys-on-keyring mark + lowercase thin-outline "web10" wordmark, white on transparent | Navbars, footers, hero, og-image. Dark backgrounds ONLY (it is white). Min height 24px; keep clear space ≥ the height of the "w" on all sides. |
+| **Square mark** | `marketing/web10-social/public/alternative.png` (842×854) | The keys mark alone, white on transparent | Avatars, favicons, PWA icons, app-store tiles, anywhere square. Dark backgrounds only. Also the default profile picture in web10-social. |
+
+Rules of use:
+- Never stretch, recolor, outline, shadow, or rotate the marks.
+- Never place the white marks on light backgrounds — if a light
+  surface needs a logo, that surface should probably be dark, or use
+  the (to-be-generated) dark variant below.
+- Never typeset "web10" in a way that imitates the wordmark. In
+  running text it is plain lowercase `web10` in the current font. If
+  a heading needs the brand set as type, use the display font (§5) in
+  lowercase — it will rhyme with the wordmark without counterfeiting it.
+
+### Boilerplate and squatters (NOT logos — purge on sight)
+
+| File | What it actually is | Action |
+|---|---|---|
+| `ui/public/logo512.png`, `logo192.png`, `marketing/web10-social/public/logo512.png`, `logo192.png` | **The React atom.** Create-react-app boilerplate. | Replace with exports of the square keys mark at 192/512. |
+| `ui/public/hub.png`, `ui/public/hub.jpg` | **Apple's App Store logo.** A trademark we have no right to ship, referenced as `apple-touch-icon` in `ui/index.html`. | Replace immediately with the keys mark. This is a legal fix, not an aesthetic one. |
+| `ui/public/home.png` | Clipart house. | Delete; use a Lucide icon. |
+| `*/public/favicon.ico` | Unverified boilerplate. | Regenerate all three from the square keys mark. |
+| `marketing/marketing-ui/public/layouts/images/*` (berk, cmu, mit, stan, gonzaga, thumbnail, back*.jpg, sky, mountains…) | The "web10 for education" era — old pitch, old fonts, old navy palette, university logos. | The marketing rebuild (§10) decides per file; default is delete. University logos are other people's trademarks — same rule as hub.png. |
+| `ui/public/YourOrgsLogo/*` (key_white/black, generic_school_logo) | Feature fixtures — placeholder art for a provider's own branding slot. Not web10 brand assets. | Keep, but they are white-label placeholders; label them as such where shown. |
+
+### Asset debt (queued work, lane D unless noted)
+
+The brand currently exists ONLY as two white PNGs. Generate, from the
+existing files (do not invent a new mark):
+
+1. **SVG vectorization** of both marks (trace or rebuild) — PNGs don't
+   scale to hero sizes cleanly.
+2. **Dark-on-light variants** (black/zinc-950 fills) for the rare
+   light surface and for print/docs.
+3. **Icon set**: favicon.ico + 192/512 PNG + apple-touch-icon per app,
+   all from the square mark on `#09090b`, replacing every squatter above.
+4. **One shared og-image** (1200×630): full lockup on `#09090b` with
+   the violet glow treatment (§4), used by all three apps.
+
+
+## 4. Color
+
+One palette, defined once, consumed as tokens everywhere. Dark-first:
+these are the `:root` values. Hardcoded hex in a component is a review
+rejection — if a color isn't a token, it doesn't exist.
+
+### Neutrals (zinc — cool, never brown, never pure black)
+
+| Token | Value | Role |
+|---|---|---|
+| `--color-background` | `#09090b` | Page background. Never `#000` — pure black is harsh and crushes the violet. |
+| `--color-surface` / `--color-card` | `#111113` | Cards, panels, one step up. |
+| `--color-elevated` / `--color-muted` | `#18181b` | Hover fills, popovers, inputs-at-rest, second step up. |
+| `--color-border` / `--color-input` | `#27272a` | 1px borders. Elevation in dark UI is borders + background steps, not shadows (§6). |
+| `--color-muted-foreground` | `#a1a1aa` | Secondary text. ~7.4:1 on background — safe for body copy. |
+| `--color-foreground` | `#fafafa` | Primary text. Never `#fff`. |
+
+### Brand (violet — the electric thread)
+
+| Token | Value | Role |
+|---|---|---|
+| `--color-brand-300` | `#c4b5fd` | Brand-tinted TEXT on dark (links, highlighted copy). Body-text safe. |
+| `--color-brand-400` | `#a78bfa` | Hover text, icons, chart accent. |
+| `--color-brand` | `#8b5cf6` | THE brand color. Primary buttons, active nav, focus rings, the glow. 4.5:1 on background — fine for fills, large text, and UI, not for small body text (use 300). |
+| `--color-brand-600` | `#7c3aed` | Pressed/active states of brand fills. |
+| `--color-brand-muted` | `#2e1065` | Brand-tinted backgrounds: active-nav pill fills, selected rows, badge backgrounds. |
+
+Usage discipline: violet is an accent, not wallpaper. One primary CTA
+per view. Active states, focus rings, key stats, the occasional glow
+(a soft `brand` blur behind a hero mark or CTA — the ONE permitted
+decorative flourish, used at most once per screen). If a screen is
+more than ~10% violet, pull back.
+
+### Semantic
+
+| Token | Value |
+|---|---|
+| `--color-success` | `#22c55e` |
+| `--color-warning` | `#f59e0b` |
+| `--color-danger` / `--color-destructive` | `#ef4444` |
+| `--color-danger-muted` | `#450a0a` (danger-tinted background) |
+
+Semantic colors mean things; never use them decoratively. Money/
+monetization surfaces (the Studio) use `success` green for revenue
+numbers ONLY — everything else in the Studio stays neutral + brand.
+
+### Contrast rules (non-negotiable)
+
+- Body text: ≥ 4.5:1 (AA). `foreground` and `muted-foreground` on any
+  neutral surface pass; `brand-300` passes; `brand` (500) does NOT —
+  it is for fills, rings, icons, and large display text only.
+- UI components & large text: ≥ 3:1.
+- Never light-gray-on-slightly-less-light-gray. If you're reaching for
+  a fourth gray, the hierarchy is wrong, not the palette.
+
+
+## 5. Typography
+
+Three families, self-hosted via `@fontsource-variable/*` packages.
+**Never load fonts from Google's CDN** — a privacy-first product does
+not leak its users' IPs to a tracking company for a font. Today all
+three apps silently fall back to system-ui (social declares Inter but
+never loads it); actually loading the fonts is part of the level-up.
+
+| Family | Package | Role |
+|---|---|---|
+| **Inter Variable** | `@fontsource-variable/inter` | Everything: UI, body, forms. Weights 400 / 500 / 600 only. |
+| **Space Grotesk Variable** | `@fontsource-variable/space-grotesk` | Display: marketing headlines, hero numerals, section titles, the brand set as type. Weights 500 / 700. Its slightly techy geometry rhymes with the thin-outline wordmark. |
+| **JetBrains Mono Variable** | `@fontsource-variable/jetbrains-mono` | Code in docs, tokens/IDs in the admin UI, terminal snippets. |
+
+Scale (rem, on a 16px root — expose as tokens, don't freelance):
+
+| Step | Size / line-height | Use |
+|---|---|---|
+| display | 3.5rem / 1.1, Space Grotesk 700, tracking −0.02em | Marketing hero only |
+| h1 | 2.25rem / 1.2, Space Grotesk 700, −0.02em | Page titles, section heads |
+| h2 | 1.5rem / 1.3, Space Grotesk 500 | Card group titles |
+| h3 | 1.125rem / 1.4, Inter 600 | Card titles, modal titles |
+| body | 1rem / 1.6 (marketing) · 0.9375rem / 1.5 (app UI) | Default |
+| small | 0.8125rem / 1.5, Inter 400–500 | Meta, captions, table density |
+| micro | 0.75rem / 1.3, Inter 500, +0.04em, uppercase | Overlines, badges, column headers |
+
+Rules: max two families per screen (mono is exempt in code contexts).
+Long-form prose (docs, manifesto) sets measure 65–75ch. Numbers in
+stats/tables use `font-variant-numeric: tabular-nums`. No font-weight
+above 700, no thin weights below 400 in UI (the wordmark is the only
+thin thing in the brand).
+
+
+## 6. Space, radius, elevation
+
+- **4px grid.** Every margin, padding, and gap is a multiple of 4px
+  (Tailwind's default scale — use it, never arbitrary `p-[13px]`).
+  Component-internal rhythm: 8/12/16. Between components: 16/24.
+  Between sections: 32/48. Marketing sections breathe: `py-24`–`py-32`.
+- **Radius:** `--radius-sm: 0.5rem` (inputs, badges), `--radius:
+  0.75rem` (buttons, cards — the house radius), `--radius-lg: 1rem`
+  (modals, hero cards), `--radius-full` (pills, avatars). Nested
+  radii: inner = outer − padding, or it reads as a mistake.
+- **Elevation in dark UI is NOT shadows.** It is background steps
+  (`background` → `surface` → `elevated`) plus 1px `border`. Shadows
+  are reserved for things that float: dropdowns, popovers, modals
+  (`0 8px 30px rgb(0 0 0 / 0.35)`). The one decorative exception is
+  the brand glow (§4).
+- Dense surfaces (admin tables, Studio analytics) tighten to the
+  small type step and 8px internal rhythm — density is a feature in
+  operator tools, as long as alignment stays exact.
+
+
+## 7. Motion
+
+Motion confirms causality; it never performs.
+
+- **Micro** (hover, press, focus): 150ms, `ease-out`. Transform +
+  opacity + color only — never animate width/height/top/left.
+- **Panels** (drawers, modals, dropdowns): 200–250ms ease-out in,
+  150ms out. Subtle: 4–8px translate + fade, not flying across screen.
+- **Marketing reveals**: 400–600ms fade/rise on scroll-into-view, once,
+  staggered ≤ 80ms apart. No parallax, no scroll-jacking, no looping
+  attention-seekers.
+- **Skeletons** pulse at ~1.5s; content replaces them in place (no
+  shift). Spinners only where a skeleton is impossible.
+- `prefers-reduced-motion: reduce` is honored everywhere: transitions
+  collapse to instant, reveals render visible.
+- App UI (`ui/`, admin surfaces): no spring/bounce easings. The
+  console is calm. Social/marketing may be 10% springier, never circus.
+
+
+## 8. Components
+
+- **shadcn/ui conventions** (D22): primitives live in
+  `src/components/ui/` (Button, Card, Input, Dialog, DropdownMenu,
+  Avatar, Badge, Skeleton, Tabs, Tooltip…), built on Radix, variants
+  via `class-variance-authority`, composed with `cn()` (clsx +
+  tailwind-merge). `marketing/web10-social/src/components/ui/` is the
+  reference implementation — extend that idiom; when another app needs
+  a primitive, copy it (apps are separate packages; verbatim copies
+  with a "keep in sync with design.md" header beat a premature shared
+  package).
+- **Styling is utility classes referencing tokens.** No inline
+  `style={{}}` for anything a token or utility covers (the `ui/` app's
+  inline-style habit is debt to burn down). No new one-off CSS files
+  per component. No CSS-in-JS (rejected in D22).
+- **Icons: Lucide only.** `lucide-react`, 16/20/24px, `stroke-width`
+  1.5–2, colored via `currentColor`. **FontAwesome is retired** —
+  social loads a FA kit script from a third-party CDN (privacy leak +
+  render-blocking) and marketing-ui uses `fa` classes without loading
+  FA at all (invisible icons). Both go.
+- **Focus**: every interactive element shows `focus-visible` as a 2px
+  `--color-ring` (brand) ring with 2px offset. Keyboard users see
+  exactly where they are on every screen.
+- **Forms**: labels above inputs, always visible (placeholders are
+  hints, never labels). Inline validation on blur, error text in
+  `danger` under the field, never only a red border.
+- **data-testid stays.** The e2e harness (C5) navigates by test ids —
+  a beautification pass that strips them breaks CI. Keep existing
+  hooks; add them to new interactive elements.
+
+
+## 9. Responsive
+
+Dogma: **375px phone and 1440px desktop are both first-class.**
+Creators will open this on a phone in the middle of a pitch.
+
+- Breakpoints: Tailwind defaults (`sm` 640, `md` 768, `lg` 1024,
+  `xl` 1280). Design mobile-first; add complexity upward.
+- App shells: desktop = fixed left sidebar (`w-64`, `border-r`,
+  `bg-surface`); mobile = top header + bottom tab bar (the pattern
+  already in `web10-social/src/components/Social/Layout.tsx` — it's
+  correct; adopt it in `ui/` too).
+- Touch targets ≥ 44×44px on mobile. Hover-only affordances get a
+  visible mobile equivalent.
+- Tables that matter on mobile become card lists; tables that don't
+  scroll horizontally inside their card, never the page.
+- Test at 375, 768, 1280, 1440 before calling a screen done. PR
+  screenshots (§12) include 375px.
+
+
+## 10. Per-app direction
+
+### `marketing/marketing-ui/` — the pitch site (lane D)
+The job: a creator's manager lands here and in 30 seconds believes
+this is a company, not a weekend project. **Bulma comes out entirely**
+(D22 already rejected it) — Tailwind v4 + tokens + the shadcn idiom.
+Dark, cinematic, restrained: hero = full lockup + one declarative line
+in the manifesto voice + one CTA; a reach-gap proof section (the
+1M-subs-300k-views mechanic, shown as a simple chart, not adjectives);
+real product screenshots in device frames; docs pages stay light-on-
+reading-comfort (prose measure, mono code blocks); App Store cards on
+the house Card primitive. Education-era imagery and university logos:
+deleted. If it isn't true, it isn't on the site.
+
+### `ui/` — the node console (lane B)
+The job: the operator/consent surface reads like Vercel or Linear —
+calm, precise, trustworthy. This surface holds the **Studio** (B4.5),
+the money screen, the highest-stakes UI in the repo: monetization
+cards on `surface` with exact alignment, revenue numerals in
+tabular-nums with `success` green reserved for money. Burn down the
+inline-style habit; delete the dead vendored Bulma in
+`ui/src/assets/bulma/`; fix the `SideBar.tsx` bug where a literal
+`style={{…}}` string is concatenated into `className`; adopt the
+`components/ui` primitive kit and the mobile bottom-nav shell. Auth +
+consent screens are the narrative surface ("this is your node; these
+are your contracts") — one column, generous space, zero clutter.
+
+### `marketing/web10-social/` — the flagship (lane D)
+The job: the screenshot that goes in the deck next to Kick and Twitch.
+Media-forward feed (images/video lead, chrome recedes), tight
+avatar/name/timestamp system on the small type step, a composer that
+feels like publishing rather than filling a form, DMs with presence
+polish, profile as a creator page (banner, stats row, grid). First-run
+empty states are the story: point at the importer. Fix the wiring
+gaps: `@tailwindcss/vite` plugin is missing from `vite.config.ts`
+(the build pipeline is half-connected) and Inter is declared but never
+loaded. Finish evicting the excluded legacy `rectangles-npm`/
+`@chatscope` components.
+
+
+## 11. Accessibility (part of pretty, not opposed to it)
+
+- Contrast per §4. Focus-visible per §8. Reduced motion per §7.
+- Semantic HTML first: real `<button>`, `<nav>`, `<main>`, headings in
+  order. Radix handles ARIA for composite widgets — don't hand-roll
+  what Radix provides.
+- Every image has alt (or `alt=""` if decorative); every icon-only
+  button has an `aria-label`.
+- Fully keyboard-operable: anything a mouse can do, Tab/Enter/Esc can do.
+
+
+## 12. Definition of done for UI work
+
+A UI PR merges when:
+
+1. **The screenshot test (§1) passes** on every changed screen.
+2. **Screenshots are in the PR description**: each changed screen at
+   desktop (≥1280) and mobile (375). Reviewers judge pixels, not diffs.
+3. **Zero hardcoded colors/fonts/radii** in the diff — tokens only.
+4. All interactive states + loading/empty/error states exist (§1, §8).
+5. No layout shift, no dead assets, no invisible icons, no
+   browser-default controls on the changed screens.
+6. `data-testid` hooks preserved/added; existing tests + e2e smoke
+   still green.
+7. No regression of the security invariants' UI surfaces (consent
+   screens must stay explicit about what a token may touch — pretty
+   never means vague).
+
+Changing THIS file: token values and brand rules change by PR that
+edits design.md itself, with a decisions.md entry if it's a real
+direction change. App code never quietly diverges from the doc — if
+the doc is wrong, fix the doc, then the code.
+
+
+## 13. Canonical tokens (copy verbatim)
+
+Tailwind v4 `@theme` block — the single source of truth. Each app
+carries a copy in `src/styles/tokens.css` (or its `index.css @theme`
+block) headed by: `/* SOURCE OF TRUTH: /design.md §13 — sync, don't
+fork */`. `ui/src/styles/tokens.css`'s current light-first blue token
+set migrates TO this; `web10-social`'s `@theme` is closest and gains
+the missing steps.
+
+```css
+@theme {
+  /* neutrals — zinc, dark-first (§4) */
+  --color-background: #09090b;
+  --color-foreground: #fafafa;
+  --color-surface: #111113;
+  --color-elevated: #18181b;
+  --color-border: #27272a;
+  --color-input: #27272a;
+  --color-ring: #8b5cf6;
+  --color-muted: #18181b;
+  --color-muted-foreground: #a1a1aa;
+
+  /* brand — violet (§4) */
+  --color-brand-300: #c4b5fd;
+  --color-brand-400: #a78bfa;
+  --color-brand: #8b5cf6;
+  --color-brand-600: #7c3aed;
+  --color-brand-muted: #2e1065;
+  --color-brand-foreground: #fafafa;
+
+  /* semantic (§4) */
+  --color-success: #22c55e;
+  --color-warning: #f59e0b;
+  --color-danger: #ef4444;
+  --color-danger-muted: #450a0a;
+
+  /* shadcn compatibility layer */
+  --color-card: #111113;
+  --color-card-foreground: #fafafa;
+  --color-popover: #18181b;
+  --color-popover-foreground: #fafafa;
+  --color-primary: #fafafa;
+  --color-primary-foreground: #09090b;
+  --color-secondary: #27272a;
+  --color-secondary-foreground: #fafafa;
+  --color-accent: #27272a;
+  --color-accent-foreground: #fafafa;
+  --color-destructive: #ef4444;
+
+  /* type (§5) */
+  --font-sans: 'Inter Variable', 'Inter', ui-sans-serif, system-ui, sans-serif;
+  --font-display: 'Space Grotesk Variable', 'Space Grotesk', ui-sans-serif, system-ui, sans-serif;
+  --font-mono: 'JetBrains Mono Variable', ui-monospace, 'SF Mono', Menlo, monospace;
+
+  /* radius (§6) */
+  --radius-sm: 0.5rem;
+  --radius: 0.75rem;
+  --radius-lg: 1rem;
+  --radius-full: 9999px;
+}
+```
+
+White-label note (D22): creator nodes wear their brand by overriding
+these CSS variables at runtime — which is exactly why every color in
+every component must come through a token. A hardcoded hex isn't just
+ugly, it breaks phase-4 theming.

--- a/parallel execution.txt
+++ b/parallel execution.txt
@@ -120,6 +120,16 @@ LANE B — ui / frontend        (owns: auth2->ui/**, auth/**)
       window so the demo video shows the money screen -- visually
       complete + rung-0 functional; deeper wiring (unlock ladder,
       adapters) follows in weeks 5-10.
+  [ ] B5. level-up ui/ to the design.md standard (READ design.md
+      FIRST — repo root; it is the law for all ui work). tokens.css
+      migrated to design.md §13 (dark-first violet), inline styles
+      out, dead vendored bulma dir deleted, SideBar.tsx className/
+      style bug fixed, components/ui primitives kit, mobile bottom-
+      nav shell, hub.png (apple's app store logo — trademark,
+      replace) + react-atom icons swapped for the real keys marks
+      (design.md §3). studio = the money screen, highest stakes.
+      acceptance: design.md §12 (screenshot test, pr screenshots
+      desktop + 375px, tokens-only, all states designed).
 
 LANE C — greenfield services  (owns: sdk/, mcp/, new dirs)
   [✓ 1.0.25] C1. P5 media service (presigned urls, minio profile,
@@ -198,6 +208,26 @@ LANE D — docs / apps / mobile (owns: mobile/**, marketing/, examples/
       events + the error beacon ONLY -- no session-recording js
       on ui/ or social, ever (manifesto line). self-hosted
       posthog/openreplay deploy, if adopted, is lane E territory.
+  [ ] D12. level-up web10-social to the design.md standard (READ
+      design.md FIRST — repo root). owns marketing/web10-social/**
+      only — runs parallel to D13, disjoint dirs. this is the deck
+      screenshot next to kick/twitch: wire the missing
+      @tailwindcss/vite plugin, actually load inter, media-forward
+      feed cards, composer that feels like publishing, profile as
+      creator page, story-first empty states (point at the
+      importer), finish evicting excluded rectangles/@chatscope
+      legacy components, fontawesome CDN kit out for lucide.
+      acceptance: design.md §12.
+  [ ] D13. rebuild marketing-ui on the design system (READ design.md
+      FIRST — repo root). owns marketing/marketing-ui/** only — runs
+      parallel to D12, disjoint dirs. bulma OUT entirely (D22),
+      tailwind v4 + design.md §13 tokens, dark cinematic landing
+      (lockup hero, reach-gap proof section, real screenshots), docs
+      readable (65-75ch prose, mono code), app store on house cards,
+      education-era imagery + university logos deleted. also pays
+      the brand asset debt for all three apps (svg marks, dark
+      variants, favicons/pwa icons from the keys mark, shared
+      og-image — design.md §3). acceptance: design.md §12.
 
 
 
@@ -241,34 +271,34 @@ M3 "the network"         = encryption integration (A rtc + C2 sdk
                            polish. the last big merge.
 
 
-CURRENT CONDUCTOR BOARD (as of 18.07.2026 — keep this section fresh)
+CURRENT CONDUCTOR BOARD (as of 19.07.2026 — keep this section fresh)
 --------------------------------------------------------------------
-we are in timeline.md WEEK 0 — the M0 sprint (video by ~aug 17).
-the D20/D21 pivot re-cut this board; C2 sdk is OFF the M0 critical
-path (ws2 repointed to D4 per timeline.md week 0).
+we are in timeline.md WEEK 0/1 — the M0 sprint (video by ~aug 17).
+the data layers, studio M0 slice, e2e harness, and staging infra are
+all merged. THIS WEEK'S PUSH: the design level-up (design.md landed
+as the binding ui standard — every ui agent reads it first) + getting
+staging actually deployed. the three beautify items are parallel-safe
+(disjoint directories).
 
-  ws1: B2.5 ui makeover in ui/ — stack pick (tailwind + shadcn is
-       the named default; record in decisions.md) + shared design
-       tokens. gates D2.5 and D4's screens; merge the pick fast.
-  ws2: D4 killer app M0 slice, DATA LAYER first — posts, feed
-       (chronological + sort dropdown ONLY, lens/chatbox cut per
-       D20), profile, dms on current wapi against docs/schemas.
-       logic doesn't wait for B2.5; screens do.
-  ws3: wave 0 remainder: small security fixes (CORS, bare except,
-       provider url validation) — land these BEFORE A6 churns the
-       billing code. then A6 (D21 strip user billing -> operator
-       quotas, timeline week 2) takes this lane-A slot.
-ws4: [✓ 1.0.50] outreach list batch 1 fully enriched: 20 API-verified
-         prospects via YouTube Data API (outreach_sourcer.py), all burn
-         events verified, 5 with biz emails, 6 false positives filtered.
-         script reusable for batches 2-5. or E1 proxmox staging node
+  ws1: B5  level-up ui/ to design.md (lane B — ui/**)
+  ws2: D12 level-up web10-social to design.md (lane D —
+       marketing/web10-social/** only)
+  ws3: D13 rebuild marketing-ui on the design system, bulma out
+       (lane D — marketing/marketing-ui/** only) + pays the shared
+       brand asset debt (design.md §3)
+  ws4: E1 EXECUTE the staging deploy (infra merged in 1.0.60,
+       BLOCKED on operator input: SSH access + Cloudflare creds —
+       see STAGING-RUNBOOK.md). deploys marketing-ui + marketing-api
+       + the node stack incl. web10-social to staging. then E3
+       public domain when ready.
 
-  merge-order notes: lane A stays single-branch (security fixes ->
-  A6 -> A5). D2.5 starts the moment B2.5's tokens merge. B4.5 M0
-  slice (studio monetization-menu screen, rung-0 cards) follows
-  B2.5 in lane B — it's week 2's money shot. C2/C3/C3.5 parked
-  until after M0.
-  (A1/B1/B2/B3/B4/C1/D1/D2/D3/D5–D9/E2 are DONE — don't re-pick.)
+  merge-order notes: B5/D12/D13 don't gate each other; merge each as
+  it passes design.md §12. D13 owns the cross-app asset generation
+  (svg marks, favicons) but replacing assets INSIDE ui/ is B5's to
+  apply — D13 leaves the files + a .context note, doesn't reach in.
+  C2/C3/C3.5 still parked until after M0.
+  (A1/B1/B2/B3/B4/B4.5/C1/C5/D1/D2/D2.5/D3/D4/D5–D10/E1-infra/E2
+  are DONE — don't re-pick.)
 
   from here on: pull the top unticked item of whichever lane's queue
   is unblocked. lanes A and B are long marches; C and D are a stream

--- a/parallel execution.txt
+++ b/parallel execution.txt
@@ -128,8 +128,18 @@ LANE B — ui / frontend        (owns: auth2->ui/**, auth/**)
       nav shell, hub.png (apple's app store logo — trademark,
       replace) + react-atom icons swapped for the real keys marks
       (design.md §3). studio = the money screen, highest stakes.
+      ALSO (urgent, staging is live-broken on this): parameterize
+      the ui's backend origins — ui/src/interfaces/authAdapter.ts +
+      ui/src/config.ts hardcode api.web10.app/auth.web10.app for
+      prod builds, so auth.staging.web10.app ships a bundle calling
+      the wrong api (see ubuntu-deployment/AGENT-OPS.md §4.1).
+      build-time env (REACT_APP_*/VITE_* both allowed by
+      vite.config.js) + Dockerfile ARG; leave a .context note for
+      lane E to pass the args in docker-compose.staging.yml.
       acceptance: design.md §12 (screenshot test, pr screenshots
-      desktop + 375px, tokens-only, all states designed).
+      desktop + 375px, tokens-only, all states designed) + a
+      staging rebuild can point at staging domains without a code
+      edit.
 
 LANE C — greenfield services  (owns: sdk/, mcp/, new dirs)
   [✓ 1.0.25] C1. P5 media service (presigned urls, minio profile,
@@ -153,6 +163,23 @@ LANE C — greenfield services  (owns: sdk/, mcp/, new dirs)
       by coordination, never reach-in edits). marketing-ui smoke +
       ui auth flows are landable now; social post->feed firms up
       with D4.
+  [ ] C6. e2e deep sweep + bug hunt (specced in plan.txt CROSS-
+      CUTTING quality/testing, "e2e deep sweep"): C5's harness
+      exists — now really exercise the ecosystem locally and find
+      what doesn't work (assume plenty doesn't). expand playwright
+      across the money paths + lane seams: signup -> consent ->
+      grant; social post w/ media -> feed -> comment -> dm; terms
+      revoke actually cuts the app off; exporter upload ->
+      marketing-api job -> records; app store -> launch -> token
+      handoff; studio w/ real metering. TEST ACCOUNTS are part of
+      the harness: signup IS a test (fresh account per run), plus
+      a seed script of persona fixtures (creator + fans + granted/
+      revoked terms) for flows needing existing state — same seed
+      powers dev-env wipe+reseed. no secrets in git; per-env creds
+      via env files. every failure triaged: small fixes land with
+      the suite, lane-owned breakage -> .context/ note + lane
+      queue item, never a silent skip. deliverable = the enlarged
+      suite AND the honest bug list.
 
 LANE D — docs / apps / mobile (owns: mobile/**, marketing/, examples/
                                 *.md/txt)
@@ -236,11 +263,28 @@ LANE E — infrastructure / deployment (owns: proxmox provisioning,
 [✓ 1.0.60] E1. proxmox staging node: Portainer + Nginx Proxy Manager
        infra (prep-vm.sh, docker-compose.staging.yml self-contained stack,
        Cloudflare DNS plan). ubuntu-deploy.sh replaced by Portainer UI
-       approach. STAGING-RUNBOOK.md updated. Awaiting SSH + CF creds to
-       deploy. team-accessible internal staging.
+       approach. STAGING-RUNBOOK.md updated. DEPLOYED 19.07.2026:
+       api live at staging.web10.app, ui serves at
+       auth.staging.web10.app but is broken by hardcoded origins
+       (lane B fix queued in B5); rtc/minio DNS records missing;
+       marketing/social not in the stack yet. live triage +
+       ops procedures: ubuntu-deployment/AGENT-OPS.md + OPS-LOG.md.
 [✓ 1.0.38] E2. marketing deploy: marketing-ui + marketing-api on proxmox,
        caddy reverse proxy with auto-TLS. internal staging complete.
-  [ ] E3. public domain + auto-TLS for external traffic (when ready)
+  [ ] E3. PROD env — the whole ecosystem public (specced in plan.txt
+      CROSS-CUTTING deployment "environments"): prod marketing-ui +
+      marketing-api + node (api, ui, social, rtc, minio, db) behind
+      NPM with public cloudflare DNS + router-forwarded 80/443 +
+      real TLS. infra panels stay LAN/VPN-only (E1 security model).
+  [ ] E5. DEV env — the SAME whole ecosystem, VPN-only, on the same
+      linux box ubuntu-deployment/ preps (parallel to E3, and to
+      the B5/D12/D13 ui revamp): cloudflare DNS for dev vhosts
+      (*.dev.web10.app or similar) pointing at the box's INTERNAL
+      LAN ip — resolves publicly, unreachable off-VPN, zero
+      port-forwards, TLS still works (DNS-01 needs no inbound).
+      second Portainer stack from the same parameterized compose,
+      own volumes + env file. promotion flow (dev soak -> prod
+      redeploy) documented in STAGING-RUNBOOK.md.
   [ ] E4. automated provisioning: terraform or ssh-api script +
       ansible for idempotent VM/LXC setup. don't rush — manual is
       fine until E2 works.
@@ -286,11 +330,15 @@ staging actually deployed. the three beautify items are parallel-safe
   ws3: D13 rebuild marketing-ui on the design system, bulma out
        (lane D — marketing/marketing-ui/** only) + pays the shared
        brand asset debt (design.md §3)
-  ws4: E1 EXECUTE the staging deploy (infra merged in 1.0.60,
-       BLOCKED on operator input: SSH access + Cloudflare creds —
-       see STAGING-RUNBOOK.md). deploys marketing-ui + marketing-api
-       + the node stack incl. web10-social to staging. then E3
-       public domain when ready.
+  ws4: staging IS deployed (19.07.2026 — auth.staging.web10.app is
+       live but broken-on-arrival). first job: triage the live
+       staging against ubuntu-deployment/AGENT-OPS.md (ssh in, read
+       container logs, fix or file). then E5 dev env (VPN-only,
+       whole ecosystem — cloudflare DNS -> internal ip) and E3 prod
+       env (public marketing-ui + ui + social) on the same box.
+  ws5: C6 e2e deep sweep + bug hunt (lane C — e2e/** only; local
+       stack, no deploy gate). signup-as-a-test + persona seed
+       fixtures; the honest bug list is the deliverable.
 
   merge-order notes: B5/D12/D13 don't gate each other; merge each as
   it passes design.md §12. D13 owns the cross-app asset generation

--- a/plan.txt
+++ b/plan.txt
@@ -412,6 +412,10 @@ the three items below are PARALLEL — disjoint directories:
     kit, mobile bottom-nav shell, hub.png (apple's app store logo —
     a trademark, replace it) + react-atom icons swapped for the real
     keys marks. the studio screen is the money shot — highest stakes.
+    includes the urgent staging unblock: backend origins become
+    build-time env instead of the hardcodes in authAdapter.ts/
+    config.ts (staging ships a bundle calling api.web10.app — see
+    ubuntu-deployment/AGENT-OPS.md §4.1).
 [ ] level-up web10-social to the design.md standard (lane D, item
     D12): this is the deck screenshot next to kick/twitch. wire the
     missing @tailwindcss/vite plugin, actually load inter (declared,
@@ -1321,7 +1325,30 @@ testing:
     lands. visual-regression screenshots are explicitly LATER --
     real value, but baselines churn while B2.5/D2.5 restyle the
     world; revisit after the makeovers settle.
-[ ] marketing-ui vitest backfill: it has ZERO component tests today
+[ ] e2e deep sweep (added 19.07.2026 — C5's harness makes this
+    possible; expect it to hurt): the 10 smoke journeys prove the
+    stack boots; now actually EXERCISE the ecosystem locally
+    (e2e/docker-compose.yml) end to end and find out what doesn't
+    work — the working assumption is that plenty doesn't. expand
+    playwright coverage across the real money paths and the seams
+    between lanes: full signup -> consent -> grant on ui/; social
+    post with media -> feed -> comment/react -> dm round trip;
+    profile edit; terms revoke actually cutting an app off;
+    marketing-ui exporter upload -> marketing-api job -> records
+    in the node; app store -> launch app -> token handoff; studio
+    screens load with real metering data (A5). test accounts are
+    part of the harness: account CREATION is itself a test (every
+    run signs up fresh users), and a seed script provides persona
+    fixtures (a creator, fans, granted + revoked app terms, posted
+    content) for flows that need existing state — the same seed
+    powers the dev env's wipe+reseed. per-env test credentials via
+    env files, never in git. every failure found
+    gets triaged: small fixes land with the suite (tick the fix in
+    the changelog), lane-owned breakage gets filed as a .context/
+    note + lane queue item, never a silent skip. deliverable is
+    the enlarged suite AND the honest bug list. visual-regression
+    baselines still wait for the design level-up to settle
+    (B5/D12/D13), but functional coverage doesn't wait on pretty.
     and its test script is `vitest --passWithNoTests`, so a green
     ci check there certifies nothing. test the surfaces with logic
     (exporter/import ui, funnel events), then drop the
@@ -1642,6 +1669,29 @@ what goes in:
     own vhost, never inside the node compose.
 [ ] marketing-api: separate container. handles the ZIP import
     pipeline and analytics for marketing-ui.
+
+environments (added 19.07.2026): TWO full stacks on the linux box
+that ubuntu-deployment/ preps, both managed as Portainer stacks on
+the same host, one compose file parameterized by env (domain prefix,
+volumes, env file) — never two divergent composes:
+[ ] PROD env — the whole ecosystem public: marketing-ui +
+    marketing-api + the node (api, ui, social, rtc, minio, db).
+    public Cloudflare DNS -> router-forwarded 80/443 -> NPM with
+    real TLS certs (DNS-01 via cloudflare). this is E3 executed:
+    prod marketing ui, prod ui, prod social ui.
+[ ] DEV env — the SAME whole ecosystem, VPN-only: cloudflare DNS
+    records (dev.web10.app / *.dev.web10.app or similar) pointing
+    at the box's INTERNAL LAN ip. the records resolve publicly but
+    route nowhere unless you're on the VPN — zero exposure, no
+    port-forwards for dev vhosts, and still real domain names so
+    TLS (DNS-01 challenge needs no inbound traffic), CORS, and
+    vhost routing behave exactly like prod. dev is where merged
+    work soaks before prod promotion; wipe+reseed procedures per
+    STAGING-RUNBOOK.md. follows the E1 security model: infra
+    panels stay LAN/VPN-only regardless of env.
+[ ] promotion flow documented in STAGING-RUNBOOK.md: merge to dev
+    branch -> dev env redeploy (Portainer re-pull), tag/release ->
+    prod redeploy. keep it manual-button simple until E4.
 
 networking:
 [ ] VPN gateway must be up for any management access. document

--- a/plan.txt
+++ b/plan.txt
@@ -396,6 +396,39 @@ the makeover (story-first, not a screen-by-screen reskin):
     deliverable: THE STORY + demo video). a screen that can't
     appear in the pitch isn't done.
 
+the level-up (added 19.07.2026 — design.md is the law):
+the first makeover got the stack right and stripped rectangles, but
+the surfaces still read prototype, not product — and the repo was
+shipping the react atom and apple's app store glyph as its own logos.
+design.md (repo root) now defines the brand (dark-first, violet, the
+keys marks), the canonical token set, and the ui definition of done
+(the screenshot test; pr screenshots at desktop + 375px). every ui
+agent reads it before working, every time (CLAUDE.md/AGENTS.md gate).
+the three items below are PARALLEL — disjoint directories:
+[ ] level-up ui/ to the design.md standard (lane B, item B5):
+    tokens.css migrated to design.md §13 (dark-first violet), inline-
+    style habit burned down, dead vendored bulma dir deleted,
+    SideBar.tsx className/style bug fixed, components/ui primitives
+    kit, mobile bottom-nav shell, hub.png (apple's app store logo —
+    a trademark, replace it) + react-atom icons swapped for the real
+    keys marks. the studio screen is the money shot — highest stakes.
+[ ] level-up web10-social to the design.md standard (lane D, item
+    D12): this is the deck screenshot next to kick/twitch. wire the
+    missing @tailwindcss/vite plugin, actually load inter (declared,
+    never loaded), media-forward feed cards, composer that feels like
+    publishing, profile as creator page, story-first empty states,
+    finish evicting the excluded rectangles/@chatscope legacy
+    components, retire the fontawesome CDN kit for lucide.
+[ ] rebuild marketing-ui on the design system (lane D, item D13):
+    bulma OUT entirely (already rejected in D22), tailwind v4 +
+    design.md tokens, dark cinematic landing (lockup hero, reach-gap
+    proof section, real product screenshots), docs pages readable
+    (prose measure, mono code), app store on house cards,
+    education-era imagery + university logos deleted, and the brand
+    asset debt paid for all three apps (svg marks, dark-on-light
+    variants, favicons/pwa icons from the keys mark, shared og-image
+    — design.md §3).
+
 
 PHASE 3 — setup wizard (the missing piece)
 ------------------------------------------

--- a/ubuntu-deployment/AGENT-OPS.md
+++ b/ubuntu-deployment/AGENT-OPS.md
@@ -1,0 +1,228 @@
+# AGENT-OPS.md — field manual for agents operating the staging box
+
+You are an agent with SSH access to a LIVE machine serving real
+domains. This file is written to be followed literally, step by step.
+Do not improvise. If a step fails twice, STOP, write what happened in
+`OPS-LOG.md` (§8), and report back to the operator — a wrong guess on
+a live box costs more than a paused task.
+
+Read `README.md` (security model) before your first session. This
+file is the "what do I actually type" companion to it and to
+`STAGING-RUNBOOK.md` (day-2 procedures).
+
+## 0. Prime directives
+
+1. **Never** expose Portainer (:9000), the NPM admin (:81), or the
+   Minio console (:9001) to the internet — no DNS record, no NPM
+   proxy host, no port-forward. This is the load-bearing security
+   rule of the whole deployment.
+2. **Never** delete a Docker volume, run `docker system prune -a`,
+   or wipe data unless the task explicitly says so AND
+   `STAGING-RUNBOOK.md` has a procedure for it. Prefer restart >
+   rebuild > redeploy > wipe, in that order.
+3. **Never** commit secrets: no IPs beyond what's already public DNS,
+   no passwords, no tokens, no key material. Secrets live in
+   `ubuntu-deployment/.env` (gitignored) and in Portainer stack env
+   vars — nowhere else.
+4. **Always** append an entry to `OPS-LOG.md` (§8) before you end a
+   session in which you changed ANYTHING on the box. The log is how
+   parallel agents avoid stepping on each other.
+5. One change at a time. Change → verify → log. Never batch three
+   fixes and then check.
+
+## 1. Getting in
+
+Connection details are NOT in git. They live in
+`ubuntu-deployment/.env` (copy of `.env.example`, filled in by the
+operator):
+
+```
+VM_IP=...          # the box's LAN IP (VPN/LAN reachable)
+CF_ZONE=web10.app
+CF_API_TOKEN=...   # Cloudflare DNS edits
+```
+
+```bash
+# 1. read the env file — if it doesn't exist, STOP and ask the
+#    operator for it. do not guess IPs.
+cat ubuntu-deployment/.env
+
+# 2. ssh in (key auth; the operator's key must already be installed)
+ssh root@$VM_IP
+
+# 3. prove you're on the right box before touching anything:
+docker ps --format 'table {{.Names}}\t{{.Status}}\t{{.Image}}'
+# expect: portainer, nginx-proxy-manager (or npm_app), and the
+# web10-staging stack services (api, ui, rtc, minio, ferretdb,
+# postgres). if you don't see these, you are on the wrong machine
+# — disconnect and report.
+```
+
+Admin UIs (from LAN/VPN, or via SSH tunnel — see README §"How the
+private side is enforced"):
+
+| UI | Where | For |
+|---|---|---|
+| Portainer | `http://$VM_IP:9000` | stacks: deploy, env vars, logs, restart |
+| NPM admin | `http://$VM_IP:81` | proxy hosts, TLS certs |
+| Minio console | `http://$VM_IP:9001` | S3 buckets (rarely needed) |
+
+Remote tunnel pattern: `ssh -L 9000:localhost:9000 root@$VM_IP`, then
+open `http://localhost:9000`.
+
+## 2. Map of the box
+
+- Everything runs as Docker containers on the shared external
+  `proxy` network (created by `prep-vm.sh`).
+- The app stack is a **Portainer stack** named `web10-staging`,
+  created by pasting `docker-compose.staging.yml` into Portainer.
+  Its build contexts are `../api`, `../ui`, `../api/rtc` — Portainer
+  has a clone of this repo for that; the repo on the box is a
+  deploy artifact, never a place to develop.
+- NPM terminates TLS on 80/443 and forwards BY CONTAINER NAME over
+  the `proxy` network.
+
+Domain map (zone `web10.app`):
+
+| Public URL | NPM forwards to | What |
+|---|---|---|
+| `staging.web10.app` | `api:80` | FastAPI node |
+| `auth.staging.web10.app` | `ui:80` | node admin/consent UI |
+| `rtc.staging.web10.app` | `rtc:80` | signaling |
+| `minio.staging.web10.app` | `minio:9000` | S3 API (media) — never :9001 |
+
+Marketing + social are NOT in this stack yet (see plan.txt
+CROSS-CUTTING deployment / lane items E3+E5): `docker-compose.marketing.yml`
+is the marketing stack; social has no staging service yet.
+
+## 3. Diagnosis — run this sequence, in order, before changing anything
+
+```bash
+# A. what's up, what's crash-looping?
+docker ps -a --format 'table {{.Names}}\t{{.Status}}'
+# "Restarting (1) X seconds ago" = crash loop -> step B on that name.
+
+# B. logs of a suspect container (NEVER guess from memory):
+docker logs --tail 100 <container-name>
+
+# C. is the service healthy FROM INSIDE the proxy network?
+docker run --rm --network proxy curlimages/curl -sS -o /dev/null \
+  -w '%{http_code}\n' http://api:80/docs        # expect 200
+docker run --rm --network proxy curlimages/curl -sS -o /dev/null \
+  -w '%{http_code}\n' http://ui:80/             # expect 200
+
+# D. is it reachable FROM OUTSIDE?
+curl -sS -o /dev/null -w '%{http_code}\n' https://staging.web10.app/docs
+curl -sS -o /dev/null -w '%{http_code}\n' https://auth.staging.web10.app/
+
+# E. does DNS even exist? (run from YOUR machine, not the box)
+dig +short auth.staging.web10.app
+```
+
+Symptom → likely cause (check in this order, stop at first hit):
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `Could not resolve host` | Cloudflare DNS record missing | add A record (DNS only, not proxied) via CF dashboard or API with `CF_API_TOKEN` |
+| 502 from NPM | container down, or NPM forwards to wrong name/port | step A/B; check NPM proxy host target matches §2 table |
+| 521/timeout | box or NPM down, or router 80/443 forward broken | `docker ps` for NPM; check router |
+| Container `Restarting` | app crash — env var missing is the usual | `docker logs`; compare env against `docker-compose.staging.yml` requireds (e.g. `MINIO_PASSWORD`) |
+| Page loads but app is dead/blank | frontend built with wrong baked-in URLs, or CORS | §4 Known issues — check browser devtools console first: what URL is it calling? |
+| API 500s | read the traceback in `docker logs <api-container>` — don't theorize | fix per traceback |
+
+## 4. KNOWN ISSUES — live breakage, triaged 19.07.2026
+
+Read this before re-diagnosing; these are already understood:
+
+1. **The auth UI at `auth.staging.web10.app` is broken by
+   construction.** The UI serves (HTTP 200) but the JS bundle has
+   its backend origins HARDCODED at build time in
+   `ui/src/interfaces/authAdapter.ts` — dev builds point at
+   `*.localhost`, any production build points at
+   `https://api.web10.app` / `https://auth.web10.app` (which is not
+   this environment). `ui/src/config.ts` likewise defaults to
+   `api.web10.app`. So the staging UI calls a wrong API and dies.
+   **The fix is a `ui/` code change (lane B, queued with B5):**
+   read the origins from build-time env
+   (`REACT_APP_*`/`VITE_*` — `ui/vite.config.js` already allows both
+   prefixes) + a Dockerfile `ARG`, and have
+   `docker-compose.staging.yml` pass them from `PROVIDER`. An ops
+   agent CANNOT fix this on the box — do not try; rebuilding with
+   the same code reproduces the same bundle.
+2. **DNS records exist only for `staging` + `auth.staging`.**
+   `rtc.staging` / `minio.staging` (and any future
+   `social.staging` / `www.staging`) did not resolve as of
+   19.07.2026 — media upload and RTC will fail even once the UI is
+   fixed. Add the A records per §2.
+3. **CORS**: the API's `CORS_SERVICE_MANAGERS` must include
+   `https://auth.staging.web10.app` (Portainer → stack → env vars).
+   See STAGING-RUNBOOK.md troubleshooting.
+4. **Marketing + social are not deployed at all.** The staging stack
+   only contains api/ui/rtc/minio/db. Deploying them is lane E work
+   (E3 prod / E5 dev env), not an ops fix.
+
+When one of these is fixed, update this section in the same PR.
+
+## 5. Redeploy (the normal change loop)
+
+Code changed in git and you need the box to serve it:
+
+```bash
+# Portainer way (preferred): Portainer → Stacks → web10-staging →
+#   "Pull and redeploy" / re-deploy with "Re-pull image and rebuild".
+# SSH way:
+ssh root@$VM_IP
+cd /path/to/web10-clone && git pull          # find it: docker inspect or ls /root /opt /srv
+docker compose -f ubuntu-deployment/docker-compose.staging.yml up -d --build
+```
+
+After ANY redeploy, verify (§3 C+D) and smoke-test the money path:
+open `https://auth.staging.web10.app`, sign up a throwaway account,
+log in. If you can't complete that, the deploy is NOT done.
+
+## 6. Changing DNS (Cloudflare)
+
+Use the token from `.env` (scope: DNS edit on the zone). Records for
+public services: A record, name per §2, content = the box's PUBLIC
+IP, **proxy status: DNS only**. For the future VPN-only dev env (E5):
+same, but content = the box's INTERNAL LAN IP — that record is
+intentionally useless off-VPN.
+
+```bash
+# list records (sanity check what exists):
+curl -sS -H "Authorization: Bearer $CF_API_TOKEN" \
+  "https://api.cloudflare.com/client/v4/zones?name=$CF_ZONE" # -> zone id
+curl -sS -H "Authorization: Bearer $CF_API_TOKEN" \
+  "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/dns_records?per_page=100" \
+  | python3 -m json.tool | grep -E '"name"|"content"'
+```
+
+Never create records for admin ports/panels (prime directive 1).
+
+## 7. What an ops agent may and may not do
+
+MAY (self-serve): restart containers, read any logs, redeploy stacks
+from git, edit stack env vars per a documented fix, add/repair NPM
+proxy hosts and DNS records for the public services in §2, run the
+smoke test.
+
+MAY NOT (report instead): change code to "fix" something on the box
+(code fixes go through a PR in the right lane), touch Portainer/NPM
+admin accounts, expose new surfaces, delete volumes/data, change the
+router/firewall, rotate `MINIO_PASSWORD` (coordinated change — API
+and Minio share it).
+
+## 8. OPS-LOG.md — the coordination ledger
+
+`ubuntu-deployment/OPS-LOG.md` is append-only, newest entry at top:
+
+```
+## DD.MM.YYYY HH:MM — <who> (<workspace/branch>)
+did: <exact changes — commands run, env vars set, records added>
+state: <what's green, what's still red>
+next: <what you'd do next / what you're handing off>
+```
+
+Append an entry for every session that changed the box, commit it in
+your branch. Before starting ops work, READ the top entries — someone
+may already be mid-fix on the thing you're about to touch.

--- a/ubuntu-deployment/OPS-LOG.md
+++ b/ubuntu-deployment/OPS-LOG.md
@@ -1,0 +1,23 @@
+# OPS-LOG.md — append-only ledger of changes to the staging box
+
+Newest at top. Format per AGENT-OPS.md §8. Read the top entries
+BEFORE doing ops work — someone may already be mid-fix.
+
+## 19.07.2026 — Claude (valencia, planning branch) — remote triage only, no box changes
+did: probed the fresh deploy from outside (no SSH used).
+state:
+  - GREEN: api up at https://staging.web10.app (/docs 200, openapi
+    serves); ui serves at https://auth.staging.web10.app (200).
+  - RED: auth UI is broken by construction — bundle hardcodes
+    https://api.web10.app / auth.web10.app (ui/src/interfaces/
+    authAdapter.ts, ui/src/config.ts); needs the lane-B env-
+    parameterization fix (AGENT-OPS.md §4.1). NOT fixable on box.
+  - RED: DNS missing for rtc.staging + minio.staging (NXDOMAIN) —
+    media/rtc will fail even after the UI fix (§4.2).
+  - UNKNOWN: CORS_SERVICE_MANAGERS on the api — verify it includes
+    https://auth.staging.web10.app when the UI fix lands (§4.3).
+  - NOT DEPLOYED: marketing-ui, marketing-api, web10-social (not in
+    the staging stack yet — lane E3/E5 work).
+next: (1) lane B lands the UI origin env fix + staging compose build
+args, (2) ops agent adds rtc/minio DNS records per §6, (3) redeploy
++ smoke test per §5.

--- a/ubuntu-deployment/README.md
+++ b/ubuntu-deployment/README.md
@@ -7,8 +7,15 @@ the two admin UIs.
 
 ## Files
 
+**Agents doing ops work on the box: `AGENT-OPS.md` is your file.**
+Read it fully before your first SSH — it has the connection
+procedure, the diagnosis sequence, the current known breakage, and
+the rules. Log every session in `OPS-LOG.md`.
+
 | File | Purpose |
 |------|---------|
+| `AGENT-OPS.md` | Field manual for agents operating the box (SSH, diagnose, redeploy, guardrails) |
+| `OPS-LOG.md` | Append-only ledger of box changes — read before ops, write after |
 | `prep-vm.sh` | One-shot VM prep: Docker + Portainer + NPM + shared `proxy` network |
 | `docker-compose.staging.yml` | Self-contained staging stack (prod-mode: gunicorn, built UI, no hot-reload) |
 | `docker-compose.marketing.yml` | Standalone marketing stack (marketing-ui + marketing-api) |


### PR DESCRIPTION
## What

**`design.md`** — a deep, binding UI/brand standard for every user-facing surface, plus the three parallel beautification lane items to execute it.

### The standard (design.md)
- **The bar**: D20's Kick/Twitch-grade slick, made operational as *the screenshot test* — would this screen hold in a deck between Kick and Twitch, in front of a creator, their manager, and an a16z partner?
- **Brand**: keys-on-keyring = you hold the keys. Dark-first (the only real logos are white-on-transparent), violet accent (#8b5cf6) on zinc (#09090b), restrained manifesto voice.
- **Brand assets (§3)**: canonical inventory. `logo_white.png` (lockup) and `alternative.png` (square keys mark) ARE the logos. `logo512/192.png` are the **React atom**; `ui/public/hub.png` is **Apple's App Store logo** (trademark — legal fix, not aesthetic); `home.png` is clipart. Purge list + asset debt (SVG marks, dark variants, favicons, og-image) queued.
- **Tokens (§13)**: one Tailwind v4 `@theme` block, copied verbatim per app with a sync header.
- Type (self-hosted Inter / Space Grotesk / JetBrains Mono — never Google CDN), spacing/radius/elevation, motion, component standards (shadcn idiom, Lucide-only, focus-visible everywhere), responsive rules (375px first-class), a11y, and a **UI definition of done (§12)**: PR screenshots at desktop + 375px, tokens-only colors, all states designed, data-testid preserved.

### The enforcement
CLAUDE.md + AGENTS.md now gate every UI-touching task on reading design.md first — every time.

### The work queued (parallel-safe, disjoint dirs)
- **B5** (lane B, `ui/`): level-up to standard — token migration, inline styles out, dead vendored Bulma deleted, SideBar bug fix, primitives kit, mobile shell, trademark assets replaced. Studio = the money screen.
- **D12** (lane D, `web10-social/`): the deck screenshot — wire missing @tailwindcss/vite plugin, actually load Inter, media-forward feed, composer, creator profile, story empty states, legacy eviction.
- **D13** (lane D, `marketing-ui/`): Bulma OUT (D22), dark cinematic landing, reach-gap proof section, docs polish, education-era imagery deleted, pays the shared brand-asset debt.

Conductor board refreshed: ws1–ws3 = B5/D12/D13, ws4 = **execute the E1 staging deploy** (infra merged in 1.0.60, blocked on SSH + Cloudflare creds).

decisions.md **D23** records the design-language call.

## Why
Three frontends, three styling worlds, zero shared tokens in practice, and boilerplate shipping as brand. The pitch dies on the first screenshot (D20) — this makes the fix systematic instead of another one-off reskin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)