### PR TITLE
queue E9: deployment status page — version/commit/date/PR at one URL per env (1.0.71)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 1.0.71 || 19.07.2026
-Queued E9 (deploy → github feedback loop): Portainer CE has no
-outbound "I deployed" notification, so a box-side script will poll
-each git-stack's deployed commit SHA, run smoke.sh, and POST a
-GitHub Deployment + status (repo Environments panel shows prod/dev
-sha + green/red, dev included since it runs on the box). Below
-priority zero — after A7/B6.
+Queued E9 (deployment status page): one URL per env
+(status.web10.app / status.dev.web10.app) showing what's live — the
+CHANGELOG version, commit sha + squash title (carries the PR #),
+deploy date, and per-service health. Preferred design has zero new
+machinery: the GitOps stacks rebuild from git on every change, so
+the page is BAKED AT BUILD TIME (git sha/date/title + CHANGELOG top
+→ status.html/json) and refreshes itself on every auto-redeploy; a
+Portainer-API poller is the fallback (the API does track the
+deployed sha — verified). Supersedes the earlier github-Deployments
+idea from this same session. Below priority zero — after A7/B6.
 
 1.0.70 || 19.07.2026
 PRIORITY ZERO declared at the top of plan.txt (operator): the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+1.0.71 || 19.07.2026
+Queued E9 (deploy → github feedback loop): Portainer CE has no
+outbound "I deployed" notification, so a box-side script will poll
+each git-stack's deployed commit SHA, run smoke.sh, and POST a
+GitHub Deployment + status (repo Environments panel shows prod/dev
+sha + green/red, dev included since it runs on the box). Below
+priority zero — after A7/B6.
+
 1.0.70 || 19.07.2026
 PRIORITY ZERO declared at the top of plan.txt (operator): the
 deployed product must WORK AT A BASELINE — baseline fixes outrank

--- a/parallel execution.txt
+++ b/parallel execution.txt
@@ -467,6 +467,18 @@ LANE E — infrastructure / deployment (owns: proxmox provisioning,
       signing certs/provisioning, review. NOT now (post-M0, gated on
       the encryptor actually doing e2e key management) — parked here
       so it's on the board, not lost.
+  [ ] E9. deploy → github feedback loop (operator, 19.07: "would be
+      cool if portainer alerted github it deployed"). portainer CE
+      has NO outbound deploy notification — build it: a small script
+      on the box (scripts/, cron or systemd timer) polls the
+      portainer API for each git-stack's DEPLOYED COMMIT SHA; on
+      change, run scripts/smoke.sh, then POST a github Deployment +
+      status (repo Environments panel shows prod/dev: sha + green/
+      red). GH token (deployments scope only) lives in the box .env,
+      never git. covers the VPN-only dev env too (runs on the box).
+      alt considered: an Actions-side poller against a public
+      /version marker — rejected as primary (can't see dev off-VPN).
+      below PRIORITY ZERO — do after A7/B6.
 
 WHAT MUST STAY SEQUENTIAL (don't try to parallelize these)
 ----------------------------------------------------------

--- a/parallel execution.txt
+++ b/parallel execution.txt
@@ -467,18 +467,31 @@ LANE E — infrastructure / deployment (owns: proxmox provisioning,
       signing certs/provisioning, review. NOT now (post-M0, gated on
       the encryptor actually doing e2e key management) — parked here
       so it's on the board, not lost.
-  [ ] E9. deploy → github feedback loop (operator, 19.07: "would be
-      cool if portainer alerted github it deployed"). portainer CE
-      has NO outbound deploy notification — build it: a small script
-      on the box (scripts/, cron or systemd timer) polls the
-      portainer API for each git-stack's DEPLOYED COMMIT SHA; on
-      change, run scripts/smoke.sh, then POST a github Deployment +
-      status (repo Environments panel shows prod/dev: sha + green/
-      red). GH token (deployments scope only) lives in the box .env,
-      never git. covers the VPN-only dev env too (runs on the box).
-      alt considered: an Actions-side poller against a public
-      /version marker — rejected as primary (can't see dev off-VPN).
-      below PRIORITY ZERO — do after A7/B6.
+  [ ] E9. DEPLOYMENT STATUS PAGE (operator, 19.07 — iterated from
+      "portainer should alert github" down to what's actually
+      wanted: "all i need is an easy way to know we are deployed, a
+      url i can visit ... the version, the commit, the date, the
+      PR"). one URL per env — status.web10.app / status.dev.
+      web10.app — showing the juicy info about what's live:
+        - VERSION: the top entry of CHANGELOG.md at the deployed
+          commit (the repo's release number, e.g. 1.0.71)
+        - COMMIT: sha + the squash title (which carries the PR #,
+          e.g. "... (#130)") + author date
+        - DEPLOYED AT: when the stack last updated
+        - per-service health dots (reuse scripts/smoke.sh checks)
+      preferred design — ZERO new machinery: the stacks already
+      rebuild from git on every change (GitOps), so add a tiny
+      static status page BAKED AT BUILD TIME (a build step reads
+      git sha/date/title + CHANGELOG top and emits status.html/
+      status.json; serve via a minimal nginx container or an
+      existing frontend's public dir) + one NPM vhost + DNS record
+      per env. every auto-redeploy refreshes it by construction —
+      no poller, no github token, works for VPN-only dev too.
+      (portainer's API does track the deployed sha — verified — so
+      a box-side poller remains the fallback design if the
+      build-time stamp proves awkward.) json endpoint doubles as
+      the version marker future tooling can check. below PRIORITY
+      ZERO — do after A7/B6.
 
 WHAT MUST STAY SEQUENTIAL (don't try to parallelize these)
 ----------------------------------------------------------


### PR DESCRIPTION
Doc-only. E9 iterated with the operator from "portainer should alert github" to the actual need: an easy URL that says what's deployed — status.web10.app / status.dev.web10.app with the CHANGELOG version, commit sha + squash title (carries the PR #), deploy date, and per-service health dots. Preferred design: bake the page at build time — the GitOps stacks rebuild from git on every change, so it self-refreshes with zero pollers/tokens; Portainer-API poller as fallback. Below Priority Zero (A7/B6 first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)