### PR TITLE
docs: add branch naming conventions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,25 @@ pre-existing on `dev` and not caused by your branch, prove it (link
 the same failure on a `dev` run or another PR) and say so explicitly —
 never silently call a red PR ready.
 
+## Branch naming conventions
+
+Every branch must use a type prefix so the history is scannable:
+
+| Prefix | Use when |
+|--------|----------|
+| `feature/` | New functionality, UI screens, endpoints |
+| `fix/` | Bug fixes, security patches, regression fixes |
+| `refactor/` | Code restructuring with no behavioral change |
+| `chore/` | Deps, CI, tooling, docs, config |
+| `test/` | Test additions or test infrastructure |
+| `docs/` | Documentation only (CLAUDE.md, plan.txt, etc.) |
+
+**Format:** `type/short-description` — e.g. `fix/auth-token-expiry`, `feature/social-feed`.
+
+Keep descriptions imperative, hyphen-separated, under ~40 characters. No need to include your username or lane — `git log` and the PR already carry that.
+
+Existing `lane-x/` and `username/` branches are fine historically. New branches after this rule should follow the type-prefix format.
+
 ## PRs always go to `dev`, never `main`
 
 The base branch for every PR is `dev`. `main` is only updated by an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+1.0.86 || 20.07.2026
+Add branch naming conventions to AGENTS.md: all new branches must use a
+type prefix (feature/, fix/, refactor/, chore/, test/, docs/) followed by
+a short imperative description, e.g. fix/auth-token-expiry. Existing
+lane-x/ and username/ branches grandfathered.
+
 1.0.85 || 20.07.2026
 Remove Netlify integration. Deleted ui/netlify.toml so GitHub pushes no
 longer trigger Netlify builds. Removed web10social.netlify.app from the


### PR DESCRIPTION
All new branches must use a type prefix so history is scannable:

| Prefix | Use when |
|--------|----------|
| `feature/` | New functionality, UI screens, endpoints |
| `fix/` | Bug fixes, security patches, regression fixes |
| `refactor/` | Code restructuring with no behavioral change |
| `chore/` | Deps, CI, tooling, docs, config |
| `test/` | Test additions or test infrastructure |
| `docs/` | Documentation only |

**Format:** `type/short-description` — e.g. `fix/auth-token-expiry`

Existing `lane-x/` and `username/` branches are grandfathered.