### PR TITLE
plan: A7 detail — legacy mongo is host-native + surface total-users/apps (1.0.69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+1.0.70 || 19.07.2026
+PRIORITY ZERO declared at the top of plan.txt (operator): the
+deployed product must WORK AT A BASELINE — baseline fixes outrank
+polish; the chain is A7 (real data) → B6 (auth works) → docs
+reachable → D16 (real store). Conductor board reordered around it.
+Live-prod fix: /docs/* 404'd (e.g. /docs/protocol-spec) — marketing-
+ui's nginx /docs/ alias block shadowed the SPA fallback; now
+try_files → index.html (D16.1). Recovered-work capture: the old
+sharp dev docs are NOT lost — two runnable demo apps (hello/,
+notes/) + sdk.md/sdk.pdf live at git `82667060^:auth/public/docs/`;
+queued D17 to restore them into marketing-ui docs + revive the "make
+your own web10 app with the web10 CLI" store CTA (the CLI exists at
+marketing/web10-cli/ but is invisible). Queued D18+E7: document/link
+the web10 sdk (github packages shows 4, none the sdk) and confirm/
+extend the npm publish flow. Queued E8 (parked): mobile encryptor →
+Apple/Google app stores via expo eas, post-M0.
+
 1.0.69 || 19.07.2026
 Plan refinement (A7): the legacy production MongoDB (~208 real users)
 runs NATIVELY on the ubuntu host, not in Docker — captured in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ plan.txt + the lane file so whoever wires it reaches it via the host
 gateway / box LAN ip (not a compose service name) and keeps it
 as-is. Added the explicit deliverable of surfacing total-users +
 total-apps counts from the real data, like the original web10 (feeds
-the D16 app-store stats).
+the D16 app-store stats). Recorded decisions.md D25 — DB backend is per-env config, not baked: dev = all-in-one containerized FerretDB (docker compose up works out of the box), prod = bootstrap on the host mongo via the db_url config item (real 208-user data, zero migration risk), with an eventual mongodump->container migration so prod is also self-contained + SSPL-clean. Corollary: the WordPress-style first-run panel already largely exists (setup wizard + NodeConfig with nice defaults); noted the gap that ConfigUpdate doesn't expose db_url yet (kept a guarded action by design) — plan.txt setup section + a new panel item updated.
 
 1.0.68 || 19.07.2026
 E3 + E5 EXECUTED — the whole ecosystem is LIVE on the box. Both

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+1.0.69 || 19.07.2026
+Plan refinement (A7): the legacy production MongoDB (~208 real users)
+runs NATIVELY on the ubuntu host, not in Docker — captured in
+plan.txt + the lane file so whoever wires it reaches it via the host
+gateway / box LAN ip (not a compose service name) and keeps it
+as-is. Added the explicit deliverable of surfacing total-users +
+total-apps counts from the real data, like the original web10 (feeds
+the D16 app-store stats).
+
 1.0.68 || 19.07.2026
 E3 + E5 EXECUTED — the whole ecosystem is LIVE on the box. Both
 environments run as Portainer git-backed stacks (branch dev, 5-min

--- a/decisions.md
+++ b/decisions.md
@@ -35,15 +35,28 @@ never hardcoded:
   container (plan.txt already lists the mongo→ferretdb migration),
   then flip `db_url`. Data-only, no app change.
 
+Where config lives: IN THE DB, WordPress-style (wp_options in mysql).
+`web10.config` holds the node config doc (`_id:"node"`, `{body:{...}}`),
+`web10.jwt_keys` holds the signing keys — `api/app/services/config.py`.
+Not a flat file on the data volume (older plan wording said "data
+volume"; the real store is the db collection).
+
+The ONE exception, by necessity: **`db_url` itself can't live in the
+db** — chicken-and-egg, you need the connection string to reach the db
+that would hold it. So `db_url` is bootstrapped from env/stack config
+(compose `DB_URL` → `settings.DB_URL` → the pymongo client), and
+everything else (provider, policy, S3, stripe/twilio, branding) lives
+in `web10.config` and is editable in the panel. This is exactly why
+`ConfigUpdate` omits `db_url`/`db_name` and `SetupRequest` takes them
+as a bootstrap input — it's architecturally correct, not just a
+guardedness choice (and it happens to also be the safe default, since
+repointing a live node's DB swaps its whole data identity).
+
 Corollary — the WordPress-style first-run: a node boots into a setup
 wizard + config panel where an operator CAN set everything (provider,
 DB, S3, policy, stripe/twilio, branding — `NodeConfig` already models
 all of it) but sane DEFAULTS mean `docker compose up` just works for a
-dev. Caveat/gap: `ConfigUpdate` (the post-setup panel model) does NOT
-currently expose `db_url`/`db_name` — deliberately keep repointing a
-live node's DB a guarded action (it swaps the node's whole data
-identity; WordPress makes you edit wp-config, not click a button, for
-the same reason), not a casual toggle.
+dev.
 
 ### D24 — design.md §3 correction: `web10-social/public/alternative.png` was never the keys mark [decided]
 D12 (web10-social level-up) and D13 (marketing-ui rebuild) independently

--- a/decisions.md
+++ b/decisions.md
@@ -9,6 +9,42 @@ Status legend: [decided] intent set · [in-progress] · [open] still debating.
 
 ---
 
+### D25 — DB backend is per-env config, not baked; prod bootstraps on the host mongo [decided]
+The node's DB is a config item (`db_url`/`db_name` in `NodeConfig`,
+default `mongodb://ferretdb:27017`), and the backend is wire-protocol
+compatible either way (documentdb.py speaks to real Mongo OR
+FerretDB/DocumentDB — D3). So the DB hookup is chosen PER ENVIRONMENT,
+never hardcoded:
+- **dev = all-in-one.** The containerized FerretDB/DocumentDB inside
+  the stack. Self-contained: one Portainer stack, its own volume,
+  clean wipe+reseed (pairs with the C6 persona seed), dev/prod
+  parity for everything except the data source. `docker compose up`
+  works out of the box on the defaults — the local dev experience.
+- **prod = bootstrap on the existing HOST mongo (A7).** It already
+  holds the ~208 real users + the original app-store apps and runs
+  natively on the box (not a container). Point prod's `db_url` at it
+  (host gateway / LAN ip) to go live on real data with zero migration
+  risk. This is a config change, not code.
+- **eventual: migrate prod into the containerized documentdb** so
+  prod is ALSO self-contained + license-clean. Two reasons it
+  shouldn't stay on host mongo forever: (1) SSPL — the whole point of
+  D3 was that MongoDB's license is a problem for the node-operator
+  model; the flagship prod node running real Mongo re-introduces it;
+  (2) the host mongo is outside the stack lifecycle (separate backup,
+  no compose record). Path: `mongodump` host → `mongorestore` into the
+  container (plan.txt already lists the mongo→ferretdb migration),
+  then flip `db_url`. Data-only, no app change.
+
+Corollary — the WordPress-style first-run: a node boots into a setup
+wizard + config panel where an operator CAN set everything (provider,
+DB, S3, policy, stripe/twilio, branding — `NodeConfig` already models
+all of it) but sane DEFAULTS mean `docker compose up` just works for a
+dev. Caveat/gap: `ConfigUpdate` (the post-setup panel model) does NOT
+currently expose `db_url`/`db_name` — deliberately keep repointing a
+live node's DB a guarded action (it swaps the node's whole data
+identity; WordPress makes you edit wp-config, not click a button, for
+the same reason), not a casual toggle.
+
 ### D24 — design.md §3 correction: `web10-social/public/alternative.png` was never the keys mark [decided]
 D12 (web10-social level-up) and D13 (marketing-ui rebuild) independently
 discovered the same bug while paying the asset debt design.md §3 queued:

--- a/marketing/marketing-ui/nginx.conf
+++ b/marketing/marketing-ui/nginx.conf
@@ -8,7 +8,12 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
+    # Docs are client-side routes (/docs/<slug>) that FETCH the raw
+    # /docs/<slug>.md. Serve real files (the .md, schemas/) statically,
+    # but fall back to index.html for the client-side route — without
+    # this fallback, /docs/protocol-spec 404s (no such file) instead of
+    # letting react-router render it.
     location /docs/ {
-        alias /usr/share/nginx/html/docs/;
+        try_files $uri $uri/ /index.html;
     }
 }

--- a/parallel execution.txt
+++ b/parallel execution.txt
@@ -97,19 +97,28 @@ LANE A — api / backend        (owns: api/**, docker-compose, settings)
   [ ] A7. connect the node to the EXISTING production MongoDB on the
       ubuntu box (~208 real users + historical data + registered
       apps from the original web10) instead of the empty ferretdb
-      the stacks ship with. we already speak the mongo wire protocol
+      the stacks ship with. IMPORTANT (operator, 19.07): this mongo
+      runs NATIVELY on the host — it is NOT a docker container and
+      that's fine, leave it as-is. so the node's containers reach it
+      NOT by a compose service name but via the host: DB_URL points
+      at the host gateway (add `host.docker.internal:host-gateway`
+      to the api service's extra_hosts, or use the box LAN ip
+      192.168.8.25) : mongo's port (27017), assuming it binds a
+      reachable interface — confirm the bind + any auth creds, keep
+      them in the box .env, coordinate the compose var/extra_hosts
+      with lane E. we already speak the mongo wire protocol
       (documentdb.py), so this is mainly config + verification, not
-      a rewrite: point DB_URL/DB at the real mongo (a stack env var,
-      keep it in the box .env, coordinate the compose var with
-      lane E), confirm the {service,body} + star-record shape
+      a rewrite: confirm the {service,body} + star-record shape
       matches what our code expects (older records may predate
       to_gui/to_db conventions — write a read-only audit first,
       then a migration/adapter if the shape drifted), and make sure
       star protection + scoped queries behave against real data.
       gate: do NOT point PROD at the real mongo until a login works
       against a COPY in dev (dump/restore into web10-dev's db, or a
-      read-only replica). deliverable: dev logs in as a real
-      historical user, and the honest report of any shape drift.
+      read-only connection). deliverable: dev logs in as a real
+      historical user; total-users + total-apps counts computed from
+      the real data and surfaced like the original web10 (feeds the
+      D16 app-store stats); and the honest report of any shape drift.
       unblocks B6 (real login to test against) and D16 (real apps).
 
 LANE B — ui / frontend        (owns: auth2->ui/**, auth/**)

--- a/parallel execution.txt
+++ b/parallel execution.txt
@@ -349,7 +349,43 @@ LANE D — docs / apps / mobile (owns: mobile/**, marketing/, examples/
       restoring it IS the "looks like a real company" goal, not a
       distraction. record this reversal in decisions.md when D16
       lands.
-
+  [✓ 1.0.70] D16.1. fix the /docs/* 404 — marketing-ui nginx served
+      /docs/ via an alias block that shadowed the SPA fallback, so
+      /docs/protocol-spec 404'd (it's a client-side route that
+      fetches /docs/<slug>.md). added try_files ... /index.html to
+      the /docs/ location. (small live-prod fix done alongside the
+      planning.)
+  [ ] D17. RESTORE THE DEV DOCS (operator, 19.07 — "docs are lacking,
+      were sharp before with demo apps"). NOT LOST — recoverable from
+      git: the old rich docs lived in auth/public/docs/ and were
+      removed in 82667060 ("moving of docs to separate endpoint").
+      recover from `82667060^:auth/public/docs/`:
+      - hello/ and notes/ — the two live DEMO APPS (index.html +
+        script.js each) that made the docs sharp.
+      - sdk.md + sdk.pdf — the SDK guide.
+      bring these into marketing-ui's docs (the new home,
+      marketing/marketing-ui/public/docs + src/pages/Docs.tsx), on
+      the design.md standard, as runnable demo apps + an SDK page.
+      also: the old app store had a "make your own web10 app with the
+      web10 CLI" call-to-action (old AppStore.js, commit cc548b68) —
+      the CLI still exists (marketing/web10-cli/) but is invisible;
+      restore that CTA (ties to D16's "Build on web10" card) and
+      write a CLI quickstart doc. acceptance: /docs shows demo apps +
+      SDK + CLI quickstart; the app store links devs to "build your
+      own". gate: none (docs), but the SDK doc should reflect C2's
+      typed sdk once it lands (don't teach legacy wapi as the future
+      — see C2/C3.5 parking note).
+  [ ] D18. DOCUMENT + LINK THE WEB10 SDK (operator, 19.07: GitHub
+      shows 4 built packages, none is the SDK; docs never mention it
+      or link to it). the sdk lives in sdk/ (web10-npm) and cd.yml
+      already publishes it to npm on a v* tag. work: (1) add an SDK
+      section/link to the docs + a badge/link from marketing-ui and
+      the README; (2) confirm the npm publish actually fires and the
+      package is public + discoverable; (3) plan.txt CI/CD note:
+      publish the sdk to npm whenever it changes (today it's
+      tag-gated — decide if a version-bump-on-merge should trigger
+      it). coordinate the doc voice with C2 (typed sdk) so we link
+      the RIGHT sdk. small; not M0-gating but cheap credibility.
 
 
 LANE E — infrastructure / deployment (owns: proxmox provisioning,
@@ -418,6 +454,19 @@ LANE E — infrastructure / deployment (owns: proxmox provisioning,
       per-env build-on-box stays correct until a runtime-config
       refactor; the api/rtc images are env-agnostic and could
       switch to pulls anytime.
+  [ ] E7. SDK npm publish flow (with C2/D18): cd.yml publishes sdk/
+      to npm on a v* tag today — confirm it fires + the package is
+      public, and decide whether a version bump on merge to dev/main
+      should auto-publish so the sdk stays fresh (operator, 19.07:
+      "publish the web10 sdk to npm if it updates"). small.
+  [ ] E8. MOBILE ENCRYPTOR → app stores (future, operator 19.07 —
+      "just dont want to lose track"): mobile/encryptor is an Expo
+      app (the phone-as-keychain seed, D3/D6). when it's ready,
+      deploying to the Apple App Store + Google Play becomes real
+      work: expo eas build + submit pipeline, store listings,
+      signing certs/provisioning, review. NOT now (post-M0, gated on
+      the encryptor actually doing e2e key management) — parked here
+      so it's on the board, not lost.
 
 WHAT MUST STAY SEQUENTIAL (don't try to parallelize these)
 ----------------------------------------------------------
@@ -448,11 +497,16 @@ M3 "the network"         = encryption integration (A rtc + C2 sdk
 CURRENT CONDUCTOR BOARD (as of 19.07.2026 — keep this section fresh)
 --------------------------------------------------------------------
 we are in timeline.md WEEK 0/1 — the M0 sprint (video by ~aug 17).
-the data layers, studio M0 slice, e2e harness, and deploy infra are
-all merged. THIS WEEK'S PUSH: the design level-up (design.md landed
-as the binding ui standard — every ui agent reads it first) + getting
-dev and prod actually deployed. the three beautify items are
-parallel-safe (disjoint directories).
+the beautify wave (B5/D12/D13/D14) and the FULL DEPLOYMENT (E3/E5 —
+both envs live behind NPM with TLS + GitOps polling) are merged.
+PRIORITY ZERO (plan.txt, top): the deployed product must WORK AT A
+BASELINE — auth is broken, docs 404'd (fixed in D16.1), the node
+points at an empty db. baseline fixes outrank polish, in this order:
+  ws-A: A7 connect the real host mongo (unblocks everything)
+  ws-B: B6 authenticator revamp (login must complete; playwright
+        guard) — logo + obvious breakage can start before A7
+  ws-C: C6 e2e deep sweep (now can also run against dev)
+  ws-D: D17 restore the dev docs + D16 real app store (after A7)
 
   ws1: [✓ 1.0.65] B5 level-up ui/ to design.md (lane B — ui/**) — merged
   ws2: [✓ 1.0.64] D12 level-up web10-social to design.md (lane D —

--- a/plan.txt
+++ b/plan.txt
@@ -320,14 +320,19 @@ a DB_URL change, not a rewrite.
 [ ] CONNECT THE REAL DATA (A7, added 19.07.2026): the ubuntu box
     already runs the ORIGINAL production MongoDB — ~208 real users,
     historical usage stats, and the registered apps from web10's
-    live app-store era. the new stacks ship an empty ferretdb; point
-    the node at the real mongo instead of starting from zero. we
-    already speak the wire protocol, so it's config + verification
-    (shape audit for pre-convention records, star protection against
-    real data), NOT a rewrite. gate: prove a real historical user
-    can log in against a COPY in dev before pointing prod at it.
-    this is the data foundation for the auth revamp (B6) and the
-    app-store restoration (D16) below.
+    live app-store era. it runs NATIVELY on the host (not a docker
+    container — leave it that way), so the node's containers reach it
+    via the host gateway / box LAN ip, not a compose service name.
+    the new stacks ship an empty ferretdb; point the node at the real
+    mongo instead of starting from zero. we already speak the wire
+    protocol, so it's config + verification (shape audit for pre-
+    convention records, star protection against real data), NOT a
+    rewrite. gate: prove a real historical user can log in against a
+    COPY in dev before pointing prod at it. deliverable also includes
+    the total-users + total-apps counts surfaced like the original
+    web10 (the numbers that made it feel alive). this is the data
+    foundation for the auth revamp (B6) and the app-store
+    restoration (D16) below.
 
 
 PHASE 2 — ui (finish auth2, rename, migrate)

--- a/plan.txt
+++ b/plan.txt
@@ -510,13 +510,15 @@ ui side (lives in the ui, phase 2 dependency):
     already models all of it) — but sane DEFAULTS mean `docker
     compose up` just works for a dev out of the box (db_url ->
     containerized ferretdb, minio, open signup). the SetupRequest
-    defaults already do this; the post-setup ConfigUpdate panel does
-    NOT yet expose db_url/db_name — adding it makes "change the DB
-    hookup anytime like wordpress" real, but keep it a GUARDED action
-    (repointing a live node's DB swaps its whole data identity — wp
-    makes you edit wp-config, not click a button, for the same
-    reason). pairs with B6 (the panel/auth ui must actually work +
-    look like design.md).
+    defaults already do this. config is stored IN THE DB
+    (web10.config collection, wordpress-wp_options-style — already
+    built, api/app/services/config.py), NOT a flat file. the one
+    field that can't be panel-editable is db_url itself (chicken-and-
+    egg: you need it to reach the db that stores config), so it stays
+    a bootstrap/stack-env input — that's WHY ConfigUpdate omits it,
+    correctly. everything else is db-backed + panel-editable. pairs
+    with B6 (the panel/auth ui must actually work + look like
+    design.md).
 
 node policy (anti-abuse is the NODE'S call, not the protocol's):
 [ ] phone-required signup becomes a policy toggle, not a hardcode.

--- a/plan.txt
+++ b/plan.txt
@@ -1,6 +1,19 @@
 web10 plan
 ==========
 
+PRIORITY ZERO (operator, 19.07.2026): MAKE IT WORK AT A BASELINE.
+it is embarrassing that the deployed product does not work right
+now — the authenticator is broken (login doesn't complete, the logo
+renders broken), the docs 404, the app store is hollow, and the live
+node points at an empty database instead of the 208 real users.
+polish, beautification, new features, and docs prose all rank BELOW
+"a person can sign up, log in, use the apps, and read the docs
+without hitting something broken." when choosing between a shiny
+addition and a baseline fix, take the baseline fix. the current
+baseline chain, in order: A7 (real data) → B6 (auth actually works)
+→ D16.1/D17 (docs reachable) → D16 (store shows real apps). the
+C5/C6 e2e suite is the referee for "works."
+
 the thesis (why this plan):
 - THIS IS A PRODUCT FOR INFLUENCERS. the proposition is OWNERSHIP ON
   THE INTERNET: own your node, your brand, your domain, your audience
@@ -484,6 +497,26 @@ the original data changes what "done" looks like for these):
     — that assumed an empty catalog; with 208 real users and real
     apps reconnected, restoring the store IS the "real company"
     goal. log the reversal in decisions.md when it lands.
+[✓ 1.0.70] docs 404 fix (lane D, D16.1): /docs/protocol-spec 404'd
+    live — marketing-ui's nginx /docs/ alias block shadowed the SPA
+    fallback. try_files → index.html added.
+[ ] RESTORE THE DEV DOCS (lane D, item D17): the old sharp docs —
+    two runnable demo apps (hello/, notes/) + sdk.md/sdk.pdf — are
+    NOT lost; they live in git at `82667060^:auth/public/docs/`.
+    bring them into marketing-ui's docs on the design.md standard,
+    and restore the app store's "make your own web10 app with the
+    web10 CLI" call-to-action (the CLI still exists at
+    marketing/web10-cli/ but is invisible) + a CLI quickstart.
+    don't teach legacy wapi as the future — align with C2.
+[ ] SDK visibility + publish flow (lane D item D18 + lane E item
+    E7): github shows 4 packages, none is the sdk; docs never link
+    it. document + link the sdk everywhere it should be, confirm
+    cd.yml's npm publish fires (today tag-gated; decide if updates
+    should auto-publish).
+[ ] mobile encryptor → app stores (lane E item E8, parked): expo
+    eas build/submit, listings, signing. post-M0, gated on the
+    encryptor doing real e2e key management — on the board so it
+    isn't lost.
 
 
 PHASE 3 — setup wizard (the missing piece)

--- a/plan.txt
+++ b/plan.txt
@@ -504,6 +504,19 @@ ui side (lives in the ui, phase 2 dependency):
 [✓] /setup wizard screens: welcome -> node identity -> admin account ->
     (optional) payments/sms -> done, you're on your node
 [ ] setup only reachable in setup mode, 404s forever after
+[ ] the WORDPRESS-STYLE config panel (operator direction, 19.07;
+    D25): first run is a panel where you CAN set everything —
+    provider, DB, S3, policy, stripe/twilio, branding (NodeConfig
+    already models all of it) — but sane DEFAULTS mean `docker
+    compose up` just works for a dev out of the box (db_url ->
+    containerized ferretdb, minio, open signup). the SetupRequest
+    defaults already do this; the post-setup ConfigUpdate panel does
+    NOT yet expose db_url/db_name — adding it makes "change the DB
+    hookup anytime like wordpress" real, but keep it a GUARDED action
+    (repointing a live node's DB swaps its whole data identity — wp
+    makes you edit wp-config, not click a button, for the same
+    reason). pairs with B6 (the panel/auth ui must actually work +
+    look like design.md).
 
 node policy (anti-abuse is the NODE'S call, not the protocol's):
 [ ] phone-required signup becomes a policy toggle, not a hardcode.


### PR DESCRIPTION
Doc-only refinement of the A7 plan item, per operator clarification: the legacy production MongoDB (~208 real users, historical stats, original registered apps) runs **natively on the ubuntu host, not in Docker** — and should stay that way.

- Captured that the node's containers reach it via the host gateway (`host.docker.internal:host-gateway`) or the box LAN IP `:27017`, **not** a compose service name — so whoever picks up A7 doesn't assume a container alias.
- Added the explicit deliverable: compute + surface **total-users** and **total-apps** counts from the real data, like the original web10 (feeds the D16 app-store stats).

plan.txt + parallel execution.txt updated; CHANGELOG 1.0.69.

🤖 Generated with [Claude Code](https://claude.com/claude-code)