### PR TITLE
Prod fixes: ship static assets, correct readiness API, unlock DB override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+1.0.79 || 19.07.2026
+Prod fixes: missing static assets, wrong readiness API, and the DB override.
+(1) ui/Dockerfile never COPYed public/, so vite had nothing to fold into
+dist — every static asset (logo /YourOrgsLogo/key_white.png, favicon.ico,
+manifest.json, PWA icons) 404'd on the deployed auth app. Copy public/
+before the build; verified the rebuilt image serves them. (2) App.tsx's
+readiness probe fell back to a hardcoded "api.localhost" when logged out, so
+/ready hit the wrong API on prod (and hung locally). Fall back to the
+configured API host, with *.localhost detection mirroring authAdapter.
+(3) The ecosystem compose hardcoded DB: web10, so the prod override was
+ignored and the API served the empty FerretDB — real accounts (the "deploy"
+DB) looked like "the user doesn't exist". DB is now ${DB:-web10}; prod sets
+DB=deploy + DB_URL=host mongo (env.prod). (4) Repositioned the OAuth consent
+banner from a stray in-flow card (it rendered "status: ready" in an odd spot
+above the shell) to a fixed prompt below the top bar.
 1.0.78 || 19.07.2026
 Fix marketing-ui /docs 403. The docs .md files ship in a public/docs
 directory, so nginx resolved the bare /docs and /docs/ routes to that

--- a/ubuntu-deployment/docker-compose.ecosystem.yml
+++ b/ubuntu-deployment/docker-compose.ecosystem.yml
@@ -98,7 +98,11 @@ services:
     environment:
       PROVIDER: ${PROVIDER:?set PROVIDER, e.g. api.dev.web10.app}
       DB_URL: ${DB_URL:-mongodb://web10:web10@${STACK}-ferretdb:27017/}
-      DB: web10
+      # DB was hardcoded, so the prod override was ignored and the API served
+      # the empty FerretDB instead of the real data (users "don't exist"). The
+      # real accounts live in the host mongo's "deploy" database — prod sets
+      # DB=deploy + DB_URL=mongodb://host.docker.internal:27017/ (env.prod).
+      DB: ${DB:-web10}
       S3_ENDPOINT: http://${STACK}-minio:9000
       S3_ACCESS_KEY: minioadmin
       S3_SECRET_KEY: ${MINIO_PASSWORD}

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -11,6 +11,7 @@ RUN bun install --frozen-lockfile
 RUN sed -i 's/wapi\.defaultAPIProtocol/wapi.APIProtocol/g' node_modules/web10-npm/dist/node/wapi.js node_modules/web10-npm/dist/node/wapi.modern.js
 
 COPY index.html tsconfig.json vite.config.js ./
+COPY public/ public/
 COPY src/ src/
 
 EXPOSE 80

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -10,6 +10,7 @@ import ConfigPage from './components/Config/ConfigPage';
 import StudioPage from './components/Studio/StudioPage';
 import { Card, CardContent } from './components/ui/card';
 import { Button } from './components/ui/button';
+import { config } from './config';
 
 function StatusBar({ I }: { I: Record<string, any> }) {
   if (!I.status) return null;
@@ -45,37 +46,42 @@ function OAuthBanner({ I }: { I: Record<string, any> }) {
 
   const SMRs = I.SMR?.sirs?.length > 0 || I.SMR?.scrs?.length > 0;
 
+  // A fixed prompt below the top bar — not a stray card in the page flow
+  // (which rendered in an odd spot above the console shell).
   return (
-    <Card className="m-5 max-w-[400px]" data-testid="oauth-banner">
-      <CardContent className="p-4">
-        <div className="mb-2.5 text-sm">
-          <span className="text-muted-foreground">From <span className="font-medium text-foreground">{referrerHost}</span>:</span>
-          <br />
-          status:{SMRs
-            ? <span className="font-medium text-warning"> requests need approval</span>
-            : <span className="font-medium text-success"> ready</span>}
-        </div>
-        {SMRs ? (
-          <Button
-            variant="outline"
-            size="sm"
-            data-testid="oauth-banner-review-requests"
-            onClick={() => I.setMode("requests")}
-          >
-            Review Requests
-          </Button>
-        ) : (
-          <Button
-            variant="brand"
-            size="sm"
-            data-testid="oauth-banner-login"
-            onClick={() => I.sendToken()}
-          >
-            Log In
-          </Button>
-        )}
-      </CardContent>
-    </Card>
+    <div className="fixed left-1/2 top-16 z-40 w-[calc(100%-2rem)] max-w-sm -translate-x-1/2">
+      <Card className="shadow-[0_8px_30px_rgb(0_0_0/0.35)]" data-testid="oauth-banner">
+        <CardContent className="flex items-center justify-between gap-3 p-4">
+          <div className="min-w-0 text-sm">
+            <p className="font-medium text-foreground">Connect to {referrerHost}</p>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              {SMRs ? "This app is requesting access to your data." : "Ready to grant this app a scoped token."}
+            </p>
+          </div>
+          {SMRs ? (
+            <Button
+              variant="outline"
+              size="sm"
+              className="shrink-0"
+              data-testid="oauth-banner-review-requests"
+              onClick={() => I.setMode("requests")}
+            >
+              Review
+            </Button>
+          ) : (
+            <Button
+              variant="brand"
+              size="sm"
+              className="shrink-0"
+              data-testid="oauth-banner-login"
+              onClick={() => I.sendToken()}
+            >
+              Continue
+            </Button>
+          )}
+        </CardContent>
+      </Card>
+    </div>
   );
 }
 
@@ -100,7 +106,13 @@ function App() {
       return;
     }
     const decoded = I.wapi?.readToken?.();
-    const provider = decoded?.provider || "api.localhost";
+    // Logged out, there's no token to name the provider — fall back to the
+    // configured API host, NOT a hardcoded "api.localhost" (which made the
+    // readiness probe hit the wrong API on prod). Mirror authAdapter's
+    // *.localhost detection so local dev still points at api.localhost.
+    const host = window.location.hostname;
+    const isLocal = host === "localhost" || host === "127.0.0.1" || host.endsWith(".localhost");
+    const provider = decoded?.provider || (isLocal ? "api.localhost" : config.REACT_APP_DEFAULT_API);
     const protocol = window.location.protocol;
     fetch(`${protocol}//${provider}/ready`)
       .then(r => r.json())


### PR DESCRIPTION
Three prod bugs (operator-reported) + one UI jank fix.

## 1. Static assets 404 on the deployed auth app
`ui/Dockerfile` copied `index.html`, `src/`, and config, but **never `COPY public/`** — so vite had no `public/` to fold into `dist/`, and every static asset was missing from the image.

- Before (deployed): `/YourOrgsLogo/key_white.png`, `/favicon.ico`, `/manifest.json` → **404**
- After (rebuilt image, verified locally): all **200**

## 2. Readiness probe hits the wrong API on prod
`App.tsx` fell back to a hardcoded `"api.localhost"` when logged out, so `/ready` went to `https://api.localhost/ready` on prod (and hung locally). Now falls back to the configured API host (`REACT_APP_DEFAULT_API`), mirroring `authAdapter`'s `*.localhost` detection.

## 3. "The user doesn't exist" — wrong database
`/stats` reports **5 users**, but the real mongo (`deploy`) has 208 — the API was serving the empty containerized FerretDB. The ecosystem compose **hardcoded `DB: web10`**, so the prod env override was ignored. Now `DB: ${DB:-web10}`.

> ⚠️ **Ops follow-up (needs Portainer/box access, not in this PR):** set the prod stack env `DB=deploy` and `DB_URL=mongodb://host.docker.internal:27017/` (the host-native mongo with the real accounts). `extra_hosts: host.docker.internal` is already wired. Without this env change the API still points at FerretDB.

## 4. OAuth consent banner placement
It rendered as a stray in-flow `<Card>` above the console shell (the "status: ready" card in an odd spot). Repositioned to a fixed prompt below the top bar, with clearer copy.

## Verification
Rebuilt the `ui` image and served it: assets 200. `ui` build + 74 tests green. `nginx`/compose changes are config-only.

## Notes
Spans `ui/` (Lane B) and `ubuntu-deployment/` (Lane E) as an operator-directed prod hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)