### PR TITLE
Point prod at the real mongo (deploy DB) via deploy-stacks env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+1.0.80 || 19.07.2026
+Prod cutover to the real mongo. deploy-stacks.py now sets the web10-prod
+env DB=deploy + DB_URL=mongodb://host.docker.internal:27017/, so the prod
+API serves the host-native mongo's "deploy" database (208 real accounts)
+instead of the empty containerized FerretDB. Applied on the box and
+verified: POST /stats users 5 -> 208, real apps/usage show, and a real
+account (jacoby149) is found again ("incorrect username or password" on a
+wrong password, not "the user doesn't exist"). Completes the DB override
+enabled by 1.0.79's compose fix. Ops details in ubuntu-deployment/OPS-LOG.md.
 1.0.79 || 19.07.2026
 Prod fixes: missing static assets, wrong readiness API, and the DB override.
 (1) ui/Dockerfile never COPYed public/, so vite had nothing to fold into

--- a/ubuntu-deployment/OPS-LOG.md
+++ b/ubuntu-deployment/OPS-LOG.md
@@ -3,6 +3,35 @@
 Newest at top. Format per AGENT-OPS.md §8. Read the top entries
 BEFORE doing ops work — someone may already be mid-fix.
 
+## 19.07.2026 — Claude (lincoln, b7-auth-ui) — prod cutover to the real mongo (deploy)
+did (SSH as jacob; box /opt/web10 is still a stale non-git snapshot):
+  - ROOT CAUSE: web10-prod-api was serving the containerized FerretDB
+    (DB=web10, ~5 e2e smoke accounts) instead of the host-native mongo's
+    `deploy` DB (208 real accounts) — so every real login said "the user
+    doesn't exist". The compose hardcoded `DB: web10`, so the intended
+    prod override never took effect.
+  - FIX (two parts, both merged to dev): (1) compose `DB: ${DB:-web10}`
+    so the env can override it (PR #145); (2) deploy-stacks.py prod env
+    now sets DB=deploy + DB_URL=mongodb://host.docker.internal:27017/.
+  - Verified the deploy DB before flipping: 208 collections, jacoby149
+    present, its {service:services, body.service:"*"} record has a
+    bcrypt hash + verified=true (matches get_star()). The only accounts
+    in FerretDB were e2e smoke users (smoke*, verified=false) — nothing
+    real stranded.
+  - APPLIED: scp'd updated deploy-stacks.py to the box (backup left as
+    deploy-stacks.py.bak.<ts>), ran `deploy-stacks.py prod` → Portainer
+    stack web10-prod (id 2) redeployed. web10-prod-api-1 now has
+    DB=deploy + DB_URL=host mongo (status running).
+  - VERIFIED: POST /stats → users:208 (was 5); real apps show
+    (web10auth 13.5k visits, crm/mail.web10.app, …); jacoby149 with a
+    wrong password now returns "incorrect username or password" (found),
+    not "the user doesn't exist".
+  - host mongo needs no auth (binds 127.0.0.1 + 172.17.0.1:27017;
+    host.docker.internal→host-gateway already in the compose).
+next: the ~5 FerretDB smoke accounts are orphaned (harmless test data).
+  If any real signups happened while prod was on FerretDB, migrate them
+  into `deploy` before decommissioning the prod FerretDB.
+
 ## 19.07.2026 — Claude (port-vila, mongo-backup-and-dev-urls) — dev URL rename: api.dev.web10.app
 did (SSH as jacob, scripts scp'd to the box since /opt/web10 is a stale
 non-git snapshot — see note below):

--- a/ubuntu-deployment/scripts/deploy-stacks.py
+++ b/ubuntu-deployment/scripts/deploy-stacks.py
@@ -56,6 +56,10 @@ def env_for(stack):
                  MINIO_PASSWORD=cfg["MINIO_PASSWORD_DEV"])
     else:
         d = dict(STACK="web10-prod", PROVIDER="api.web10.app",
+                 # Prod serves the REAL data in the host-native mongo's "deploy"
+                 # database (208 accounts), not the containerized FerretDB. The
+                 # compose defaults DB to web10/FerretDB; override here.
+                 DB="deploy", DB_URL="mongodb://host.docker.internal:27017/",
                  API_ORIGIN="https://api.web10.app", API_HOST="api.web10.app",
                  AUTH_ORIGIN="https://auth.web10.app", RTC_ORIGIN="https://rtc.web10.app",
                  MINIO_HOST="minio.web10.app", MARKETING_API_ORIGIN="https://marketing-api.web10.app",


### PR DESCRIPTION
Completes the DB cutover started by #145. **Already applied on the box and verified live** — this PR is the source-of-truth commit so a fresh deploy keeps the setting.

## What
`web10-prod-api` was serving the empty containerized FerretDB (`DB=web10`, ~5 e2e smoke accounts) instead of the host-native mongo's **`deploy`** database (208 real accounts) — so every real login returned "the user doesn't exist". #145 made `DB` overridable (`DB: ${DB:-web10}`); this adds the prod env:

```python
DB="deploy", DB_URL="mongodb://host.docker.internal:27017/"
```

## Verified on the box (all-spark, SSH)
- Pre-flight: `deploy` DB has 208 collections; `jacoby149` present with a bcrypt hash + `verified=true` matching `get_star()`'s `{service:"services", body.service:"*"}` lookup. Only FerretDB accounts were e2e smoke users — nothing real stranded.
- Applied: `deploy-stacks.py prod` → web10-prod redeployed; api env now `DB=deploy` + host-mongo URL.
- After: `POST /stats` → **users 5 → 208**, real apps/usage show, `jacoby149` returns "incorrect username or password" (found), not "doesn't exist".

Host mongo needs no auth; `host.docker.internal` is already wired via `extra_hosts`. Full ops entry in `ubuntu-deployment/OPS-LOG.md`.

## Notes
Lane E (infra/ops). No secrets added (`DB`/`DB_URL` are non-sensitive; the host mongo is unauthenticated and bound to loopback + the docker bridge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)