### PR TITLE
Consent flow overhaul: dedicated screen, login handoff fix, crash fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+1.0.81 || 20.07.2026
+Consent flow overhaul + crash fixes. A dedicated full-screen ConsentView
+replaces the floating banner that overlapped the console: one focused,
+polished screen (its own space) when the auth app is opened by another app.
+It is concise by default — one line per requested service with plain-English
+summary — and each row expands (progressive disclosure) to the full detail:
+sites with access, allowed/blocked users with exact permissions, and for
+changes the delta (added/removed highlighted). It shows what's already
+shared vs new, and no longer re-asks for services already granted.
+Approve all / Continue without sharing are sticky (no scrolling). The
+token/login handoff is fixed: goToApp mints a fresh scoped token for the
+referrer and posts it to the opener (approving one request no longer ships
+the token early and strands the rest — the token goes only when you choose
+to continue). submitSIR refuses to create a duplicate terms record for an
+already-granted service (root of the duplicate-contracts bug). Also:
+RequestPage rendered whitelist entries as {anchor, allowed[]} but the real
+shape is {username, provider, <action>}, so `.join` on undefined blanked
+the whole review screen (now defensive); the contract viewer crashed
+expanding records without whitelist/blacklist/cross_origins (e.g. the
+services record) — now guarded; a top-level ErrorBoundary turns any future
+render throw into a designed error state instead of a blank page; the app
+shell is now fixed-height so the sidebar/top bar stay put and only content
+scrolls; social.localhost now targets auth.localhost automatically (any
+*.localhost host is local) so social -> auth -> social works without
+?local=true. 74 ui tests green.
 1.0.79 || 19.07.2026
 Prod fixes: missing static assets, wrong readiness API, and the DB override.
 (1) ui/Dockerfile never COPYed public/, so vite had nothing to fold into

--- a/marketing/web10-social/src/data/wapi.ts
+++ b/marketing/web10-social/src/data/wapi.ts
@@ -76,7 +76,12 @@ export function createWapiWrapper(authUrl?: string, rtcServer?: string): WapiWra
   if (instance) return instance;
 
   const queryParameters = new URLSearchParams(window.location.search);
-  const local = queryParameters.get('local');
+  const host = window.location.hostname;
+  const local =
+    queryParameters.get('local') != null ||
+    host === 'localhost' ||
+    host === '127.0.0.1' ||
+    host.endsWith('.localhost');
   const resolvedAuthUrl = authUrl ?? (local ? 'http://auth.localhost' : AUTH_ORIGIN);
   const resolvedRtcServer = rtcServer ?? (local ? 'rtc.localhost' : RTC_HOST);
 

--- a/marketing/web10-social/src/interfaces/Web10SocialAdapter.ts
+++ b/marketing/web10-social/src/interfaces/Web10SocialAdapter.ts
@@ -165,19 +165,23 @@ interface Web10SocialAdapter {
 
 const web10SocialAdapterInit = (): Web10SocialAdapter => {
   const queryParameters = new URLSearchParams(window.location.search);
-  const local = queryParameters.get('local');
+  // Go local when served from any *.localhost host (so social.localhost ->
+  // auth.localhost -> social.localhost works without needing ?local=true),
+  // or when ?local=true is explicitly set.
+  const host = window.location.hostname;
+  const local =
+    queryParameters.get('local') != null ||
+    host === 'localhost' ||
+    host === '127.0.0.1' ||
+    host.endsWith('.localhost');
 
-  const wapi = wapiInit(
-    local ? 'http://auth.localhost' : AUTH_ORIGIN,
-    undefined,
-    local ? 'rtc.localhost' : RTC_HOST
-  ) as WapiInstance;
+  const authUrl = local ? 'http://auth.localhost' : AUTH_ORIGIN;
+  const rtcHost = local ? 'rtc.localhost' : RTC_HOST;
+
+  const wapi = wapiInit(authUrl, undefined, rtcHost) as WapiInstance;
 
   // Initialize the typed wapi wrapper for the data layer
-  const wapiWrapper = createWapiWrapper(
-    local ? 'http://auth.localhost' : AUTH_ORIGIN,
-    local ? 'rtc.localhost' : RTC_HOST,
-  );
+  const wapiWrapper = createWapiWrapper(authUrl, rtcHost);
 
   const adapter: Partial<Web10SocialAdapter> & WapiInstance = { ...wapi };
 

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -8,8 +8,7 @@ import RequestPage from './components/Contracts/RequestPage';
 import SetupWizard from './components/SetupWizard/SetupWizard';
 import ConfigPage from './components/Config/ConfigPage';
 import StudioPage from './components/Studio/StudioPage';
-import { Card, CardContent } from './components/ui/card';
-import { Button } from './components/ui/button';
+import ConsentView from './components/Consent/ConsentView';
 import { config } from './config';
 
 function StatusBar({ I }: { I: Record<string, any> }) {
@@ -21,66 +20,6 @@ function StatusBar({ I }: { I: Record<string, any> }) {
       className="fixed inset-x-0 top-0 z-[500] px-4 py-2 text-center text-sm font-medium bg-warning/15 text-warning"
     >
       {I.status}
-    </div>
-  );
-}
-
-function OAuthBanner({ I }: { I: Record<string, any> }) {
-  const [hasReferrer, setHasReferrer] = React.useState(false);
-  const [referrerHost, setReferrerHost] = React.useState("");
-
-  React.useEffect(() => {
-    const referrer = window.document.referrer;
-    if (referrer) {
-      try {
-        const url = new URL(referrer);
-        if (url.origin !== window.location.origin) {
-          setHasReferrer(true);
-          setReferrerHost(url.hostname);
-        }
-      } catch { }
-    }
-  }, []);
-
-  if (!hasReferrer || !I.isAuthenticated()) return null;
-
-  const SMRs = I.SMR?.sirs?.length > 0 || I.SMR?.scrs?.length > 0;
-
-  // A fixed prompt below the top bar — not a stray card in the page flow
-  // (which rendered in an odd spot above the console shell).
-  return (
-    <div className="fixed left-1/2 top-16 z-40 w-[calc(100%-2rem)] max-w-sm -translate-x-1/2">
-      <Card className="shadow-[0_8px_30px_rgb(0_0_0/0.35)]" data-testid="oauth-banner">
-        <CardContent className="flex items-center justify-between gap-3 p-4">
-          <div className="min-w-0 text-sm">
-            <p className="font-medium text-foreground">Connect to {referrerHost}</p>
-            <p className="mt-0.5 text-xs text-muted-foreground">
-              {SMRs ? "This app is requesting access to your data." : "Ready to grant this app a scoped token."}
-            </p>
-          </div>
-          {SMRs ? (
-            <Button
-              variant="outline"
-              size="sm"
-              className="shrink-0"
-              data-testid="oauth-banner-review-requests"
-              onClick={() => I.setMode("requests")}
-            >
-              Review
-            </Button>
-          ) : (
-            <Button
-              variant="brand"
-              size="sm"
-              className="shrink-0"
-              data-testid="oauth-banner-login"
-              onClick={() => I.sendToken()}
-            >
-              Continue
-            </Button>
-          )}
-        </CardContent>
-      </Card>
     </div>
   );
 }
@@ -159,6 +98,15 @@ function App() {
     return <SetupWizard I={I} />;
   }
 
+  // Opened by another app for consent (window.opener present, or ?consent=1 to
+  // preview) → a dedicated, focused consent screen, not the full console with a
+  // floating prompt over it.
+  const consentMode =
+    typeof window !== "undefined" && (window.opener != null || queryParameters.get("consent") != null);
+  if (consentMode) {
+    return <ConsentView I={I} />;
+  }
+
   // The credential (login/signup/forgot) screens are the only ones a
   // signed-out user may see. Anything else — including an expired/scrubbed
   // token that leaves mode on "contracts" — routes to the login page so a
@@ -171,7 +119,6 @@ function App() {
   return (
     <>
       <StatusBar I={I} />
-      <OAuthBanner I={I} />
       {(() => {
         switch (effectiveMode) {
           case "contracts": return <ContractPage I={I} />;

--- a/ui/src/components/Consent/ConsentView.tsx
+++ b/ui/src/components/Consent/ConsentView.tsx
@@ -1,0 +1,323 @@
+import React from 'react';
+import { Globe, ShieldCheck, Check, X, ChevronDown, ChevronRight, ArrowRight, Plus, Minus } from 'lucide-react';
+import Branding from '../shared/Branding';
+import LoginForm from '../CredentialPage/LoginForm';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+// A whitelist/blacklist entry is {username, provider, <action>: true}. Render a
+// readable anchor + granted actions defensively (never throw on odd shapes).
+function entryAnchor(e: any): string {
+  if (!e || typeof e !== 'object') return String(e);
+  const u = e.username === '.*' || e.username == null ? 'anyone' : e.username;
+  const p = e.provider && e.provider !== '.*' ? `@${e.provider}` : '';
+  return `${u}${p}`;
+}
+function entryActions(e: any): string[] {
+  if (!e || typeof e !== 'object') return [];
+  const meta = new Set(['username', 'provider', 'anchor', 'allowed', 'denied']);
+  return Object.keys(e).filter((k) => !meta.has(k) && e[k] === true);
+}
+function entryLabel(e: any): string {
+  const a = entryActions(e);
+  return `${entryAnchor(e)}${a.length ? ` · ${a.join(', ')}` : ''}`;
+}
+
+// A one-line plain-English summary of what a request grants.
+function summarize(req: any): string {
+  const actions = new Set<string>();
+  (Array.isArray(req.whitelist) ? req.whitelist : []).forEach((w: any) =>
+    entryActions(w).forEach((a) => actions.add(a)),
+  );
+  const verbs = actions.size ? Array.from(actions).join('/') : 'access';
+  const sites = Array.isArray(req.cross_origins) ? req.cross_origins.length : 0;
+  return `${verbs} · ${sites} ${sites === 1 ? 'site' : 'sites'}`;
+}
+
+// diff two string lists → {added, removed, same}
+function diffStrings(current: string[], next: string[]) {
+  const c = new Set(current || []);
+  const n = new Set(next || []);
+  return {
+    added: [...n].filter((x) => !c.has(x)),
+    removed: [...c].filter((x) => !n.has(x)),
+    same: [...n].filter((x) => c.has(x)),
+  };
+}
+
+function DetailRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="mt-2 first:mt-0">
+      <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground/70">{label}</div>
+      <div className="mt-1 flex flex-wrap gap-1.5">{children}</div>
+    </div>
+  );
+}
+
+function Chip({ tone = 'default', children }: { tone?: 'default' | 'add' | 'remove'; children: React.ReactNode }) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs',
+        tone === 'add'
+          ? 'bg-success/15 text-success'
+          : tone === 'remove'
+            ? 'bg-danger-muted text-danger line-through'
+            : 'border border-border bg-secondary text-secondary-foreground',
+      )}
+    >
+      {tone === 'add' && <Plus className="h-3 w-3" strokeWidth={2} />}
+      {tone === 'remove' && <Minus className="h-3 w-3" strokeWidth={2} />}
+      {children}
+    </span>
+  );
+}
+
+function RequestRow({
+  req,
+  kind,
+  current,
+  onApprove,
+  onDeny,
+  idx,
+}: {
+  req: any;
+  kind: 'new' | 'change';
+  current: any | undefined;
+  onApprove: () => void;
+  onDeny: () => void;
+  idx: number;
+}) {
+  const [open, setOpen] = React.useState(false);
+  const sites: string[] = Array.isArray(req.cross_origins) ? req.cross_origins : [];
+  const allows: any[] = Array.isArray(req.whitelist) ? req.whitelist : [];
+  const blocks: any[] = Array.isArray(req.blacklist) ? req.blacklist : [];
+  const siteDiff = kind === 'change' && current ? diffStrings(current.cross_origins || [], sites) : null;
+
+  return (
+    <div className="rounded-lg border border-border bg-elevated" data-testid={`consent-req-${idx}`}>
+      <div className="flex items-center gap-3 p-3.5">
+        <button
+          type="button"
+          onClick={() => setOpen((o) => !o)}
+          aria-expanded={open}
+          className="flex min-w-0 flex-1 items-center gap-2.5 rounded text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          data-testid={`consent-details-${idx}`}
+        >
+          <span className="shrink-0 text-muted-foreground">
+            {open ? <ChevronDown className="h-4 w-4" strokeWidth={1.5} /> : <ChevronRight className="h-4 w-4" strokeWidth={1.5} />}
+          </span>
+          <span className="min-w-0">
+            <span className="flex items-center gap-2">
+              <span className="truncate font-medium text-foreground">{req.service}</span>
+              <span className="shrink-0 rounded-full bg-brand-muted px-2 py-0.5 text-[11px] font-medium text-brand-300">
+                {kind === 'new' ? 'new access' : 'change'}
+              </span>
+            </span>
+            <span className="mt-0.5 block truncate text-xs text-muted-foreground">{summarize(req)}</span>
+          </span>
+        </button>
+        <div className="flex shrink-0 items-center gap-1.5">
+          <Button variant="brand" size="sm" onClick={onApprove} data-testid={`consent-approve-${idx}`}>
+            <Check className="mr-1 h-4 w-4" strokeWidth={2} />
+            Allow
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onDeny}
+            aria-label={`Deny ${req.service}`}
+            data-testid={`consent-deny-${idx}`}
+            className="text-muted-foreground hover:text-danger"
+          >
+            <X className="h-4 w-4" strokeWidth={2} />
+          </Button>
+        </div>
+      </div>
+
+      {open && (
+        <div className="border-t border-border px-3.5 py-3 text-sm">
+          <DetailRow label={kind === 'change' ? 'Sites (changes highlighted)' : 'Sites with access'}>
+            {siteDiff ? (
+              <>
+                {siteDiff.same.map((s, i) => (
+                  <Chip key={`s${i}`}><Globe className="h-3 w-3 text-muted-foreground" strokeWidth={1.5} />{s}</Chip>
+                ))}
+                {siteDiff.added.map((s, i) => (
+                  <Chip key={`a${i}`} tone="add">{s}</Chip>
+                ))}
+                {siteDiff.removed.map((s, i) => (
+                  <Chip key={`r${i}`} tone="remove">{s}</Chip>
+                ))}
+                {siteDiff.same.length + siteDiff.added.length + siteDiff.removed.length === 0 && (
+                  <span className="text-xs text-muted-foreground">No sites</span>
+                )}
+              </>
+            ) : sites.length ? (
+              sites.map((s, i) => (
+                <Chip key={i}><Globe className="h-3 w-3 text-muted-foreground" strokeWidth={1.5} />{s}</Chip>
+              ))
+            ) : (
+              <span className="text-xs text-muted-foreground">No sites</span>
+            )}
+          </DetailRow>
+
+          {allows.length > 0 && (
+            <DetailRow label="Allowed">
+              {allows.map((w, i) => <Chip key={i} tone="add">{entryLabel(w)}</Chip>)}
+            </DetailRow>
+          )}
+          {blocks.length > 0 && (
+            <DetailRow label="Blocked">
+              {blocks.map((w, i) => <Chip key={i} tone="remove">{entryLabel(w)}</Chip>)}
+            </DetailRow>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ConsentView({ I }: { I: Record<string, any> }) {
+  const host = React.useMemo(() => {
+    try {
+      return I._referrerHost || (document.referrer ? new URL(document.referrer).hostname : 'this app');
+    } catch {
+      return 'this app';
+    }
+  }, [I._referrerHost]);
+
+  const authed = I.isAuthenticated?.();
+  const services: any[] = I.services || [];
+  const grantedNames = new Set(services.map((s) => s.service));
+  const sirs: any[] = I.SMR?.sirs || [];
+  const scrs: any[] = I.SMR?.scrs || [];
+
+  // Only ask for what's actually new. A SIR for a service you've already
+  // granted isn't re-asked (re-approving it just makes a duplicate); it's
+  // shown as "already shared". Changes (SCRs) are always something to review.
+  const alreadyShared: string[] = sirs.filter((s) => grantedNames.has(s.service)).map((s) => s.service);
+  const requests = [
+    ...sirs.filter((s) => !grantedNames.has(s.service)).map((s) => ({ req: s, kind: 'new' as const })),
+    ...scrs.map((s) => ({ req: s, kind: 'change' as const })),
+  ];
+  const username = I.wapi?.readToken?.()?.username as string | undefined;
+
+  return (
+    <div className="relative flex h-screen flex-col items-center justify-center overflow-hidden bg-background px-4 py-8 text-foreground">
+      {/* the one permitted decorative flourish (design.md §4): a soft brand glow */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute left-1/2 top-0 h-72 w-72 -translate-x-1/2 rounded-full bg-brand/20 blur-[120px]"
+      />
+
+      <div className="relative flex w-full max-w-md flex-col" style={{ maxHeight: 'calc(100vh - 4rem)' }}>
+        <div className="mb-6 flex shrink-0 justify-center">
+          <Branding I={I} size="lg" tagline={false} />
+        </div>
+
+        <div className="flex min-h-0 flex-col rounded-lg border border-border bg-card shadow-[0_8px_30px_rgb(0_0_0/0.35)]">
+          {!authed ? (
+            <div className="p-6 sm:p-8">
+              <div className="mb-6 text-center">
+                <h1 className="font-display text-xl font-semibold text-foreground">
+                  Log in to connect <span className="text-brand-300">{host}</span>
+                </h1>
+                <p className="mt-1 text-sm text-muted-foreground">Sign in to your node, then choose what to share.</p>
+              </div>
+              <LoginForm I={I} embedded />
+            </div>
+          ) : requests.length === 0 ? (
+            <div className="flex flex-col items-center p-8 text-center" data-testid="consent-allset">
+              <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-brand-muted">
+                <ShieldCheck className="h-6 w-6 text-brand-300" strokeWidth={1.5} />
+              </div>
+              <h1 className="font-display text-xl font-semibold text-foreground">You're all set</h1>
+              <p className="mt-1.5 text-sm text-muted-foreground">
+                {alreadyShared.length > 0 ? (
+                  <>
+                    <span className="text-foreground">{host}</span> already has access to{' '}
+                    <span className="text-foreground">{alreadyShared.join(', ')}</span>. Nothing new to review.
+                  </>
+                ) : (
+                  <>Nothing left to review. Head back to <span className="text-foreground">{host}</span>.</>
+                )}
+              </p>
+              <Button variant="brand" className="mt-6 w-full" onClick={() => I.goToApp()} data-testid="consent-goto-app">
+                Go to {host}
+                <ArrowRight className="ml-1.5 h-4 w-4" strokeWidth={2} />
+              </Button>
+            </div>
+          ) : (
+            <>
+              {/* header — fixed */}
+              <div className="shrink-0 border-b border-border p-5 text-center">
+                <h1 className="font-display text-xl font-semibold text-foreground">
+                  Connect <span className="text-brand-300">{host}</span>
+                </h1>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Requesting {requests.length} new {requests.length === 1 ? 'service' : 'services'}. Tap any to see details.
+                </p>
+                {alreadyShared.length > 0 && (
+                  <p className="mt-2 text-xs text-muted-foreground/70">
+                    Already shared: <span className="text-muted-foreground">{alreadyShared.join(', ')}</span>
+                  </p>
+                )}
+              </div>
+
+              {/* request list — scrolls internally so the actions stay visible */}
+              <div className="min-h-0 flex-1 space-y-2.5 overflow-y-auto p-4">
+                {requests.map(({ req, kind }, idx) => (
+                  <RequestRow
+                    key={`${req.service}-${idx}`}
+                    req={req}
+                    kind={kind}
+                    idx={idx}
+                    current={services.find((s) => s.service === req.service)}
+                    onApprove={() => (kind === 'new' ? I.submitSIR(req) : I.changeTerms(req))}
+                    onDeny={() => I.purgeSMR(req)}
+                  />
+                ))}
+              </div>
+
+              {/* actions — always visible, no scrolling required */}
+              <div className="shrink-0 space-y-2 border-t border-border p-4">
+                {I.status && (
+                  <p className="text-center text-sm text-muted-foreground" role="status">{I.status}</p>
+                )}
+                <Button variant="brand" className="w-full" onClick={() => I.approveAll()} data-testid="consent-approve-all">
+                  Approve all &amp; continue
+                </Button>
+                <Button
+                  variant="ghost"
+                  className="w-full text-muted-foreground hover:text-foreground"
+                  onClick={() => I.goToApp()}
+                  data-testid="consent-skip"
+                >
+                  Continue without sharing
+                </Button>
+              </div>
+            </>
+          )}
+        </div>
+
+        {authed && (
+          <p className="mt-4 shrink-0 text-center text-xs text-muted-foreground">
+            Signed in as <span className="text-foreground">{username}</span>
+            {' · '}
+            <button
+              type="button"
+              onClick={() => I.logout()}
+              className="rounded underline-offset-2 hover:text-foreground hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              data-testid="consent-logout"
+            >
+              Not you? Log out
+            </button>
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default ConsentView;

--- a/ui/src/components/Contracts/RequestPage.tsx
+++ b/ui/src/components/Contracts/RequestPage.tsx
@@ -4,6 +4,21 @@ import { CircleCheck, SquarePlus, SquareMinus } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 
+// A whitelist/blacklist entry is {username, provider, <action>: true, ...}
+// (NOT {anchor, allowed[]} — assuming that shape crashed this page). Derive a
+// readable anchor + the granted actions defensively so no shape can throw.
+function entryAnchor(e: any): string {
+  if (!e || typeof e !== 'object') return String(e);
+  const u = e.username === '.*' || e.username == null ? 'anyone' : e.username;
+  const p = e.provider && e.provider !== '.*' ? `@${e.provider}` : '';
+  return `${u}${p}`;
+}
+function entryActions(e: any): string[] {
+  if (!e || typeof e !== 'object') return [];
+  const meta = new Set(['username', 'provider', 'anchor', 'allowed', 'denied']);
+  return Object.keys(e).filter((k) => !meta.has(k) && e[k] === true);
+}
+
 function Requests({ I }: { I: Record<string, any> }) {
   const [mode, setMode] = React.useState("basic");
   const pendingSIRs = I.SMR?.sirs || [];
@@ -48,37 +63,43 @@ function Requests({ I }: { I: Record<string, any> }) {
                   <span className="font-medium text-foreground">{req.service}</span>
                 </div>
                 <div className="p-4">
-                  {req.cross_origins && (
+                  {Array.isArray(req.cross_origins) && req.cross_origins.length > 0 && (
                     <div className="mb-2">
                       <span className="text-sm font-medium text-muted-foreground">Websites/IPs:</span>
                       <div className="mt-1 flex flex-wrap gap-1.5">
                         {req.cross_origins.map((o: string, i: number) => (
-                          <Badge key={i} variant="default">{o}</Badge>
+                          <Badge key={i} variant="default">{String(o)}</Badge>
                         ))}
                       </div>
                     </div>
                   )}
-                  {req.whitelist && (
+                  {Array.isArray(req.whitelist) && req.whitelist.length > 0 && (
                     <div className="mt-2">
                       <span className="text-sm font-medium text-muted-foreground">Allowed:</span>
                       <div className="mt-1 flex flex-wrap gap-1.5">
-                        {req.whitelist.map((w: any, i: number) => (
-                          <Badge key={i} variant="success">
-                            {w.anchor} [{w.allowed.join(", ")}]
-                          </Badge>
-                        ))}
+                        {req.whitelist.map((w: any, i: number) => {
+                          const actions = entryActions(w);
+                          return (
+                            <Badge key={i} variant="success">
+                              {entryAnchor(w)}{actions.length ? ` [${actions.join(", ")}]` : ""}
+                            </Badge>
+                          );
+                        })}
                       </div>
                     </div>
                   )}
-                  {req.blacklist && (
+                  {Array.isArray(req.blacklist) && req.blacklist.length > 0 && (
                     <div className="mt-2">
                       <span className="text-sm font-medium text-muted-foreground">Blocked:</span>
                       <div className="mt-1 flex flex-wrap gap-1.5">
-                        {req.blacklist.map((b: any, i: number) => (
-                          <Badge key={i} variant="danger">
-                            {b.anchor} [{b.denied.join(", ")}]
-                          </Badge>
-                        ))}
+                        {req.blacklist.map((b: any, i: number) => {
+                          const actions = entryActions(b);
+                          return (
+                            <Badge key={i} variant="danger">
+                              {entryAnchor(b)}{actions.length ? ` [${actions.join(", ")}]` : ""}
+                            </Badge>
+                          );
+                        })}
                       </div>
                     </div>
                   )}

--- a/ui/src/components/Contracts/components/ContractComponents.tsx
+++ b/ui/src/components/Contracts/components/ContractComponents.tsx
@@ -16,7 +16,8 @@ function Tag({ text }: { text: string }) {
 }
 
 function Websites({ contractI }: { contractI: Record<string, any> }) {
-  const sites: string[] = contractI.data.cross_origins;
+  // records without cross_origins (e.g. the "services" record) must not crash
+  const sites: string[] = Array.isArray(contractI.data.cross_origins) ? contractI.data.cross_origins : [];
   if (sites.length === 0) return null;
   return (
     <div className="ml-1 mt-1.5 flex flex-wrap gap-1.5">
@@ -57,14 +58,15 @@ function PermissionList({
   onDelete: (i: number) => void;
   testIdPrefix: string;
 }) {
-  if (entries.length === 0) return null;
+  const list = Array.isArray(entries) ? entries : [];
+  if (list.length === 0) return null;
   return (
     <div className="mt-3">
       <div className="mb-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
         {title}
       </div>
       <div className="space-y-1.5">
-        {entries.map((p: any, i: number) => (
+        {list.map((p: any, i: number) => (
           <div key={i} className="flex flex-wrap items-center gap-1.5 rounded-sm bg-elevated px-2.5 py-1.5">
             <span className="mr-1 text-sm text-muted-foreground">
               {p.provider}/{p.username}

--- a/ui/src/components/CredentialPage/LoginForm.tsx
+++ b/ui/src/components/CredentialPage/LoginForm.tsx
@@ -3,46 +3,71 @@ import Provider from "./FormInputs/Provider";
 import Username from "./FormInputs/Username";
 import { Button } from '@/components/ui/button';
 
-function LoginForm({ I }: { I: Record<string, any> }) {
-  return (
-    <div className="w-full max-w-sm">
-      <div className="rounded border border-border bg-card p-6 sm:p-8">
-        <h1 className="font-display text-xl font-semibold text-foreground">Log in to your node</h1>
-        <p className="mt-1 text-sm text-muted-foreground">Your data, your keys, your rules.</p>
+// `embedded` renders just the fields + actions (no card chrome, no
+// "create account") so it can sit inside another surface — e.g. ConsentView.
+function LoginForm({ I, embedded = false }: { I: Record<string, any>; embedded?: boolean }) {
+  const form = (
+    <>
+      {!embedded && (
+        <>
+          <h1 className="font-display text-xl font-semibold text-foreground">Log in to your node</h1>
+          <p className="mt-1 text-sm text-muted-foreground">Your data, your keys, your rules.</p>
+        </>
+      )}
 
-        <div className="mt-6 space-y-1">
-          <Provider I={I} />
-          <Username I={I} />
-          <Password I={I} />
-        </div>
-
-        <Button
-          variant="brand"
-          className="mt-2 w-full"
-          data-testid="login-submit"
-          onClick={() => {
-            I.login(
-              (document.getElementById("provider") as HTMLInputElement).value,
-              (document.getElementById("username") as HTMLInputElement).value,
-              (document.getElementById("password") as HTMLInputElement).value,
-            );
-          }}
-        >
-          Log in
-        </Button>
-
-        <div className="mt-4 text-center">
-          <button
-            type="button"
-            onClick={() => I.setMode("forgot")}
-            className="rounded text-sm text-brand-300 underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-            data-testid="login-forgot-link"
-          >
-            Forgot username or password?
-          </button>
-        </div>
+      <div className={embedded ? "space-y-1" : "mt-6 space-y-1"}>
+        <Provider I={I} />
+        <Username I={I} />
+        <Password I={I} />
       </div>
 
+      <Button
+        variant="brand"
+        className="mt-2 w-full"
+        data-testid="login-submit"
+        onClick={() => {
+          I.login(
+            (document.getElementById("provider") as HTMLInputElement).value,
+            (document.getElementById("username") as HTMLInputElement).value,
+            (document.getElementById("password") as HTMLInputElement).value,
+          );
+        }}
+      >
+        Log in
+      </Button>
+
+      <div className="mt-4 text-center">
+        <button
+          type="button"
+          onClick={() => I.setMode("forgot")}
+          className="rounded text-sm text-brand-300 underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          data-testid="login-forgot-link"
+        >
+          Forgot username or password?
+        </button>
+      </div>
+    </>
+  );
+
+  if (embedded) {
+    return (
+      <div>
+        {form}
+        <Button
+          variant="outline"
+          className="mt-4 w-full"
+          onClick={() => I.setMode("signup")}
+          data-testid="login-create-account"
+        >
+          Create a new account
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full max-w-sm">
+      <div className="rounded border border-border bg-card p-6 sm:p-8">{form}</div>
       <Button
         variant="outline"
         className="mt-4 w-full"

--- a/ui/src/components/shared/AppShell.tsx
+++ b/ui/src/components/shared/AppShell.tsx
@@ -20,11 +20,14 @@ interface AppShellProps {
 // copy-pasted into all five pages so the layout lives in exactly one place.
 function AppShell({ I, children, maxWidth = 'max-w-4xl', testid, padded = true }: AppShellProps) {
   return (
-    <div className="flex min-h-screen bg-background text-foreground">
+    // h-screen + overflow-hidden keeps the sidebar and top bar fixed; only the
+    // <main> content scrolls (its own scrollbar), instead of the whole page
+    // (which stretched the sidebar down with long content).
+    <div className="flex h-screen overflow-hidden bg-background text-foreground">
       <SideBar I={I} />
       <div className="flex min-w-0 flex-1 flex-col">
         <TopBar I={I} />
-        <main className="flex-1 overflow-auto pb-16 md:pb-0">
+        <main className="flex-1 overflow-y-auto pb-16 md:pb-0">
           {padded ? (
             <div className={cn('mx-auto p-4 sm:p-6', maxWidth)} data-testid={testid}>
               {children}

--- a/ui/src/components/shared/ErrorBoundary.tsx
+++ b/ui/src/components/shared/ErrorBoundary.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+// Last-resort guard: a render throw anywhere below here shows a designed
+// error state instead of a blank white/black page (design.md §1). Several
+// "blank page" reports traced to unhandled render throws — this contains them.
+interface State {
+  error: Error | null;
+}
+
+class ErrorBoundary extends React.Component<{ children: React.ReactNode }, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    // eslint-disable-next-line no-console
+    console.error('web10 UI crashed:', error, info);
+  }
+
+  render() {
+    if (!this.state.error) return this.props.children;
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-background p-6 text-foreground">
+        <div className="w-full max-w-md rounded-lg border border-border bg-card p-6 text-center">
+          <h1 className="font-display text-lg font-semibold text-foreground">Something went wrong</h1>
+          <p className="mt-1.5 text-sm text-muted-foreground">
+            This screen hit an unexpected error. Your data and login are safe.
+          </p>
+          <div className="mt-4 flex justify-center gap-2">
+            <button
+              type="button"
+              onClick={() => this.setState({ error: null })}
+              className="inline-flex h-9 items-center rounded bg-brand px-4 text-sm font-medium text-brand-foreground transition-colors hover:bg-brand-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              Try again
+            </button>
+            <button
+              type="button"
+              onClick={() => window.location.reload()}
+              className="inline-flex h-9 items-center rounded border border-input px-4 text-sm font-medium transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              Reload
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default ErrorBoundary;

--- a/ui/src/interfaces/Interface.tsx
+++ b/ui/src/interfaces/Interface.tsx
@@ -3,6 +3,19 @@ import web10AuthAdapterInit from './authAdapter'
 import axios from 'axios'
 import { config } from '../config';
 
+// Build a service-change update from a desired terms record: $set the changed
+// term fields, $unset cleared ones, never touching protected star fields.
+function buildSCR(service: any) {
+    const SCR: Record<string, any> = { PULL: true, $unset: {}, $set: {} };
+    const starFields = ["_id", "hashed_password", "customer_id", "business_id", "service", "credit_limit", "space_limit"];
+    for (const [key, value] of Object.entries(service)) {
+        if (key === "_id" || key === "service" || starFields.includes(key)) continue;
+        if (value === undefined || value === null) SCR["$unset"][key] = "";
+        else SCR["$set"][key] = value;
+    }
+    return SCR;
+}
+
 function useInterface() {
     const I = {} as Record<string, any>;
 
@@ -199,56 +212,114 @@ function useInterface() {
     }
 
     I.changeTerms = function (service: any) {
-        const SCR = { PULL: true, $unset: {}, $set: {} };
-        const starFields = ["_id", "hashed_password", "customer_id", "business_id", "service", "credit_limit", "space_limit"];
-        for (const [key, value] of Object.entries(service)) {
-            if (key === "_id" || key === "service" || starFields.includes(key)) continue;
-            if (value === undefined || value === null) {
-                SCR["$unset"][key] = "";
-            } else {
-                SCR["$set"][key] = value;
-            }
-        }
         I.setStatus("Saving service terms...");
         I.wapi
-            .update("services", { service: service.service }, SCR)
+            .update("services", { service: service.service }, buildSCR(service))
             .then(() => {
                 I.setStatus("Service terms saved!");
                 const newServices = I.services.map((s: any) => s.service === service.service ? service : s);
                 I.setServices(newServices);
+                // approving a modification clears it from the pending list too,
+                // and ships the token only once nothing is left to review
+                I.resolveRequest({
+                    scrs: (I.SMR["scrs"] || []).filter((s: any) => s["service"] !== service["service"]),
+                    sirs: I.SMR["sirs"],
+                });
                 setTimeout(() => I.setStatus(null), 2000);
             })
             .catch((e) => I.setStatus("Failed to save: " + (e.response?.data?.detail || String(e))));
     }
 
+    // Approving/denying just updates the pending list now — the token is NOT
+    // auto-sent. The user explicitly returns to the app via "go to the app"
+    // (goToApp) or "continue without approving". This lets them approve some,
+    // all (approveAll), or none (withhold data) and still reach the app.
+    I.resolveRequest = function (nextSMR: any) {
+        I.setSMR(nextSMR);
+    }
+
     I.submitSIR = function (service: any) {
-        I.setStatus("Creating service...");
+        // Never create a second terms record for a service that already has one
+        // (that's how duplicate contracts appeared). If it exists, just clear
+        // the request — the grant is already in place.
+        const exists = (I.services || []).some((s: any) => s["service"] === service["service"]);
+        if (exists) {
+            I.resolveRequest({
+                scrs: I.SMR["scrs"],
+                sirs: (I.SMR["sirs"] || []).filter((sir: any) => sir["service"] !== service["service"]),
+            });
+            return;
+        }
+        I.setStatus("Approving service...");
         I.wapi
             .create("services", service)
             .then(() => {
-                I.setStatus("Service created!");
+                I.setStatus(null);
                 I.servicesLoad();
-                I.setSMR({
+                I.resolveRequest({
                     scrs: I.SMR["scrs"],
-                    sirs: I.SMR["sirs"].filter((sir: any) => sir["service"] !== service["service"]),
+                    sirs: (I.SMR["sirs"] || []).filter((sir: any) => sir["service"] !== service["service"]),
                 });
-                I.sendToken();
             })
-            .catch((e) => I.setStatus("Failed to create: " + (e.response?.data?.detail || String(e))));
+            .catch((e) => I.setStatus("Failed to approve: " + (e.response?.data?.detail || String(e))));
     }
 
     I.purgeSMR = function (service: any) {
-        I.setSMR({
-            scrs: I.SMR["scrs"],
-            sirs: I.SMR["sirs"].filter((sir: any) => sir["service"] !== service["service"]),
+        // deny removes the request from whichever list it's in
+        I.resolveRequest({
+            scrs: (I.SMR["scrs"] || []).filter((s: any) => s["service"] !== service["service"]),
+            sirs: (I.SMR["sirs"] || []).filter((s: any) => s["service"] !== service["service"]),
         });
         I.setStatus("Request denied.");
-        I.sendToken();
+    }
+
+    // Approve every pending request in one shot, then return to the app.
+    // Skip SIRs for services already granted — re-creating them just makes
+    // duplicate contract records.
+    I.approveAll = function () {
+        const granted = new Set((I.services || []).map((s: any) => s.service));
+        const sirs = (I.SMR["sirs"] || []).filter((s: any) => !granted.has(s.service));
+        const scrs = I.SMR["scrs"] || [];
+        if (sirs.length + scrs.length === 0) { I.goToApp(); return; }
+        I.setStatus("Approving all…");
+        const ops = [
+            ...sirs.map((s: any) => I.wapi.create("services", s)),
+            ...scrs.map((s: any) => I.wapi.update("services", { service: s.service }, buildSCR(s))),
+        ];
+        Promise.all(ops)
+            .then(() => {
+                I.servicesLoad();
+                I.setSMR({ scrs: [], sirs: [] });
+                I.setStatus(null);
+                I.goToApp();
+            })
+            .catch((e: any) => I.setStatus("Failed to approve all: " + (e.response?.data?.detail || String(e))));
+    }
+
+    // Return to the requesting app, logging it in. Mint a FRESH scoped token
+    // for the referrer right here rather than trusting wapiAuth.oAuthToken to
+    // already be set (it's minted async at load/login and often wasn't ready,
+    // so the app never received a token). Approving nothing still logs the app
+    // in — it just has no data grants (withheld).
+    I.goToApp = function () {
+        const decoded = I.wapi.readToken?.();
+        let host: string | null = null;
+        try { host = document.referrer ? new URL(document.referrer).hostname : null; } catch { host = null; }
+        if (decoded && host && I.wapi.getTieredToken) {
+            I.setStatus("Connecting…");
+            I.wapi.getTieredToken(host, decoded.provider)
+                .then((r: any) => { I.wapiAuth.oAuthToken = r.data.token; I.sendToken(); })
+                .catch(() => I.sendToken());
+        } else {
+            I.sendToken();
+        }
     }
 
     I.sendToken = function () {
-        if (I.wapiAuth.oAuthToken) {
+        if (I.wapiAuth.oAuthToken && I.wapiAuth.sendToken) {
             I.wapiAuth.sendToken();
+        } else if (window.opener) {
+            window.close();
         }
     }
 

--- a/ui/src/interfaces/MockInterface.tsx
+++ b/ui/src/interfaces/MockInterface.tsx
@@ -92,17 +92,39 @@ function useMockInterface() {
         return I.verified;
     }
 
-    I.changeTerms = function (service: any) {
-        const newServices = I.services.map(
-            (s: any) => {
-                return s.service === service.service ? service : s
-            }
-        )
-        I.setServices(newServices)
+    // Mirror the real interface: only hand the token back once ALL pending
+    // requests (SIRs + SCRs) are resolved (see Interface.tsx).
+    I.resolveRequest = function (nextSMR: any) {
+        I.setSMR(nextSMR);
+        const remaining = (nextSMR.sirs?.length || 0) + (nextSMR.scrs?.length || 0);
+        if (remaining === 0) I.sendToken();
     }
 
-    I.submitSIR = function () { I.setStatus("Mock: service created"); }
-    I.purgeSMR = function () { I.setStatus("Mock: request denied"); }
+    I.changeTerms = function (service: any) {
+        const newServices = I.services.map(
+            (s: any) => (s.service === service.service ? service : s)
+        )
+        I.setServices(newServices)
+        I.resolveRequest({
+            scrs: (I.SMR["scrs"] || []).filter((s: any) => s["service"] !== service["service"]),
+            sirs: I.SMR["sirs"],
+        })
+    }
+
+    I.submitSIR = function (service: any) {
+        I.setStatus("Mock: service created");
+        I.resolveRequest({
+            scrs: I.SMR["scrs"],
+            sirs: (I.SMR["sirs"] || []).filter((s: any) => s["service"] !== service["service"]),
+        })
+    }
+    I.purgeSMR = function (service: any) {
+        I.setStatus("Mock: request denied");
+        I.resolveRequest({
+            scrs: (I.SMR["scrs"] || []).filter((s: any) => s["service"] !== service["service"]),
+            sirs: (I.SMR["sirs"] || []).filter((s: any) => s["service"] !== service["service"]),
+        })
+    }
     I.sendToken = function () { }
     I.deleteService = function () { I.setStatus("Mock: service deleted"); }
     I.wipeServiceData = function () { I.setStatus("Mock: data wiped"); }

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
+import ErrorBoundary from './components/shared/ErrorBoundary'
 // Self-hosted variable fonts (design.md §5) — never a font CDN.
 import '@fontsource-variable/inter'
 import '@fontsource-variable/space-grotesk'
@@ -9,6 +10,8 @@ import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </React.StrictMode>,
 )


### PR DESCRIPTION
Operator-driven rebuild of the app-consent experience, plus the crash fixes surfaced along the way.

## Consent screen (its own space)
A dedicated **`ConsentView`** replaces the floating banner that overlapped the console. When the auth app is opened by another app (`window.opener`), it takes over with a focused, polished screen:
- **Concise by default** — one line per requested service with a plain-English summary.
- **Progressive disclosure** — expand any row for full detail: sites with access, allowed/blocked users with exact permissions, and for a *change* the **delta** (added/removed highlighted). Not a separate "advanced mode" — detail is one tap away.
- **New vs already-shared** — services you've already granted aren't re-asked (shown as "Already shared: …").
- **Sticky actions** — *Approve all & continue* / *Continue without sharing* always visible (no scrolling).

## Login handoff (the "doesn't log in on the app" bug)
`goToApp` now mints a **fresh scoped token** for the referrer and posts it to the opener. Approving a single request no longer ships the token early and strands the rest — the token goes back only when you choose to continue (approve all, or one-by-one then "go to the app").

## Duplicate contracts
`submitSIR` refuses to create a second terms record for an already-granted service (client guard; server-side guard is a companion PR).

## Crash fixes (were blank pages)
- `RequestPage` assumed `{anchor, allowed[]}` but the real shape is `{username, provider, <action>}` → `undefined.join` blanked the review screen. Now defensive + readable.
- The contract viewer crashed expanding records without `whitelist`/`blacklist`/`cross_origins` (e.g. the `services` record). Guarded.
- Top-level **ErrorBoundary** → any render throw shows a designed error state, never a blank page.

## Also
- App shell is fixed-height: sidebar + top bar stay put, only content scrolls (was: whole page scrolled, sidebar stretched).
- `social.localhost` targets `auth.localhost` automatically (any `*.localhost` host is local) → `social → auth → social` works locally without `?local=true`.

## Verification
Screenshots in-thread (consent concise + expanded delta + already-shared; contract expand no-crash). `ui` build clean, **74 tests**. `web10-social` build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)