### PR TITLE
D14: parameterize web10-social backend origins (1.0.67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+1.0.67 || 19.07.2026
+D14: web10-social backend origins parameterized — the last app-side
+deploy gate. New src/lib/origins.ts reads VITE_API_ORIGIN /
+VITE_AUTH_ORIGIN / VITE_RTC_ORIGIN at build time (prod origins as
+fallbacks, ?local=true still wins); Web10SocialAdapter + the typed
+wapi wrapper + Interface.ts's bare-username default provider all use
+it. The 15 identical hardcoded cross_origins lists collapsed into one
+that also includes the serving hostname, so a dev/prod deploy
+authorizes its own vhost without a per-env code edit. Stale
+"pending D14" notes cleared from the ecosystem compose, social
+Dockerfile, and AGENT-OPS §4.1 (origin parameterization now DONE for
+all three frontends). Verified: 195 vitest green (2 new origin
+tests), `bun run build` clean, and an arg-set build bakes the dev
+origins into the bundle (grepped the emitted JS).
+
 1.0.66 || 19.07.2026
 E3/E5 repo side: the whole ecosystem is deployable. NEW
 ubuntu-deployment/docker-compose.ecosystem.yml — ONE parameterized

--- a/marketing/web10-social/Dockerfile
+++ b/marketing/web10-social/Dockerfile
@@ -4,11 +4,9 @@ COPY package.json bun.lock* ./
 RUN bun install --frozen-lockfile || bun install
 COPY . .
 
-# Backend origins are baked at build time (vite). Passed by
-# ubuntu-deployment/docker-compose.ecosystem.yml per environment.
-# VITE_MARKETING_API is read today (ReportBug); the API/AUTH/RTC args
-# are consumed once the adapter env-read lands (lane D / D14) —
-# Web10SocialAdapter.ts still hardcodes its origins until then.
+# Backend origins are baked at build time (vite), passed by
+# ubuntu-deployment/docker-compose.ecosystem.yml per environment and
+# read in src/lib/origins.ts (prod origins are the fallback).
 ARG VITE_API_ORIGIN
 ARG VITE_AUTH_ORIGIN
 ARG VITE_RTC_ORIGIN

--- a/marketing/web10-social/src/__tests__/origins.test.ts
+++ b/marketing/web10-social/src/__tests__/origins.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { AUTH_ORIGIN, API_ORIGIN, API_HOST, RTC_ORIGIN, RTC_HOST } from '../lib/origins';
+
+// The test env sets no VITE_*_ORIGIN vars, so this pins the production
+// fallbacks — a bare build must still target prod (AGENT-OPS.md §4.1).
+describe('origins', () => {
+  it('falls back to the production origins when no build env is set', () => {
+    expect(AUTH_ORIGIN).toBe('https://auth.web10.app');
+    expect(API_ORIGIN).toBe('https://api.web10.app');
+    expect(RTC_ORIGIN).toBe('https://rtc.web10.app');
+  });
+
+  it('derives bare hosts from the origins', () => {
+    expect(API_HOST).toBe('api.web10.app');
+    expect(RTC_HOST).toBe('rtc.web10.app');
+  });
+});

--- a/marketing/web10-social/src/data/wapi.ts
+++ b/marketing/web10-social/src/data/wapi.ts
@@ -1,4 +1,5 @@
 import { wapiInit } from 'web10-npm';
+import { AUTH_ORIGIN, RTC_HOST } from '../lib/origins';
 
 // Thin typed wrapper around the legacy wapi.js SDK.
 // All CRUD operations return the raw record body (no axios envelope).
@@ -76,8 +77,8 @@ export function createWapiWrapper(authUrl?: string, rtcServer?: string): WapiWra
 
   const queryParameters = new URLSearchParams(window.location.search);
   const local = queryParameters.get('local');
-  const resolvedAuthUrl = authUrl ?? (local ? 'http://auth.localhost' : 'https://auth.web10.app');
-  const resolvedRtcServer = rtcServer ?? (local ? 'rtc.localhost' : 'rtc.web10.app');
+  const resolvedAuthUrl = authUrl ?? (local ? 'http://auth.localhost' : AUTH_ORIGIN);
+  const resolvedRtcServer = rtcServer ?? (local ? 'rtc.localhost' : RTC_HOST);
 
   const wapi = wapiInit(resolvedAuthUrl, undefined, resolvedRtcServer);
 

--- a/marketing/web10-social/src/interfaces/Interface.ts
+++ b/marketing/web10-social/src/interfaces/Interface.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import type { AppInterface, Bulletin, Contact, CrmColor, CrmContact, CrmNote, Identity, MailMessage, Message, Mode, Post, Theme } from '../types';
 import web10SocialAdapterInit from './Web10SocialAdapter';
+import { API_HOST } from '../lib/origins';
 import defaultIdentity from '../mocks/defaultIdentity';
 import { onlySettled, sortSettled } from './settledHelpers';
 
@@ -109,7 +110,8 @@ const useInterface = (): AppInterface => {
 
   const runSearch = (query: string) => {
     if (mode === 'contacts') {
-      const web10 = query.includes('/') ? query : `api.web10.app/${query}`;
+      // bare usernames default to this deployment's own provider
+      const web10 = query.includes('/') ? query : `${API_HOST}/${query}`;
       const [provider, user] = web10.split('/');
       if (!socialAdapter) return;
       socialAdapter

--- a/marketing/web10-social/src/interfaces/Web10SocialAdapter.ts
+++ b/marketing/web10-social/src/interfaces/Web10SocialAdapter.ts
@@ -1,4 +1,5 @@
 import { wapiInit } from 'web10-npm';
+import { AUTH_ORIGIN, RTC_HOST } from '../lib/origins';
 import type { Contact, Identity, Message, Post } from '../types';
 import contactIco from '../assets/images/Contact.png';
 import {
@@ -167,15 +168,15 @@ const web10SocialAdapterInit = (): Web10SocialAdapter => {
   const local = queryParameters.get('local');
 
   const wapi = wapiInit(
-    local ? 'http://auth.localhost' : 'https://auth.web10.app',
+    local ? 'http://auth.localhost' : AUTH_ORIGIN,
     undefined,
-    local ? 'rtc.localhost' : 'rtc.web10.app'
+    local ? 'rtc.localhost' : RTC_HOST
   ) as WapiInstance;
 
   // Initialize the typed wapi wrapper for the data layer
   const wapiWrapper = createWapiWrapper(
-    local ? 'http://auth.localhost' : 'https://auth.web10.app',
-    local ? 'rtc.localhost' : 'rtc.web10.app',
+    local ? 'http://auth.localhost' : AUTH_ORIGIN,
+    local ? 'rtc.localhost' : RTC_HOST,
   );
 
   const adapter: Partial<Web10SocialAdapter> & WapiInstance = { ...wapi };
@@ -184,76 +185,83 @@ const web10SocialAdapterInit = (): Web10SocialAdapter => {
     return adapter.openAuthPortal?.() ?? Promise.resolve();
   };
 
+  // Sites allowed to act on these services. Including the host the app
+  // is actually served from means a dev/prod deploy authorizes itself
+  // without this list needing a code edit per environment.
+  const crossOrigins = Array.from(
+    new Set(['localhost', 'web10social.netlify.app', 'social.web10.app', window.location.hostname]),
+  );
+
   const sirs = [
     {
       service: 'identity',
-      cross_origins: ['localhost', 'web10social.netlify.app', 'social.web10.app'],
+      cross_origins: crossOrigins,
       whitelist: [{ provider: '.*', username: '.*', read: true }],
     },
     {
       service: 'bulletin',
-      cross_origins: ['localhost', 'web10social.netlify.app', 'social.web10.app'],
+      cross_origins: crossOrigins,
       provider: '.*',
       username: '.*',
       read: true,
     },
     {
       service: 'contact-addresses',
-      cross_origins: ['localhost', 'web10social.netlify.app', 'social.web10.app'],
+      cross_origins: crossOrigins,
     },
     {
       service: 'message-inbox',
-      cross_origins: ['localhost', 'web10social.netlify.app', 'social.web10.app'],
+      cross_origins: crossOrigins,
       whitelist: [{ provider: '.*', username: '.*', create: true }],
     },
     {
       service: 'message-outbox',
-      cross_origins: ['localhost', 'web10social.netlify.app', 'social.web10.app'],
+      cross_origins: crossOrigins,
     },
     {
       service: 'posts',
-      cross_origins: ['localhost', 'web10social.netlify.app', 'social.web10.app'],
+      cross_origins: crossOrigins,
       whitelist: [{ provider: '.*', username: '.*', read: true }],
     },
     {
       service: 'crm-contacts',
-      cross_origins: ['localhost', 'web10social.netlify.app', 'social.web10.app'],
+      cross_origins: crossOrigins,
     },
     {
       service: 'crm-notes',
-      cross_origins: ['localhost', 'web10social.netlify.app', 'social.web10.app'],
+      cross_origins: crossOrigins,
     },
     {
       service: 'mail',
-      cross_origins: ['localhost', 'web10social.netlify.app', 'social.web10.app'],
+      cross_origins: crossOrigins,
       whitelist: [{ username: '.*', provider: '.*', create: true }],
     },
     // ── D4: conventions-schema services ──────────────────────────────
     {
       service: 'profile',
-      cross_origins: ['localhost', 'web10social.netlify.app', 'social.web10.app'],
+      cross_origins: crossOrigins,
       whitelist: [{ provider: '.*', username: '.*', read: true }],
     },
     {
       service: 'contacts',
-      cross_origins: ['localhost', 'web10social.netlify.app', 'social.web10.app'],
+      cross_origins: crossOrigins,
     },
     {
       service: 'inbox',
-      cross_origins: ['localhost', 'web10social.netlify.app', 'social.web10.app'],
+      cross_origins: crossOrigins,
       whitelist: [{ provider: '.*', username: '.*', create: true }],
     },
     {
       service: 'comments',
-      cross_origins: ['localhost', 'web10social.netlify.app', 'social.web10.app'],
+      cross_origins: crossOrigins,
     },
     {
       service: 'reactions',
-      cross_origins: ['localhost', 'web10social.netlify.app', 'social.web10.app'],
+      cross_origins: crossOrigins,
     },
     {
       service: 'media',
-      cross_origins: ['localhost', 'web10social.netlify.app', 'social.web10.app'],
+      cross_origins: crossOrigins,
     },
   ];
   adapter.SMROnReady(sirs, []);

--- a/marketing/web10-social/src/lib/origins.ts
+++ b/marketing/web10-social/src/lib/origins.ts
@@ -1,0 +1,17 @@
+// Backend origins, baked in at build time by vite. Deployed builds get
+// these from the Dockerfile ARGs that ubuntu-deployment/
+// docker-compose.ecosystem.yml passes per environment (see
+// AGENT-OPS.md §4.1); the production origins are the fallback so a
+// bare `vite build` still targets prod. The `?local=true` dev-mode
+// switch in the adapters overrides all of this with *.localhost.
+const env = import.meta.env;
+
+export const AUTH_ORIGIN: string = env?.VITE_AUTH_ORIGIN || 'https://auth.web10.app';
+
+export const API_ORIGIN: string = env?.VITE_API_ORIGIN || 'https://api.web10.app';
+// web10 addresses are written provider-host/username
+export const API_HOST: string = API_ORIGIN.replace(/^https?:\/\//, '');
+
+export const RTC_ORIGIN: string = env?.VITE_RTC_ORIGIN || 'https://rtc.web10.app';
+// wapiInit takes the rtc endpoint as a bare host
+export const RTC_HOST: string = RTC_ORIGIN.replace(/^https?:\/\//, '');

--- a/parallel execution.txt
+++ b/parallel execution.txt
@@ -264,17 +264,14 @@ LANE D — docs / apps / mobile (owns: mobile/**, marketing/, examples/
       variants still open, no tracing tool in-environment. flagged:
       design.md §3's alternative.png does not contain the keys mark —
       needs a design.md correction (not done here, out of lane).
-  [ ] D14. parameterize web10-social's backend origins (small,
-      gates the dev/prod social deploys the same way B5's origins
-      fix gates the auth ui): Web10SocialAdapter.ts hardcodes
-      auth.web10.app/rtc.web10.app for non-local builds. read
-      VITE_API_ORIGIN / VITE_AUTH_ORIGIN / VITE_RTC_ORIGIN from
-      import.meta.env with the current values as fallbacks — the
-      Dockerfile ARGs already exist and
-      ubuntu-deployment/docker-compose.ecosystem.yml already passes
-      them (see AGENT-OPS.md §4.1). acceptance: an env rebuild
-      points social at dev/prod domains without a code edit; tests
-      stay green.
+  [✓ 1.0.67] D14. parameterize web10-social's backend origins:
+      src/lib/origins.ts reads VITE_API_ORIGIN / VITE_AUTH_ORIGIN /
+      VITE_RTC_ORIGIN with the prod values as fallbacks; adapter +
+      wapi wrapper + bare-username default provider use it, and the
+      15 repeated cross_origins lists collapsed to one that also
+      includes the serving hostname (a deploy authorizes itself).
+      verified: env-arg build bakes dev origins into the bundle,
+      195 tests green.
 
 
 

--- a/ubuntu-deployment/AGENT-OPS.md
+++ b/ubuntu-deployment/AGENT-OPS.md
@@ -160,20 +160,15 @@ Symptom → likely cause (check in this order, stop at first hit):
 
 Read this before re-diagnosing; these are already understood:
 
-1. **Frontend origin parameterization — ui DONE, social PENDING.**
-   The auth UI's fix MERGED (B5, 1.0.65): `ui/Dockerfile` declares
-   `REACT_APP_API_ORIGIN` / `REACT_APP_AUTH_ORIGIN` /
-   `REACT_APP_RTC_ORIGIN` / `REACT_APP_DEFAULT_API` ARGs and
-   `docker-compose.ecosystem.yml` passes them — a fresh stack build
-   serves the right origins per env; prod values remain the
-   fallback when args are empty. web10-social's adapter
-   (`Web10SocialAdapter.ts`) still hardcodes `auth.web10.app` /
-   `rtc.web10.app` for non-local builds — that's lane D item D14
-   (its Dockerfile `VITE_*` ARGs + compose args already exist).
-   Until D14 merges, the social app in dev talks to prod's
-   auth/rtc. An ops agent CANNOT fix this on the box — do not try;
-   rebuilding the same code reproduces the same bundle. When D14
-   merges: redeploy stacks with rebuild.
+1. **Frontend origin parameterization — DONE for all three
+   frontends.** ui (B5, 1.0.65: `REACT_APP_*` ARGs), web10-social
+   (D14, 1.0.67: `VITE_*` ARGs read in `src/lib/origins.ts`) and
+   marketing-ui (`VITE_*` ARGs) all take their backend origins from
+   build args that `docker-compose.ecosystem.yml` passes per env;
+   the production origins remain the fallback when args are empty.
+   A fresh stack BUILD (not just restart) serves the right origins.
+   The legacy staging deployment predates all of this — its bundles
+   stay wrong until decommissioned (issue #2).
 2. **The live box runs the LEGACY deployment, due for teardown.**
    What's there today: a root-managed **Caddy** container holding
    80/443 (config `/opt/caddy/Caddyfile` — WORLD-READABLE with a

--- a/ubuntu-deployment/docker-compose.ecosystem.yml
+++ b/ubuntu-deployment/docker-compose.ecosystem.yml
@@ -32,9 +32,8 @@
 #
 # Frontends bake their backend origins at BUILD time (vite). The
 # build args below are the lane-E side of the contract; the app-side
-# ARG/env plumbing is DONE for ui (B5, REACT_APP_* names) and
-# marketing-ui (VITE_* names); web10-social's adapter env-read is
-# still open (lane D / D14 — its Dockerfile ARGs already exist).
+# ARG/env plumbing is DONE for all three frontends: ui (B5,
+# REACT_APP_* names), marketing-ui and web10-social (VITE_* names).
 # Changing an origin means re-BUILDING the stack, not just restarting.
 
 services:
@@ -148,8 +147,6 @@ services:
       context: ../marketing/web10-social
       dockerfile: Dockerfile
       args:
-        # adapter env-read is lane D (D14); VITE_MARKETING_API is
-        # consumed today (ReportBug).
         VITE_API_ORIGIN: ${API_ORIGIN}
         VITE_AUTH_ORIGIN: ${AUTH_ORIGIN}
         VITE_RTC_ORIGIN: ${RTC_ORIGIN}


### PR DESCRIPTION
## What

The last app-side deployment gate. web10-social's adapter hardcoded `auth.web10.app` / `rtc.web10.app` for any non-local build, so a dev-env deploy would have talked to prod's auth. Now:

- **`src/lib/origins.ts`** — reads `VITE_API_ORIGIN` / `VITE_AUTH_ORIGIN` / `VITE_RTC_ORIGIN` at build time; production origins are the fallback (a bare `vite build` is unchanged); the `?local=true` dev switch still overrides everything.
- `Web10SocialAdapter.ts`, the typed wapi wrapper (`data/wapi.ts`), and `Interface.ts`'s bare-username default provider all consume it.
- The **15 identical `cross_origins` literals** collapsed into one shared list that also includes `window.location.hostname` — a deployed vhost (e.g. `social.dev.web10.app`) authorizes itself without per-env code edits.
- Cleared the stale "pending D14" notes in `docker-compose.ecosystem.yml`, the social Dockerfile, and AGENT-OPS §4.1 — origin parameterization is now DONE for all three frontends (ui = B5's `REACT_APP_*`, social + marketing-ui = `VITE_*`).

No visual changes (no colors/fonts/layout touched — design.md §12 screenshot criteria not applicable to this diff).

## Verification

- 195 vitest green (2 new tests pin the prod fallbacks + host derivation)
- `bun run build` (tsc + vite) clean
- Arg-set build (`VITE_AUTH_ORIGIN=https://auth.dev.web10.app …`) verified to bake the dev origins into the emitted bundle

## Bookkeeping

CHANGELOG 1.0.67; lane D item D14 ticked in parallel execution.txt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)