### PR TITLE
D18: document and link the web10 SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+1.0.72 || 19.07.2026
+D18: SDK visibility + publish flow. New sdk.md docs page in
+marketing-ui/public/docs/ with install instructions, API overview,
+and a note on the upcoming C2 typed rewrite. Wired into Docs.tsx
+sidebar. SDK link added to Home.tsx footer. npm badge + SDK link
+added to README.md. npm publish verified: web10-npm@1.0.8 public on
+npmjs.com, cd.yml `npm` job fires on v* tags with provenance +
+`--access public`. Publish flow decision: stays tag-gated
+(decisions.md D26) — auto-publish on merge rejected while C2's typed
+rewrite is in flight; a v* tag forces a deliberate release decision,
+preventing legacy wapi.js from drowning npm with versions nobody
+should install.
+
 1.0.71 || 19.07.2026
 Queued E9 (deployment status page): one URL per env
 (status.web10.app / status.dev.web10.app) showing what's live — the

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # web10
 
+[![npm version](https://img.shields.io/npm/v/web10-npm)](https://www.npmjs.com/package/web10-npm)
+
 <img src="ui/public/logo512.png" alt="web10 logo" height="75" />
 
 web10 starts from one premise: **what you make is yours.**
@@ -98,6 +100,7 @@ at the box and the certificates provision themselves. See
 - **[`decisions.md`](decisions.md)** — why the big calls were made.
 - **[`manifesto.md`](manifesto.md)** — the fan-facing pitch that ships on every node.
 - **Developer docs** — protocol spec, conventions, schemas: `marketing/marketing-ui/public/docs/`.
+- **SDK** — `npm install web10-npm` · [npm](https://www.npmjs.com/package/web10-npm) · [docs](https://www.web10.app/docs/sdk)
 - **[`SECURITY.md`](SECURITY.md)** — how to report vulnerabilities, and the security invariants (I1–I5) that define what a break means.
 
 ## Community

--- a/decisions.md
+++ b/decisions.md
@@ -9,6 +9,24 @@ Status legend: [decided] intent set · [in-progress] · [open] still debating.
 
 ---
 
+### D26 — SDK npm publish stays tag-gated; no auto-publish on merge [decided]
+`cd.yml` publishes `web10-npm` to npm on a `v*` tag push (the `npm` job,
+gated on `startsWith(github.ref, 'refs/tags/v')`). The operator asked whether
+a version bump on merge to `dev`/`main` should auto-publish so the SDK stays
+fresh. Decision: keep it tag-gated. Reasons: (1) the SDK is legacy wapi.js
+(axios + peerjs, untyped) — the C2 typed rewrite is in flight; auto-publishing
+the legacy surface at every merge would drown npm with versions nobody should
+install; (2) npm provenance + `--access public` already works; the gate is a
+feature, not a bug — it forces a deliberate release decision; (3) the SDK
+package.json version (1.0.8) is decoupled from the repo's CHANGELOG versioning
+(1.0.x) — auto-publish needs a version-bump step that currently doesn't exist.
+When C2 lands, the typed SDK should either bump the major version (breaking
+change: drop axios, drop peerjs from core) or publish as a new package name.
+Until then, a `v*` tag is the right friction: publish when the SDK is actually
+worth installing. Rejects: auto-publish on merge (drowns npm, publishes legacy
+surface), and a version-bump-on-merge script (premature for a package about to
+be rewritten).
+
 ### D25 — DB backend is per-env config, not baked; prod bootstraps on the host mongo [decided]
 The node's DB is a config item (`db_url`/`db_name` in `NodeConfig`,
 default `mongodb://ferretdb:27017`), and the backend is wire-protocol

--- a/marketing/marketing-ui/public/docs/sdk.md
+++ b/marketing/marketing-ui/public/docs/sdk.md
@@ -1,0 +1,106 @@
+# web10 SDK
+
+The web10 SDK (`wapi.js`) is the JavaScript library for building apps on a web10 node. It handles authentication, scoped token management, and CRUD operations against the node's data layer.
+
+## Install
+
+```bash
+npm install web10-npm
+```
+
+Or via CDN:
+
+```html
+<script src="https://unpkg.com/web10-npm/dist/wapi.js"></script>
+```
+
+## Quick start
+
+```javascript
+import { wapiInit } from 'web10-npm'
+
+const wapi = wapiInit('https://auth.web10.app')
+
+// Open the auth portal on button click
+loginBtn.onclick = wapi.openAuthPortal
+
+// Listen for the user to log in
+wapi.authListen(() => {
+  const token = wapi.readToken()
+  console.log(`Logged in as ${token.username}@${token.provider}`)
+
+  // Create a record
+  wapi.create('my-service', { text: 'hello web10' })
+    .then(r => console.log('created', r.data))
+
+  // Read records
+  wapi.read('my-service', {})
+    .then(r => console.log('records', r.data))
+})
+```
+
+## API overview
+
+### Initialization
+
+`wapiInit(authUrl, appStores?, rtcServer?)` — returns a wapi instance bound to the given auth portal. `appStores` and `rtcServer` are optional.
+
+### Authentication
+
+| Method | Description |
+|---|---|
+| `wapi.isSignedIn()` | Returns whether the user is authenticated |
+| `wapi.openAuthPortal()` | Opens the web10 auth popup |
+| `wapi.authListen(callback)` | Calls `callback` when the user logs in |
+| `wapi.signOut()` | Clears the session |
+| `wapi.readToken()` | Returns the current JWT payload, or `null` |
+| `wapi.getTieredToken(site, target)` | Mints a scoped token for a specific site/target |
+
+### CRUD
+
+Each method returns an axios promise resolving to `{ data: T[] }`.
+
+| Method | Description |
+|---|---|
+| `wapi.create(service, body, username?, provider?)` | Insert a record |
+| `wapi.read(service, query, username?, provider?)` | Query records |
+| `wapi.update(service, query, update, username?, provider?)` | Update matching records |
+| `wapi.delete(service, query, username?, provider?)` | Delete matching records |
+
+Query pagination uses `$sort`, `$skip`, and `$limit`:
+
+```javascript
+wapi.read('posts', { $sort: { _id: -1 }, $limit: 20 })
+```
+
+### Aggregate
+
+The 5th verb — server-side aggregation pipelines (read-only, sandboxed):
+
+```javascript
+wapi.aggregate('posts', [
+  { $match: { type: 'photo' } },
+  { $group: { _id: '$author', count: { $sum: 1 } } },
+  { $sort: { count: -1 } },
+])
+```
+
+### Service management
+
+`wapi.SMROnReady(sirs, scrs)` — registers service initialization requests (SIRs) and service change requests (SCRs). The node calls back when terms are accepted.
+
+## NPM package
+
+The package is published as `web10-npm` on npm:
+
+[![npm version](https://img.shields.io/npm/v/web10-npm)](https://www.npmjs.com/package/web10-npm)
+
+Published automatically on every `v*` tag push (see `cd.yml`).
+
+## Future: typed SDK rewrite
+
+A TypeScript rewrite (C2 in the lane queue) is in progress: native fetch (no axios), full types for the protocol, ESM + tree-shakeable dist, and peerjs/RTC as an optional subpath. The current SDK remains fully functional and supported.
+
+## Source
+
+The SDK source lives in [`sdk/`](https://github.com/jacoby149/web10/tree/dev/sdk) in this repository.

--- a/marketing/marketing-ui/src/pages/Docs.tsx
+++ b/marketing/marketing-ui/src/pages/Docs.tsx
@@ -7,6 +7,7 @@ import { FileText } from 'lucide-react'
 const DOC_PAGES = [
   { slug: 'protocol-spec', title: 'Protocol Spec', file: '/docs/protocol-spec.md' },
   { slug: 'conventions', title: 'Conventions', file: '/docs/conventions.md' },
+  { slug: 'sdk', title: 'SDK', file: '/docs/sdk.md' },
 ]
 
 function DocsSidebar() {

--- a/marketing/marketing-ui/src/pages/Home.tsx
+++ b/marketing/marketing-ui/src/pages/Home.tsx
@@ -164,6 +164,7 @@ function Footer() {
         <span>&copy; {new Date().getFullYear()} web10</span>
         <div className="flex gap-6">
           <a href="/docs" className="hover:text-foreground">Docs</a>
+          <a href="/docs/sdk" className="hover:text-foreground">SDK</a>
           <a href="/app-store" className="hover:text-foreground">App Store</a>
           <a href="https://auth.web10.app" className="hover:text-foreground">Sign In</a>
           <a href="https://github.com/jacoby149/web10" className="hover:text-foreground">GitHub</a>

--- a/parallel execution.txt
+++ b/parallel execution.txt
@@ -375,17 +375,14 @@ LANE D — docs / apps / mobile (owns: mobile/**, marketing/, examples/
       own". gate: none (docs), but the SDK doc should reflect C2's
       typed sdk once it lands (don't teach legacy wapi as the future
       — see C2/C3.5 parking note).
-  [ ] D18. DOCUMENT + LINK THE WEB10 SDK (operator, 19.07: GitHub
-      shows 4 built packages, none is the SDK; docs never mention it
-      or link to it). the sdk lives in sdk/ (web10-npm) and cd.yml
-      already publishes it to npm on a v* tag. work: (1) add an SDK
-      section/link to the docs + a badge/link from marketing-ui and
-      the README; (2) confirm the npm publish actually fires and the
-      package is public + discoverable; (3) plan.txt CI/CD note:
-      publish the sdk to npm whenever it changes (today it's
-      tag-gated — decide if a version-bump-on-merge should trigger
-      it). coordinate the doc voice with C2 (typed sdk) so we link
-      the RIGHT sdk. small; not M0-gating but cheap credibility.
+[✓ 1.0.72] D18. DOCUMENT + LINK THE WEB10 SDK (operator, 19.07: GitHub
+       shows 4 built packages, none is the SDK; docs never mention it
+       or link to it). DONE: sdk.md docs page created and wired into
+       Docs.tsx sidebar; SDK link added to Home.tsx footer; npm badge
+       + SDK link in README.md. npm publish confirmed: web10-npm@1.0.8
+       public on npmjs.com. Publish flow decision documented in
+       decisions.md D26: stays tag-gated (no auto-publish on merge
+       while C2 typed rewrite is in flight).
 
 
 LANE E — infrastructure / deployment (owns: proxmox provisioning,

--- a/plan.txt
+++ b/plan.txt
@@ -508,11 +508,15 @@ the original data changes what "done" looks like for these):
     web10 CLI" call-to-action (the CLI still exists at
     marketing/web10-cli/ but is invisible) + a CLI quickstart.
     don't teach legacy wapi as the future — align with C2.
-[ ] SDK visibility + publish flow (lane D item D18 + lane E item
-    E7): github shows 4 packages, none is the sdk; docs never link
-    it. document + link the sdk everywhere it should be, confirm
-    cd.yml's npm publish fires (today tag-gated; decide if updates
-    should auto-publish).
+[✓ 1.0.72] SDK visibility + publish flow (lane D item D18 + lane E item
+    E7): sdk/ documented in marketing-ui docs (new sdk.md page, wired into
+    Docs.tsx sidebar), SDK link added to Home.tsx footer, npm badge + SDK
+    link added to README.md. npm publish verified: web10-npm@1.0.8 is public
+    on npmjs.com, cd.yml's `npm` job fires on v* tags with provenance.
+    Publish flow decision: stays tag-gated (decisions.md D26) — auto-publish
+    on merge rejected while C2's typed rewrite is in flight; a v* tag forces
+    a deliberate release decision, preventing legacy wapi.js from drowning npm
+    with versions nobody should install.
 [ ] mobile encryptor → app stores (lane E item E8, parked): expo
     eas build/submit, listings, signing. post-M0, gated on the
     encryptor doing real e2e key management — on the board so it


### PR DESCRIPTION
New sdk.md docs page with install instructions, API overview, and C2 typed-rewrite note. Wired into Docs.tsx sidebar and Home.tsx footer. npm badge + SDK link added to README.md. npm publish verified (web10-npm@1.0.8 public on npmjs.com). Publish flow stays tag-gated (decisions.md D26) — auto-publish rejected while C2 is in flight.