### PR TITLE
Remove Netlify integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+1.0.85 || 20.07.2026
+Remove Netlify integration. Deleted ui/netlify.toml so GitHub pushes no
+longer trigger Netlify builds. Removed web10social.netlify.app from the
+CORS allowlist in web10-social's adapter. All deploys now go through the
+ubuntu box only.
 1.0.84 || 20.07.2026
 D16 (frontend): revive the App Store as a real, live catalog. The
 marketing-ui AppStore page now POSTs the node's /stats and renders real

--- a/marketing/web10-social/src/interfaces/Web10SocialAdapter.ts
+++ b/marketing/web10-social/src/interfaces/Web10SocialAdapter.ts
@@ -193,7 +193,7 @@ const web10SocialAdapterInit = (): Web10SocialAdapter => {
   // is actually served from means a dev/prod deploy authorizes itself
   // without this list needing a code edit per environment.
   const crossOrigins = Array.from(
-    new Set(['localhost', 'web10social.netlify.app', 'social.web10.app', window.location.hostname]),
+    new Set(['localhost', 'social.web10.app', window.location.hostname]),
   );
 
   const sirs = [


### PR DESCRIPTION
Deleted empty `ui/netlify.toml` so GitHub pushes no longer trigger Netlify builds. Removed `web10social.netlify.app` from web10-social's CORS allowlist. All deploys go through the ubuntu box only.