### PR TITLE
Plan: E10 — status page bakes "unknown" version/commit in prod (1.0.74)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+1.0.74 || 20.07.2026
+Plan: new lane-E item E10 — the E9 deployment status page bakes
+"unknown" for version/commit/date in production (verified live on
+dev; only deployedAt works — Portainer's stack build context doesn't
+give the build script usable git info, and it falls back silently).
+E10 also covers the empty-string healthEndpoints it bakes for
+social/marketing. Context: operator asked whether CI/CD was stale;
+it isn't (D17's App Store CTA change and tonight's rebuild are both
+live on dev) — the apps-with-counts store is D16, still unbuilt.
+
 1.0.73 || 19.07.2026
 Dev URL scheme made consistent with prod: the dev API moves from
 dev.web10.app to api.dev.web10.app, and dev.web10.app (the dev apex)

--- a/parallel execution.txt
+++ b/parallel execution.txt
@@ -508,6 +508,21 @@ LANE E — infrastructure / deployment (owns: proxmox provisioning,
       build-time stamp proves awkward.) json endpoint doubles as
       the version marker future tooling can check. below PRIORITY
       ZERO — do after A7/B6.
+  [ ] E10. E9 FOLLOW-UP: status page bakes "unknown" in production.
+      verified live 20.07 (www.dev.web10.app/status/status.json):
+      version/commit/commitTitle/commitDate are all "unknown" —
+      only deployedAt works. cause: the build script reads `git
+      log`/CHANGELOG at Docker build time, but Portainer's
+      git-backed stack build doesn't expose .git (or the script's
+      git calls fail silently) inside the build context. fix so the
+      page answers E9's actual question ("WHICH commit is live?"):
+      either pass sha/title/date in as build args the compose file
+      derives, or read from the checked-out files Portainer does
+      provide (CHANGELOG.md top gives version; a generated
+      build-info file gives sha), and make the build FAIL LOUDLY if
+      the values come out "unknown" — a status page that shrugs is
+      E9 unshipped. also: social/marketing healthEndpoints bake as
+      empty strings — same silent-fallback disease, same fix.
 
 WHAT MUST STAY SEQUENTIAL (don't try to parallelize these)
 ----------------------------------------------------------


### PR DESCRIPTION
Docs/plan only — no code.

Adds lane-E item **E10** to `parallel execution.txt` + a 1.0.74 CHANGELOG line.

**What it tracks:** the E9 deployment status page, verified live on dev (`www.dev.web10.app/status/status.json`), bakes `"version": "unknown", "commit": "unknown"` — only `deployedAt` works. Portainer's git-backed stack build doesn't give the build script usable git info and the script falls back silently. E10 = derive the values from what the build context does have (CHANGELOG top, build args, or a generated build-info file), fail the build loudly if they come out "unknown", and fix the empty-string social/marketing healthEndpoints.

Found while confirming for the operator that CI/CD is deploying correctly (it is — the apps-with-counts App Store they expected is D16, still unbuilt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)