### PR TITLE
Fix marketing-ui /docs 403 (nginx SPA fallback for docs directory)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+1.0.78 || 19.07.2026
+Fix marketing-ui /docs 403. The docs .md files ship in a public/docs
+directory, so nginx resolved the bare /docs and /docs/ routes to that
+directory, found no index.html, and returned 403 (autoindex off) — /docs
+even 301'd to /docs/ first. The `$uri/` in the /docs/ try_files was asking
+nginx to index the directory. Map the bare routes straight to the SPA shell
+via exact-match locations (which win over the prefix, so no directory
+redirect) and drop `$uri/` so sub-routes fall back to index.html while real
+files (.md, schemas/) still serve. Validated: /docs, /docs/, /docs/<slug>,
+and /docs/<slug>.md all 200.
 1.0.77 || 19.07.2026
 Auth console: admin model, Node Config fix, Studio reorder, working search,
 ecosystem links, balanced topbar. SECURITY: check_admin was passing for any

--- a/marketing/marketing-ui/nginx.conf
+++ b/marketing/marketing-ui/nginx.conf
@@ -8,13 +8,19 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
-    # Docs are client-side routes (/docs/<slug>) that FETCH the raw
-    # /docs/<slug>.md. Serve real files (the .md, schemas/) statically,
-    # but fall back to index.html for the client-side route — without
-    # this fallback, /docs/protocol-spec 404s (no such file) instead of
-    # letting react-router render it.
+    # Docs are client-side routes (/docs, /docs/<slug>) that also FETCH the
+    # raw /docs/<slug>.md files. Serve real files (the .md, schemas/)
+    # statically; fall back to index.html for the client-side route.
+    #
+    # The bare /docs and /docs/ resolve to the public/docs DIRECTORY on disk,
+    # so `$uri/` made nginx try to index that directory — no index.html there
+    # + autoindex off => 403. Map the bare routes straight to the SPA shell
+    # (exact-match locations win over the prefix, so no directory redirect),
+    # and drop `$uri/` from the prefix so sub-routes fall back cleanly.
+    location = /docs  { try_files /index.html =404; }
+    location = /docs/ { try_files /index.html =404; }
     location /docs/ {
-        try_files $uri $uri/ /index.html;
+        try_files $uri /index.html;
     }
 
     # Baked deployment status page — served statically from /status/


### PR DESCRIPTION
## Problem

`https://web10.app/docs/` returns **403 Forbidden**, and `https://web10.app/docs` 301s to it. (The deep route `/docs/protocol-spec` works.)

## Cause

The docs `.md` files ship in `public/docs/`, so at runtime `/usr/share/nginx/html/docs/` is a real directory. The `/docs/` location used `try_files $uri $uri/ /index.html` — the `$uri/` term asks nginx to serve the *directory*, which has no `index.html`, and with `autoindex off` that's a **403** (never falling through to the SPA `index.html`).

## Fix

- Exact-match `location = /docs` and `= /docs/` → serve the SPA shell (`/index.html`). Exact matches win over the prefix, so nginx skips the directory 301/index.
- Prefix `location /docs/` drops `$uri/` → real files (`.md`, `schemas/`) still serve; anything else falls back to `index.html` for react-router.

## Verification

Throwaway nginx container with the build's directory layout (`nginx -t` clean):

| path | before | after |
|---|---|---|
| `/docs` | 301→403 | **200** |
| `/docs/` | 403 | **200** (SPA shell) |
| `/docs/protocol-spec` | 200 | 200 |
| `/docs/protocol-spec.md` | 200 | 200 |
| `/docs/schemas/s.json` | 200 | 200 |

## Notes
`marketing/marketing-ui/` only (Lane D). Deploys via the marketing-ui pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)