### PR TITLE
Align sidebar brand header with the top bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.0.83 || 20.07.2026
+Align the auth console sidebar header with the top bar. The brand header was
+py-5 (taller) while the top bar is h-14, so their bottom borders didn't line
+up at the seam. Made the sidebar header h-14 too — dividers now match.
 1.0.82 || 20.07.2026
 API defends against duplicate service terms. documentdb.create now rejects a
 second terms record for a service that already has one (service=="services"

--- a/ui/src/components/shared/SideBar.tsx
+++ b/ui/src/components/shared/SideBar.tsx
@@ -97,7 +97,8 @@ function SideBar({ I }: SideBarProps) {
       className="hidden w-64 shrink-0 flex-col border-r border-border bg-surface md:flex"
       data-testid="sidebar"
     >
-      <div className="border-b border-border px-6 py-5">
+      {/* h-14 matches the TopBar height so their bottom borders line up */}
+      <div className="flex h-14 items-center border-b border-border px-6">
         <button
           type="button"
           onClick={() => I.setMode(authed ? 'contracts' : 'login')}


### PR DESCRIPTION
The sidebar brand header was `py-5` (taller) while the top bar is `h-14`, so their bottom borders didn't line up at the seam — a visible one-off. Made the sidebar header `h-14` too; the dividers now match.

Screenshot in-thread. `ui` build clean, 74 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)