### PR TITLE
API: reject duplicate service terms records (409)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+1.0.82 || 20.07.2026
+API defends against duplicate service terms. documentdb.create now rejects a
+second terms record for a service that already has one (service=="services"
+with a body.service already present) → 409 DUPLICATE_SERVICE. This is the
+server-side guardrail behind the duplicate-contracts bug (the UI guards it
+too); a service's terms should be updated, not re-created. +2 tests.
 1.0.79 || 19.07.2026
 Prod fixes: missing static assets, wrong readiness API, and the DB override.
 (1) ui/Dockerfile never COPYed public/, so vite had nothing to fold into

--- a/api/app/exceptions.py
+++ b/api/app/exceptions.py
@@ -60,6 +60,11 @@ DSTAR = HTTPException(
     headers={"WWW-Authenticate": "Basic"},
 )
 
+DUPLICATE_SERVICE = HTTPException(
+    status_code=status.HTTP_409_CONFLICT,
+    detail="a terms record for this service already exists — update it instead of creating a duplicate",
+)
+
 RESERVED = HTTPException(
     status_code=status.HTTP_401_UNAUTHORIZED,
     detail="the username 'web10' is reserved",

--- a/api/app/services/documentdb.py
+++ b/api/app/services/documentdb.py
@@ -224,6 +224,12 @@ def temp_pass(phone_number, hash):
 def create(user, service, _data):
     if star_found([_data]):
         raise exceptions.DSTAR
+    # A service's terms record ("services" collection-service) must be unique
+    # per target service — never create a second one (root cause of duplicate
+    # contracts). Callers should update the existing record instead.
+    if service == "services" and isinstance(_data, dict) and _data.get("service"):
+        if db[f"{user}"].find_one({"service": "services", "body.service": _data["service"]}) is not None:
+            raise exceptions.DUPLICATE_SERVICE
     data = to_db(_data, service)
     result = db[f"{user}"].insert_one(data)
     _data["_id"] = str(result.inserted_id)

--- a/api/tests/test_auth_services.py
+++ b/api/tests/test_auth_services.py
@@ -74,7 +74,9 @@ class TestCheckAdmin:
         token = Token(token="admin_token")
         with (
             patch("app.services.auth.certify", return_value=True),
-            patch("app.services.auth.decode_token", return_value=TokenData(username="alice", provider=settings.PROVIDER)),
+            patch(
+                "app.services.auth.decode_token", return_value=TokenData(username="alice", provider=settings.PROVIDER)
+            ),
             patch("app.services.config.is_admin", return_value=True),
         ):
             check_admin(token)  # returns True on success, no exception raised

--- a/api/tests/test_documentdb_crud.py
+++ b/api/tests/test_documentdb_crud.py
@@ -22,6 +22,23 @@ class TestCreate:
         with pytest.raises(Exception):
             documentdb.create("alice", "posts", {"service": "*", "x": 1})
 
+    def test_create_duplicate_service_terms_raises(self):
+        # a terms record for "posts" already exists → creating another is rejected
+        with patch.object(documentdb.db, "__getitem__") as mock_col:
+            mock_col.return_value.find_one.return_value = {"service": "services", "body": {"service": "posts"}}
+            with pytest.raises(Exception):
+                documentdb.create("alice", "services", {"service": "posts", "cross_origins": []})
+
+    def test_create_first_service_terms_ok(self):
+        # no existing terms record → creation proceeds
+        mock_result = MagicMock()
+        mock_result.inserted_id = "oid2"
+        with patch.object(documentdb.db, "__getitem__") as mock_col:
+            mock_col.return_value.find_one.return_value = None
+            mock_col.return_value.insert_one.return_value = mock_result
+            result = documentdb.create("alice", "services", {"service": "posts", "cross_origins": []})
+            assert result["_id"] == "oid2"
+
 
 class TestRead:
     def test_read_basic(self):


### PR DESCRIPTION
Server-side guardrail behind the duplicate-contracts bug (companion to the UI guard in the consent PR).

## What
`documentdb.create` now rejects creating a **second terms record** for a service that already has one — when `service == "services"` and a record with the same `body.service` already exists in the user's collection, it raises **`DUPLICATE_SERVICE` (409)**. A service's terms should be *updated*, not recreated (which is how duplicate "contracts" appeared).

## Tests
- `test_create_duplicate_service_terms_raises` — existing terms → rejected
- `test_create_first_service_terms_ok` — no existing terms → proceeds
- Full suite: **291 passed**

## Notes
Lane A (`api/`). Doesn't touch star protection or the permission model — just enforces uniqueness of a service's terms record. Existing duplicates in data are a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)