### PR TITLE
Auth hotfix: unbreak tiered token minting + SDK axios-error jank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+1.0.75 || 19.07.2026
+Auth hotfix — unbreak the social login handoff. API: tiered token
+minting always raised MINT because the minted TokenData never had its
+provider set before can_mint compared providers (Lane A bug 1 from the
+C6 sweep); set it at mint time. Verified end-to-end in the docker image:
+signup -> login -> consent term record -> tiered mint -> CRUD with the
+minted social-site token. SDK (web10-npm source, ships with next
+publish): mintOAuthToken no longer throws an unhandled axios error on
+mint failure (the raw "axios error" operators saw on every social
+login); authListen no longer stores an empty-string token when the
+authenticator sends null (apps believed they were signed in with a
+garbage token); readToken survives a malformed token cookie instead of
+white-screening at load; register_app ping is best-effort. Un-fixme'd
+the consent-grant tiered-token e2e test and rewrote it to drive the
+real consent -> mint -> CRUD chain. +2 API mint tests (281 green),
+SDK suite 52 green.
 1.0.74 || 19.07.2026
 C6: e2e deep sweep — expanded harness to 40 tests across money paths.
 Added marketing-api to e2e compose. New suites: consent-grant (4),

--- a/api/app/endpoints/auth.py
+++ b/api/app/endpoints/auth.py
@@ -104,6 +104,9 @@ async def certify_token(token: Token):
 async def create_web10_token(form_data: TokenForm):
     token_data = TokenData()
     token_data.populate_from_token_form(form_data)
+    # the minted token is always issued by this provider — can_mint compares
+    # it against the submitted token's provider, so set it before the checks
+    token_data.provider = settings.PROVIDER
     if not form_data.password and not form_data.token:
         raise exceptions.LOGIN
     try:
@@ -118,7 +121,6 @@ async def create_web10_token(form_data: TokenForm):
     except Exception as e:
         raise e
     token_data.expires = (datetime.utcnow() + timedelta(minutes=settings.TOKEN_EXPIRE_MINUTES)).isoformat()
-    token_data.provider = settings.PROVIDER
     return {"token": jwt.encode(token_data.model_dump(), settings.PRIVATE_KEY, algorithm=settings.ALGORITHM)}
 
 

--- a/api/tests/test_endpoints.py
+++ b/api/tests/test_endpoints.py
@@ -231,6 +231,58 @@ class TestWeb10Token:
         )
         assert resp.status_code == 401
 
+    def test_mint_tiered_token(self, client):
+        """The consent handoff: an auth-site login token mints a token for an app.
+
+        Regression: the minted TokenData never had its provider set, so
+        can_mint's provider comparison always raised MINT.
+        """
+        login_token = _token(
+            {
+                "username": "alice",
+                "site": "auth.localhost",  # a CORS_SERVICE_MANAGERS site
+                "target": None,
+                "provider": settings.PROVIDER,
+                "expires": _future(),
+            }
+        )
+        resp = client.post(
+            "/web10token",
+            json={
+                "username": "alice",
+                "token": login_token,
+                "site": "social.example.com",
+                "target": settings.PROVIDER,
+            },
+        )
+        assert resp.status_code == 200
+        minted = jwt.decode(resp.json()["token"], settings.PRIVATE_KEY, algorithms=[settings.ALGORITHM])
+        assert minted["username"] == "alice"
+        assert minted["site"] == "social.example.com"
+        assert minted["provider"] == settings.PROVIDER
+
+    def test_mint_rejected_for_other_user(self, client):
+        """A token for bob cannot mint a token for alice."""
+        login_token = _token(
+            {
+                "username": "bob",
+                "site": "auth.localhost",
+                "target": None,
+                "provider": settings.PROVIDER,
+                "expires": _future(),
+            }
+        )
+        resp = client.post(
+            "/web10token",
+            json={
+                "username": "alice",
+                "token": login_token,
+                "site": "social.example.com",
+                "target": settings.PROVIDER,
+            },
+        )
+        assert resp.status_code == 401
+
 
 # ---------------------------------------------------------------------------
 # 2. CRUD ROUTES — end-to-end with permissions

--- a/e2e/tests/consent-grant.spec.ts
+++ b/e2e/tests/consent-grant.spec.ts
@@ -57,9 +57,7 @@ test.describe('signup -> consent -> grant full flow', () => {
     expect(posts[0].text).toBe('Self-access post');
   });
 
-  test.fixme('signup -> login -> mint tiered token -> CRUD with tiered token', async ({ request }) => {
-    // FIXME (Lane A): can_mint() requires mint_token.provider to be set, but
-    // populate_from_token_form never sets it. Tiered token minting is broken.
+  test('signup -> login -> mint tiered token -> CRUD with tiered token', async ({ request }) => {
     const username = uniqueUser();
     const password = 'TestPass123!';
 
@@ -77,29 +75,49 @@ test.describe('signup -> consent -> grant full flow', () => {
 
     // Get auth token (site must be in CORS_SERVICE_MANAGERS)
     const authTokenRes = await request.post(`${API_BASE}/web10token`, {
-      data: { username, password, site: 'auth.localhost' },
+      data: { username, password, site: 'auth.localhost', target: 'api.localhost' },
     });
     expect(authTokenRes.ok()).toBeTruthy();
     const { token: authToken } = await authTokenRes.json();
 
-    // BUG: minting a tiered token fails because can_mint() requires
-    // mint_token.provider to be set, but populate_from_token_form never sets it.
-    // Workaround: use owner token (no site/target) which works for self-access.
-    // The tiered-token path is a known API bug (Lane A).
-    const ownerTokenRes = await request.post(`${API_BASE}/web10token`, {
-      data: { username, password },
+    // Consent: create the posts term record the auth app's grant flow
+    // would create — self on the whitelist, the app site in cross_origins
+    const termsRes = await request.post(`${API_BASE}/${username}/services`, {
+      data: {
+        token: authToken,
+        query: {
+          service: 'posts',
+          whitelist: [{ username, provider: 'api.localhost', all: true }],
+          blacklist: [],
+          cross_origins: ['social.localhost'],
+        },
+      },
     });
-    expect(ownerTokenRes.ok()).toBeTruthy();
-    const { token: ownerToken } = await ownerTokenRes.json();
+    expect(termsRes.ok()).toBeTruthy();
 
-    // Use owner token for self-access CRUD
+    // Mint the tiered token for the app site (regression: this was always
+    // 401 MINT because the minted TokenData never had provider set)
+    const mintRes = await request.post(`${API_BASE}/web10token`, {
+      data: { username, token: authToken, site: 'social.localhost', target: 'api.localhost' },
+    });
+    expect(mintRes.ok()).toBeTruthy();
+    const { token: tieredToken } = await mintRes.json();
+
+    // CRUD with the tiered token — the full consent -> grant -> app chain
     const createRes = await request.post(`${API_BASE}/${username}/posts`, {
       data: {
-        token: ownerToken,
-        query: { text: 'Owner token post', created_at: new Date().toISOString() },
+        token: tieredToken,
+        query: { text: 'Tiered token post', created_at: new Date().toISOString() },
       },
     });
     expect(createRes.ok()).toBeTruthy();
+
+    const readRes = await request.patch(`${API_BASE}/${username}/posts`, {
+      data: { token: tieredToken, query: {} },
+    });
+    expect(readRes.ok()).toBeTruthy();
+    const posts = await readRes.json();
+    expect(posts.some((p: { text?: string }) => p.text === 'Tiered token post')).toBeTruthy();
   });
 
   test('tiered token cannot access other user data', async ({ request }) => {

--- a/sdk/src/wapi.js
+++ b/sdk/src/wapi.js
@@ -90,7 +90,10 @@ const wapiInit = function(authUrl = "https://auth.web10.app", appStores=["https:
     */  
   wapi.authListen = setAuth => window.addEventListener("message", e => {
     if (e.data.type === "auth") {
-      wapi.setToken(e.data.token || "");
+      // a null token means the authenticator failed to mint one —
+      // storing "" here used to make the app think it was signed in
+      if (e.data.token) wapi.setToken(e.data.token);
+      else wapi.scrubToken();
       if (setAuth != null) setAuth(wapi.isSignedIn());
     }
   });
@@ -100,7 +103,15 @@ const wapiInit = function(authUrl = "https://auth.web10.app", appStores=["https:
     * @param  {function} setAuth [A callback function that takes logged in [boolean] as an input.]
     * @return {Object} [JWT auth token data]
     */  
-  wapi.readToken = () => !wapi.token ? null : JSON.parse(atob(wapi.token.split(".")[1]));
+  wapi.readToken = () => {
+    if (!wapi.token) return null;
+    try {
+      return JSON.parse(atob(wapi.token.split(".")[1]));
+    } catch (e) {
+      // a malformed token cookie must not crash the app at load
+      return null;
+    }
+  };
 
   /**
     * Gets an JWT token with reduced priveleges.
@@ -375,7 +386,8 @@ const wapiInit = function(authUrl = "https://auth.web10.app", appStores=["https:
     * On web10 connector load, register the web10 app with all input appStores.
   */    
   for (const [i, appStore] of appStores.entries()) {
-    axios.post(appStore+"/register_app", { "url": window.location.href.split('?')[0] })
+    // best-effort ping — an unreachable app store must not throw on load
+    axios.post(appStore+"/register_app", { "url": window.location.href.split('?')[0] }).catch(() => {})
   }
 
   /**

--- a/sdk/src/wapi.test.js
+++ b/sdk/src/wapi.test.js
@@ -53,6 +53,12 @@ describe('wapiInit', () => {
     vi.clearAllMocks()
     clearCookies()
     MockPeer.mockClear()
+    // real axios methods always return a promise (init's register_app
+    // ping chains .catch on it); tests override per-call as needed
+    axiosPost.mockResolvedValue({ data: {} })
+    axiosPatch.mockResolvedValue({ data: {} })
+    axiosDelete.mockResolvedValue({ data: {} })
+    axiosPut.mockResolvedValue({ data: {} })
   })
 
   it('returns an object with expected keys', () => {

--- a/sdk/src/wapiAuth.js
+++ b/sdk/src/wapiAuth.js
@@ -15,12 +15,23 @@ const wapiAuthInit = function(wapi) {
     * Stores it in wapiAuth's oAuthToken.
     */
   wapiAuth.mintOAuthToken = function () {
+    const tokenData = wapi.readToken();
+    if (!tokenData || !document.referrer) {
+      wapiAuth.oAuthToken = null;
+      return Promise.resolve(null);
+    }
     const referrerURL = new URL(document.referrer);
-    wapi
-      .getTieredToken(referrerURL.hostname, wapi.readToken().provider)
+    return wapi
+      .getTieredToken(referrerURL.hostname, tokenData.provider)
       .then(function (response) {
         wapiAuth.oAuthToken = response.data.token;
+        return wapiAuth.oAuthToken;
       })
+      .catch(function (error) {
+        console.error("web10: minting a token for the referrer app failed", error);
+        wapiAuth.oAuthToken = null;
+        return null;
+      });
   };
 
   /**


### PR DESCRIPTION
## What

The social login handoff has been broken at the API level: `can_mint` compares the submitted token's provider against the minted token's provider, but the minted `TokenData` never had `provider` set — so **every tiered-token mint raised MINT (401)**. The auth app's `mintOAuthToken` then rejected unhandled (the raw "axios error" the operator sees on every social login) and posted a `null` token to the opener, which `authListen` stored as `""` — leaving the app "signed in" with a garbage token.

- **api**: set `token_data.provider = settings.PROVIDER` at mint time, before the `can_mint` checks (Lane A bug 1 from the C6 sweep, `.context/laneA-e2e-bugs.md`)
- **sdk** (source; ships with next `web10-npm` publish): `mintOAuthToken` catches mint failures and returns the promise; `authListen` scrubs instead of storing an empty-string token on null; `readToken` survives a malformed cookie instead of throwing at load; `register_app` ping is best-effort
- **e2e**: un-fixme'd the consent-grant tiered-token test and rewrote it to drive the real chain: signup → auth token → consent term record → tiered mint → CRUD with the minted token
- +2 API mint regression tests

## Verification

- Full flow driven against the built docker image: signup → password login → consent term record → tiered mint (previously always 401) → CRUD write + read-back with the minted `social.*`-site token — all 200
- `api` pytest: 281 passed
- `sdk` vitest: 52 passed

## Notes

- Crosses lanes (api = A, sdk/e2e = C) deliberately as an operator-directed hotfix; nothing in flight in either lane.
- The deployed `ui`/`web10-social` bundles use the *published* `web10-npm@1.0.8`, so the SDK hardening reaches browsers on the next npm publish (E7). The API fix alone makes the deployed handoff path work, since the mint now succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)