### PR TITLE
D12 vibrancy overhaul: web10-social Kick-grade energy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+1.0.86 || 21.07.2026
+D12 follow-up: web10-social vibrancy overhaul. The social flagship was
+muted — flat surfaces, no ambient light, zero interaction energy —
+compared to Kick's vibrant, alive feel. design.md §4 relaxed: glow
+tokens (`--color-glow`, `--color-glow-intense`, `--color-glow-danger`)
+added for the social app (console stays restrained). New animations
+in index.css: shimmer skeleton sweep, heart-burst on like, glow-pulse
+for presence indicators, brand-glow-pulse for ambient energy, float
+for login particles. Custom dark scrollbar. Button gradient brand
+variant with glow-on-hover, `brand_subtle` variant. Badge `brand_glow`
+and `live` (pulsing) variants. Skeleton gradient shimmer replaces
+solid pulse. Layout: sidebar gradient, ambient glow orb, active nav
+glow pill with pulse dot, mobile nav gradient indicator. Feed: card
+hover glow, heart-burst animation on like with danger drop-shadow,
+vibrant brand-tinted tags, origin badges with glow, gradient empty
+state icon, media hover zoom + overlay. Composer: focus glow bar,
+media preview hover scale + ring. Profile: vibrant banner gradient,
+avatar glow ring, gradient avatar fallback, gradient tab indicators,
+media grid hover zoom + overlay. DMs: gradient sent bubbles with
+shadow, presence dots with pulse, conversation list presence indicators.
+Login: animated gradient background, floating ambient orbs. 195 tests
+green, tsc clean, build clean.
 1.0.85 || 20.07.2026
 Remove Netlify integration. Deleted ui/netlify.toml so GitHub pushes no
 longer trigger Netlify builds. Removed web10social.netlify.app from the

--- a/design.md
+++ b/design.md
@@ -169,11 +169,32 @@ rejection — if a color isn't a token, it doesn't exist.
 | `--color-brand-600` | `#7c3aed` | Pressed/active states of brand fills. |
 | `--color-brand-muted` | `#2e1065` | Brand-tinted backgrounds: active-nav pill fills, selected rows, badge backgrounds. |
 
-Usage discipline: violet is an accent, not wallpaper. One primary CTA
-per view. Active states, focus rings, key stats, the occasional glow
-(a soft `brand` blur behind a hero mark or CTA — the ONE permitted
-decorative flourish, used at most once per screen). If a screen is
-more than ~10% violet, pull back.
+### Glow — ambient light (social flagship only)
+
+These tokens exist so the social app (`web10-social`) can have ambient energy
+without hardcoded hex values. The console (`ui/`) and marketing site stay
+restrained; the social flagship is the deck screenshot and earns the extra
+light. See §10 for per-app direction.
+
+| Token | Value | Role |
+|---|---|---|
+| `--color-glow` | `rgba(139, 92, 246, 0.15)` | Soft ambient glow behind active nav pills, card hover halos, section anchors. |
+| `--color-glow-intense` | `rgba(139, 92, 246, 0.35)` | Focused composer glow, active CTA halos, live indicator pulse. |
+| `--color-glow-danger` | `rgba(239, 68, 68, 0.25)` | Like-burst animation, heart-pop afterglow. |
+
+Usage discipline (social only): violet is still an accent, not wallpaper.
+But the social flagship may use glow liberally as ambient light — a soft
+`brand` blur behind active elements, a colored `box-shadow` on card hovers,
+a pulse on interactive feedback. The rule shifts from "one flourish per
+screen" to "glow is the texture, not the content." If the feed looks like
+a dark spreadsheet, add glow. If it looks like a purple laser show, pull
+back. The middle is Kick-grade: energy without chaos.
+
+### Glow — ambient light (console & marketing)
+
+The node console (`ui/`) and marketing site (`marketing-ui`) remain
+restrained: one decorative glow per screen maximum (§4 original rule).
+The console is an operator tool; it reads calm.
 
 ### Semantic
 
@@ -262,12 +283,18 @@ Motion confirms causality; it never performs.
 - **Marketing reveals**: 400–600ms fade/rise on scroll-into-view, once,
   staggered ≤ 80ms apart. No parallax, no scroll-jacking, no looping
   attention-seekers.
-- **Skeletons** pulse at ~1.5s; content replaces them in place (no
-  shift). Spinners only where a skeleton is impossible.
+- **Skeletons** shimmer at ~1.5s (gradient sweep, not solid pulse);
+  content replaces them in place (no shift). Spinners only where a
+  skeleton is impossible.
 - `prefers-reduced-motion: reduce` is honored everywhere: transitions
   collapse to instant, reveals render visible.
 - App UI (`ui/`, admin surfaces): no spring/bounce easings. The
-  console is calm. Social/marketing may be 10% springier, never circus.
+  console is calm.
+- **Social flagship** (`web10-social`) may be 10% springier:
+  heart-burst on like (300ms scale + fade), shimmer skeletons,
+  glow-pulse on live/presence indicators (2s ease-in-out infinite),
+  card-hover lifts with brand `box-shadow`. Still no circus — energy,
+  not chaos.
 
 
 ## 8. Components
@@ -359,6 +386,14 @@ gaps: `@tailwindcss/vite` plugin is missing from `vite.config.ts`
 loaded. Finish evicting the excluded legacy `rectangles-npm`/
 `@chatscope` components.
 
+Vibrancy: the social flagship is the energy surface. Unlike the calm
+console (`ui/`), it earns ambient light: glow behind active nav items,
+card-hover halos, heart-burst on like, shimmer skeletons, gradient
+bubbles in DMs, presence pulses, a living login screen. The tokens
+`--color-glow`, `--color-glow-intense`, `--color-glow-danger` exist
+for this app. See §4 glow section and §7 social motion. The bar is
+Kick-grade: vibrant, alive, never muted.
+
 
 ## 11. Accessibility (part of pretty, not opposed to it)
 
@@ -423,6 +458,11 @@ the missing steps.
   --color-brand-600: #7c3aed;
   --color-brand-muted: #2e1065;
   --color-brand-foreground: #fafafa;
+
+  /* glow — ambient light, social flagship (§4) */
+  --color-glow: rgba(139, 92, 246, 0.15);
+  --color-glow-intense: rgba(139, 92, 246, 0.35);
+  --color-glow-danger: rgba(239, 68, 68, 0.25);
 
   /* semantic (§4) */
   --color-success: #22c55e;

--- a/marketing/web10-social/src/App.tsx
+++ b/marketing/web10-social/src/App.tsx
@@ -13,6 +13,24 @@ import type { Mode } from '@/types';
 function LoginScreen({ onLogin }: { onLogin: () => void }) {
   return (
     <div className="relative flex flex-col items-center justify-center min-h-screen bg-background px-6 overflow-hidden">
+      {/* Animated gradient background */}
+      <div
+        className="pointer-events-none absolute inset-0 bg-gradient-to-br from-brand/10 via-transparent to-brand-muted/20"
+        aria-hidden="true"
+      />
+      {/* Floating ambient orbs */}
+      <div
+        className="pointer-events-none absolute top-1/4 left-1/4 h-64 w-64 rounded-full bg-brand/10 blur-3xl animate-float-slow"
+        aria-hidden="true"
+      />
+      <div
+        className="pointer-events-none absolute bottom-1/4 right-1/4 h-48 w-48 rounded-full bg-brand-600/10 blur-3xl animate-float-medium"
+        aria-hidden="true"
+      />
+      <div
+        className="pointer-events-none absolute top-1/2 right-1/3 h-32 w-32 rounded-full bg-brand-400/8 blur-2xl animate-float-fast"
+        aria-hidden="true"
+      />
       {/* design.md §4 — the one permitted decorative flourish: a soft brand glow behind the mark. */}
       <div
         className="pointer-events-none absolute top-1/2 left-1/2 h-80 w-80 -translate-x-1/2 -translate-y-[60%] rounded-full bg-brand/20 blur-3xl"

--- a/marketing/web10-social/src/components/Bio/ProfileScreen.tsx
+++ b/marketing/web10-social/src/components/Bio/ProfileScreen.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
 import { Textarea } from '@/components/ui/textarea';
 import { Input } from '@/components/ui/input';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -12,8 +13,11 @@ import { cn } from '@/lib/utils';
 function ProfileEmptyState() {
   return (
     <div className="flex flex-col items-center justify-center py-24 px-8 text-center" data-testid="profile-empty">
-      <div className="w-16 h-16 rounded-2xl bg-brand-muted flex items-center justify-center mb-6">
-        <Sparkles className="w-8 h-8 text-brand-300" />
+      <div className={cn(
+        'w-16 h-16 rounded-2xl bg-gradient-to-br from-brand to-brand-600 flex items-center justify-center mb-6',
+        'shadow-lg shadow-brand/25',
+      )}>
+        <Sparkles className="w-8 h-8 text-white" />
       </div>
       <h3 className="font-display text-lg font-semibold text-foreground mb-2">Your profile is empty</h3>
       <p className="text-sm text-muted-foreground max-w-xs mb-6">
@@ -127,8 +131,16 @@ export default function ProfileScreen() {
 
   return (
     <div>
-      {/* Banner — creator page (design.md §10) */}
-      <div className="relative h-32 sm:h-44 w-full bg-gradient-to-br from-brand-muted via-elevated to-background group">
+      {/* Banner — creator page with vibrant gradient */}
+      <div className={cn(
+        'relative h-32 sm:h-44 w-full group overflow-hidden',
+        'bg-gradient-to-br from-brand/40 via-brand-muted to-background',
+      )}>
+        {/* Ambient glow layer */}
+        <div
+          className="absolute inset-0 bg-gradient-to-t from-background/60 via-transparent to-brand/10"
+          aria-hidden="true"
+        />
         {bannerMedia && (
           <img src={bannerMedia.url} alt="" className="absolute inset-0 w-full h-full object-cover" />
         )}
@@ -136,7 +148,7 @@ export default function ProfileScreen() {
           onClick={() => handleUpload('banner_ref')}
           aria-label="Change banner"
           data-testid="edit-banner-button"
-          className="absolute bottom-2 right-2 flex items-center gap-1.5 px-2.5 h-9 rounded bg-background/70 border border-border text-xs text-foreground opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity backdrop-blur-sm"
+          className="absolute bottom-2 right-2 flex items-center gap-1.5 px-2.5 h-9 rounded-lg bg-background/70 border border-border text-xs text-foreground opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity backdrop-blur-sm hover:border-brand/30 hover:bg-background/90"
         >
           <ImagePlus className="w-3.5 h-3.5" />
           Banner
@@ -147,17 +159,20 @@ export default function ProfileScreen() {
       <div className="px-4 pt-4 pb-4">
         <div className="flex items-start justify-between gap-6 -mt-14">
           <div className="relative group">
-            <Avatar className="h-20 w-20 border-4 border-background">
+            <Avatar className={cn(
+              'h-20 w-20 border-4 border-background transition-shadow duration-150',
+              'ring-2 ring-brand/20 hover:ring-brand/40',
+            )}>
               {profile?.avatar_ref && mediaMap[profile.avatar_ref] ? (
                 <AvatarImage src={mediaMap[profile.avatar_ref].url} alt={profile.display_name || ''} />
               ) : (
-                <AvatarFallback className="bg-brand-muted text-brand-300 text-2xl font-bold">
+                <AvatarFallback className="bg-gradient-to-br from-brand to-brand-600 text-white text-2xl font-bold">
                   {profile?.display_name?.charAt(0)?.toUpperCase() || '?'}
                 </AvatarFallback>
               )}
             </Avatar>
             <button
-              className="absolute bottom-0 right-0 flex items-center justify-center h-7 w-7 rounded-full bg-background border border-border shadow-md opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity"
+              className="absolute bottom-0 right-0 flex items-center justify-center h-7 w-7 rounded-full bg-background border border-border shadow-md opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity hover:border-brand/30"
               aria-label="Change avatar"
               data-testid="edit-avatar-button"
               onClick={() => handleUpload('avatar_ref')}
@@ -167,7 +182,7 @@ export default function ProfileScreen() {
           </div>
           {!editing && (
             <Button
-              variant="outline"
+              variant="brand_subtle"
               size="sm"
               className="mt-14 gap-1.5"
               data-testid="edit-profile-button"
@@ -257,7 +272,7 @@ export default function ProfileScreen() {
                     href={profile.website.startsWith('http') ? profile.website : `https://${profile.website}`}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="text-brand-300 hover:underline"
+                    className="text-brand-300 hover:text-brand-400 hover:underline transition-colors duration-150"
                   >
                     {profile.website}
                   </a>
@@ -286,27 +301,33 @@ export default function ProfileScreen() {
           data-testid="profile-tab-posts"
           aria-current={activeTab === 'posts' ? 'true' : undefined}
           className={cn(
-            'flex-1 min-h-11 py-3 text-sm font-medium text-center transition-colors duration-150',
+            'flex-1 min-h-11 py-3 text-sm font-medium text-center transition-all duration-150 relative',
             activeTab === 'posts'
-              ? 'text-foreground border-b-2 border-brand'
+              ? 'text-foreground'
               : 'text-muted-foreground hover:text-foreground',
           )}
           onClick={() => setActiveTab('posts')}
         >
           Posts
+          {activeTab === 'posts' && (
+            <div className="absolute bottom-0 inset-x-0 h-0.5 bg-gradient-to-r from-brand to-brand-600" />
+          )}
         </button>
         <button
           data-testid="profile-tab-media"
           aria-current={activeTab === 'media' ? 'true' : undefined}
           className={cn(
-            'flex-1 min-h-11 py-3 text-sm font-medium text-center transition-colors duration-150',
+            'flex-1 min-h-11 py-3 text-sm font-medium text-center transition-all duration-150 relative',
             activeTab === 'media'
-              ? 'text-foreground border-b-2 border-brand'
+              ? 'text-foreground'
               : 'text-muted-foreground hover:text-foreground',
           )}
           onClick={() => setActiveTab('media')}
         >
           Media
+          {activeTab === 'media' && (
+            <div className="absolute bottom-0 inset-x-0 h-0.5 bg-gradient-to-r from-brand to-brand-600" />
+          )}
         </button>
       </div>
 
@@ -320,17 +341,23 @@ export default function ProfileScreen() {
                 return (
                   <div key={post._id} className="aspect-square bg-elevated overflow-hidden relative group">
                     {firstMedia ? (
-                      <img src={firstMedia.url} alt="" className="w-full h-full object-cover" loading="lazy" />
+                      <img
+                        src={firstMedia.url}
+                        alt=""
+                        className="w-full h-full object-cover transition-transform duration-150 group-hover:scale-110"
+                        loading="lazy"
+                      />
                     ) : post.text ? (
                       <div className="w-full h-full p-3 flex items-start">
                         <p className="text-xs text-muted-foreground line-clamp-6">{post.text}</p>
                       </div>
                     ) : null}
                     {(post.media_refs?.length || 0) > 1 && (
-                      <div className="absolute top-2 right-2 bg-background/70 text-foreground text-xs px-1.5 py-0.5 rounded backdrop-blur-sm">
+                      <div className="absolute top-2 right-2 bg-background/80 text-foreground text-xs px-1.5 py-0.5 rounded-md backdrop-blur-sm border border-border/50">
                         {post.media_refs?.length}
                       </div>
                     )}
+                    <div className="absolute inset-0 bg-gradient-to-t from-black/30 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-150" />
                   </div>
                 );
               })}
@@ -347,8 +374,14 @@ export default function ProfileScreen() {
                 const media = mediaMap[ref];
                 if (!media) return null;
                 return (
-                  <div key={ref} className="aspect-square bg-elevated overflow-hidden">
-                    <img src={media.url} alt={media.alt_text || ''} className="w-full h-full object-cover" loading="lazy" />
+                  <div key={ref} className="aspect-square bg-elevated overflow-hidden group">
+                    <img
+                      src={media.url}
+                      alt={media.alt_text || ''}
+                      className="w-full h-full object-cover transition-transform duration-150 group-hover:scale-110"
+                      loading="lazy"
+                    />
+                    <div className="absolute inset-0 bg-gradient-to-t from-black/30 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-150" />
                   </div>
                 );
               }),

--- a/marketing/web10-social/src/components/Chat/DmsScreen.tsx
+++ b/marketing/web10-social/src/components/Chat/DmsScreen.tsx
@@ -26,8 +26,11 @@ function formatTime(dateStr: string): string {
 function DmsEmptyState() {
   return (
     <div className="flex flex-col items-center justify-center h-full py-24 px-8 text-center" data-testid="dms-empty">
-      <div className="w-16 h-16 rounded-2xl bg-brand-muted flex items-center justify-center mb-6">
-        <Sparkles className="w-8 h-8 text-brand-300" />
+      <div className={cn(
+        'w-16 h-16 rounded-2xl bg-gradient-to-br from-brand to-brand-600 flex items-center justify-center mb-6',
+        'shadow-lg shadow-brand/25',
+      )}>
+        <Sparkles className="w-8 h-8 text-white" />
       </div>
       <h3 className="font-display text-lg font-semibold text-foreground mb-2">No conversations yet</h3>
       <p className="text-sm text-muted-foreground max-w-xs mb-6">
@@ -59,17 +62,36 @@ function DmsSkeleton() {
   );
 }
 
+function TypingIndicator() {
+  return (
+    <div className="flex justify-start">
+      <div className="bg-elevated px-4 py-3 rounded-2xl rounded-bl-md">
+        <div className="flex gap-1">
+          <span className="w-2 h-2 rounded-full bg-muted-foreground/50 animate-bounce" style={{ animationDelay: '0ms' }} />
+          <span className="w-2 h-2 rounded-full bg-muted-foreground/50 animate-bounce" style={{ animationDelay: '150ms' }} />
+          <span className="w-2 h-2 rounded-full bg-muted-foreground/50 animate-bounce" style={{ animationDelay: '300ms' }} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function MessageBubble({ msg, isMe }: { msg: DmRecord; isMe: boolean }) {
   return (
     <div className={cn('flex', isMe ? 'justify-end' : 'justify-start')}>
       <div
         className={cn(
-          'max-w-[75%] px-4 py-2.5 rounded-2xl text-sm leading-relaxed',
-          isMe ? 'bg-brand text-brand-foreground rounded-br-md' : 'bg-elevated text-foreground rounded-bl-md',
+          'max-w-[75%] px-4 py-2.5 rounded-2xl text-sm leading-relaxed transition-shadow duration-150',
+          isMe
+            ? cn(
+                'bg-gradient-to-br from-brand to-brand-600 text-brand-foreground rounded-br-md',
+                'shadow-md shadow-brand/10',
+              )
+            : 'bg-elevated text-foreground rounded-bl-md',
         )}
       >
         <p className="break-words">{msg.message}</p>
-        <p className={cn('text-xs mt-1', isMe ? 'text-brand-foreground/70' : 'text-muted-foreground')}>
+        <p className={cn('text-xs mt-1', isMe ? 'text-brand-foreground/60' : 'text-muted-foreground')}>
           {formatTime(msg.sent_at)}
         </p>
       </div>
@@ -172,26 +194,33 @@ export default function DmsScreen() {
         {/* Header */}
         <div className="flex items-center gap-3 px-2 py-2 border-b border-border">
           <button
-            className="flex items-center justify-center h-11 w-11 hover:bg-elevated rounded transition-colors duration-150"
+            className="flex items-center justify-center h-11 w-11 hover:bg-elevated rounded-lg transition-colors duration-150"
             onClick={() => setSelectedConv(null)}
             aria-label="Back to messages"
             data-testid="dm-back-button"
           >
             <ChevronLeft className="w-5 h-5" />
           </button>
-          <Avatar className="h-8 w-8">
-            <AvatarFallback className="bg-brand-muted text-brand-300 text-xs font-semibold">
-              {displayName.charAt(0).toUpperCase()}
-            </AvatarFallback>
-          </Avatar>
+          <div className="relative">
+            <Avatar className="h-8 w-8">
+              <AvatarFallback className="bg-brand-muted text-brand-300 text-xs font-semibold">
+                {displayName.charAt(0).toUpperCase()}
+              </AvatarFallback>
+            </Avatar>
+            <div className={cn(
+              'absolute -bottom-0.5 -right-0.5 w-2.5 h-2.5 rounded-full border-2 border-background',
+              'bg-success animate-glow-pulse',
+            )} />
+          </div>
           <span className="font-medium text-sm text-foreground">{displayName}</span>
         </div>
 
         {/* Messages */}
         <div className="flex-1 overflow-y-auto px-4 py-4 space-y-3">
           {messages.length === 0 ? (
-            <div className="flex items-center justify-center h-full">
-              <p className="text-sm text-muted-foreground">No messages yet — say hello.</p>
+            <div className="flex flex-col items-center justify-center h-full text-center">
+              <p className="text-sm text-muted-foreground mb-1">No messages yet</p>
+              <p className="text-xs text-muted-foreground/60">Say hello to start the conversation</p>
             </div>
           ) : (
             messages.map((msg) => (
@@ -254,14 +283,20 @@ export default function DmsScreen() {
             <button
               key={conv}
               data-testid="dm-conversation-item"
-              className="w-full flex items-center gap-3 px-4 py-3 min-h-[44px] hover:bg-elevated transition-colors duration-150 text-left"
+              className="w-full flex items-center gap-3 px-4 py-3 min-h-[44px] hover:bg-elevated/80 transition-all duration-150 text-left border-b border-border/30"
               onClick={() => openConversation(conv)}
             >
-              <Avatar className="h-12 w-12">
-                <AvatarFallback className="bg-brand-muted text-brand-300 font-semibold">
-                  {displayName.charAt(0).toUpperCase()}
-                </AvatarFallback>
-              </Avatar>
+              <div className="relative shrink-0">
+                <Avatar className="h-12 w-12">
+                  <AvatarFallback className="bg-brand-muted text-brand-300 font-semibold">
+                    {displayName.charAt(0).toUpperCase()}
+                  </AvatarFallback>
+                </Avatar>
+                <div className={cn(
+                  'absolute -bottom-0.5 -right-0.5 w-3 h-3 rounded-full border-2 border-background',
+                  'bg-success',
+                )} />
+              </div>
               <div className="flex-1 min-w-0">
                 <div className="flex items-center justify-between">
                   <span className="font-medium text-sm text-foreground truncate">{displayName}</span>

--- a/marketing/web10-social/src/components/Feed/FeedScreen.tsx
+++ b/marketing/web10-social/src/components/Feed/FeedScreen.tsx
@@ -1,6 +1,7 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { Select } from '@/components/ui/select';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -46,21 +47,25 @@ function MediaGrid({ mediaItems }: { mediaItems: MediaRecord[] }) {
   return (
     <div
       className={cn(
-        'grid gap-0.5 bg-background overflow-hidden',
+        'grid gap-0.5 bg-background overflow-hidden rounded-t-md',
         count === 1 ? 'grid-cols-1' : count === 2 ? 'grid-cols-2' : 'grid-cols-3',
       )}
     >
       {mediaItems.slice(0, 6).map((m, i) => (
         <div
           key={m._id || i}
-          className={cn('bg-elevated overflow-hidden', count === 1 ? 'aspect-[4/3]' : 'aspect-square')}
+          className={cn(
+            'bg-elevated overflow-hidden group relative',
+            count === 1 ? 'aspect-[4/3]' : 'aspect-square',
+          )}
         >
           <img
             src={m.thumbnail_url || m.url}
             alt={m.alt_text || ''}
-            className="w-full h-full object-cover"
+            className="w-full h-full object-cover transition-transform duration-150 group-hover:scale-105"
             loading="lazy"
           />
+          <div className="absolute inset-0 bg-gradient-to-t from-black/20 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-150" />
         </div>
       ))}
     </div>
@@ -130,7 +135,7 @@ function CommentThread({ postId, isOpen, onCountChange }: CommentThreadProps) {
         <ul className="space-y-2">
           {comments.map((c) => (
             <li key={c._id} className="text-sm leading-relaxed">
-              <span className="font-medium text-foreground">{c.author_username || 'you'}</span>{' '}
+              <span className="font-medium text-brand-300">{c.author_username || 'you'}</span>{' '}
               <span className="text-foreground">{c.text}</span>
             </li>
           ))}
@@ -195,14 +200,26 @@ function PostCard({
 }: PostCardProps) {
   const [commentsOpen, setCommentsOpen] = useState(false);
   const [localCount, setLocalCount] = useState(commentCount);
+  const [burstKey, setBurstKey] = useState(0);
+  const prevLiked = useRef(liked);
+
+  useEffect(() => {
+    if (liked && !prevLiked.current) {
+      setBurstKey((k) => k + 1);
+    }
+    prevLiked.current = liked;
+  }, [liked]);
 
   return (
     <article
       data-testid="post-card"
-      className="bg-card border-b border-border md:border md:rounded-lg md:mb-4 overflow-hidden"
+      className={cn(
+        'bg-card border-b border-border md:border md:rounded-lg md:mb-4 overflow-hidden',
+        'glow-card transition-all duration-150',
+      )}
     >
       <div className="flex items-center gap-2.5 px-4 py-3">
-        <Avatar className="h-9 w-9">
+        <Avatar className="h-9 w-9 ring-2 ring-transparent hover:ring-brand/20 transition-all duration-150">
           {authorAvatar ? (
             <AvatarImage src={authorAvatar} alt={authorName} />
           ) : (
@@ -228,7 +245,10 @@ function PostCard({
       {post.tags?.length ? (
         <div className="flex flex-wrap gap-1.5 px-4 pt-2">
           {post.tags.map((tag) => (
-            <span key={tag} className="text-xs px-2 py-0.5 rounded-full bg-elevated text-muted-foreground">
+            <span
+              key={tag}
+              className="text-xs px-2.5 py-1 rounded-full bg-brand-muted/60 text-brand-300 border border-brand/10 hover:border-brand/30 hover:bg-brand-muted transition-all duration-150 cursor-default"
+            >
               #{tag}
             </span>
           ))}
@@ -237,30 +257,41 @@ function PostCard({
 
       <div className="flex items-center gap-1 px-2 py-2">
         <button
+          key={burstKey}
           data-testid="like-button"
           aria-pressed={liked}
           onClick={onToggleLike}
           className={cn(
-            'flex items-center gap-1.5 px-2.5 py-2 rounded min-h-10 text-sm transition-colors duration-150',
-            liked ? 'text-danger' : 'text-muted-foreground hover:text-foreground hover:bg-elevated',
+            'flex items-center gap-1.5 px-2.5 py-2 rounded-lg min-h-10 text-sm transition-all duration-150',
+            liked
+              ? 'text-danger'
+              : 'text-muted-foreground hover:text-foreground hover:bg-elevated/80',
+            liked && 'animate-heart-burst',
           )}
         >
-          <Heart className="w-[18px] h-[18px]" strokeWidth={1.75} fill={liked ? 'currentColor' : 'none'} />
+          <Heart
+            className={cn(
+              'w-[18px] h-[18px] transition-all duration-150',
+              liked && 'drop-shadow-[0_0_6px_rgba(239,68,68,0.4)]',
+            )}
+            strokeWidth={1.75}
+            fill={liked ? 'currentColor' : 'none'}
+          />
           <span className="tabular-nums">{reactionCount || ''}</span>
         </button>
         <button
           data-testid="comment-button"
           aria-expanded={commentsOpen}
           onClick={() => setCommentsOpen((o) => !o)}
-          className="flex items-center gap-1.5 px-2.5 py-2 rounded min-h-10 text-sm text-muted-foreground hover:text-foreground hover:bg-elevated transition-colors duration-150"
+          className="flex items-center gap-1.5 px-2.5 py-2 rounded-lg min-h-10 text-sm text-muted-foreground hover:text-foreground hover:bg-elevated/80 transition-all duration-150"
         >
           <MessageCircle className="w-[18px] h-[18px]" strokeWidth={1.75} />
           <span className="tabular-nums">{localCount || ''}</span>
         </button>
         {(post.origin || 'web10') !== 'web10' && (
-          <span className="ml-auto mr-2 text-[0.6875rem] uppercase tracking-wide text-muted-foreground">
+          <Badge variant="brand_glow" className="ml-auto mr-2">
             {post.origin}
-          </span>
+          </Badge>
         )}
       </div>
 
@@ -280,8 +311,11 @@ function PostCard({
 function FeedEmptyState() {
   return (
     <div className="flex flex-col items-center justify-center py-24 px-8 text-center" data-testid="feed-empty">
-      <div className="w-16 h-16 rounded-2xl bg-brand-muted flex items-center justify-center mb-6">
-        <Sparkles className="w-8 h-8 text-brand-300" />
+      <div className={cn(
+        'w-16 h-16 rounded-2xl bg-gradient-to-br from-brand to-brand-600 flex items-center justify-center mb-6',
+        'shadow-lg shadow-brand/25',
+      )}>
+        <Sparkles className="w-8 h-8 text-white" />
       </div>
       <h3 className="font-display text-lg font-semibold text-foreground mb-2">Your feed is empty</h3>
       <p className="text-sm text-muted-foreground max-w-xs mb-6">
@@ -407,7 +441,6 @@ export default function FeedScreen() {
       await toggleReaction('posts', postId, 'like', token.username, token.provider);
     } catch (e) {
       console.error('Failed to toggle reaction:', e);
-      // Roll back optimistic update on failure.
       setLikedMap((prev) => ({ ...prev, [postId]: !prev[postId] }));
       setReactionMap((prev) => ({ ...prev, [postId]: (prev[postId] || 0) + (likedMap[postId] ? 1 : -1) }));
     }

--- a/marketing/web10-social/src/components/Feed/PostComposer.tsx
+++ b/marketing/web10-social/src/components/Feed/PostComposer.tsx
@@ -15,6 +15,7 @@ export default function PostComposer({ onPostCreated }: { onPostCreated?: () => 
   const [posting, setPosting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [dragOver, setDragOver] = useState(false);
+  const [focused, setFocused] = useState(false);
   const [profile, setProfile] = useState<ProfileRecord | null>(null);
   const [avatarUrl, setAvatarUrl] = useState<string | undefined>(undefined);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -97,8 +98,9 @@ export default function PostComposer({ onPostCreated }: { onPostCreated?: () => 
   return (
     <div
       className={cn(
-        'px-4 py-4 border-b border-border transition-colors duration-150',
+        'px-4 py-4 border-b border-border transition-all duration-150 relative overflow-hidden',
         dragOver && 'bg-brand-muted/30',
+        focused && 'border-b-brand/30',
       )}
       onDragOver={(e) => {
         e.preventDefault();
@@ -108,6 +110,13 @@ export default function PostComposer({ onPostCreated }: { onPostCreated?: () => 
       onDrop={handleDrop}
       data-testid="post-composer"
     >
+      {/* Ambient glow when focused */}
+      {focused && (
+        <div
+          className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-brand to-transparent"
+          aria-hidden="true"
+        />
+      )}
       <div className="flex gap-3">
         <Avatar className="h-10 w-10 shrink-0">
           {avatarUrl ? (
@@ -123,6 +132,8 @@ export default function PostComposer({ onPostCreated }: { onPostCreated?: () => 
           <Textarea
             value={text}
             onChange={(e) => setText(e.target.value)}
+            onFocus={() => setFocused(true)}
+            onBlur={() => setFocused(false)}
             placeholder="What's on your mind?"
             disabled={posting}
             className="resize-none min-h-[72px] bg-elevated border-0 text-foreground placeholder:text-muted-foreground text-[0.9375rem]"
@@ -138,7 +149,11 @@ export default function PostComposer({ onPostCreated }: { onPostCreated?: () => 
             <div className="mt-3 flex flex-wrap gap-2">
               {mediaPreview.map((url, i) => (
                 <div key={i} className="relative group">
-                  <img src={url} alt={`Preview ${i + 1}`} className="w-20 h-20 rounded object-cover" />
+                  <img
+                    src={url}
+                    alt={`Preview ${i + 1}`}
+                    className="w-20 h-20 rounded-lg object-cover transition-transform duration-150 group-hover:scale-105 ring-1 ring-transparent group-hover:ring-brand/30"
+                  />
                   <button
                     onClick={() => removeMedia(i)}
                     aria-label="Remove attachment"
@@ -164,7 +179,7 @@ export default function PostComposer({ onPostCreated }: { onPostCreated?: () => 
               <Button
                 variant="ghost"
                 size="icon"
-                className="h-10 w-10 text-muted-foreground hover:text-brand"
+                className="h-10 w-10 text-muted-foreground hover:text-brand hover:bg-brand-muted/50 transition-colors duration-150"
                 onClick={() => fileInputRef.current?.click()}
                 disabled={uploading || posting}
                 aria-label="Attach media"

--- a/marketing/web10-social/src/components/Social/Layout.tsx
+++ b/marketing/web10-social/src/components/Social/Layout.tsx
@@ -32,11 +32,19 @@ export default function Layout({ mode, setMode, onLogout, onReportBug, children 
   return (
     <div className="flex min-h-screen bg-background">
       {/* Sidebar - desktop */}
-      <aside className="hidden md:flex flex-col w-64 border-r border-border bg-surface">
-        <div className="p-4">
+      <aside className={cn(
+        'hidden md:flex flex-col w-64 border-r border-border relative overflow-hidden',
+        'bg-gradient-to-b from-surface to-background',
+      )}>
+        {/* Ambient glow behind sidebar */}
+        <div
+          className="pointer-events-none absolute -top-20 -left-20 h-40 w-40 rounded-full bg-brand/5 blur-3xl"
+          aria-hidden="true"
+        />
+        <div className="relative p-4">
           <Wordmark />
         </div>
-        <nav className="flex-1 px-2 space-y-1" aria-label="Primary">
+        <nav className="relative flex-1 px-2 space-y-1" aria-label="Primary">
           {navItems.map(({ mode: m, icon: Icon, label, testId }) => (
             <button
               key={m}
@@ -44,29 +52,38 @@ export default function Layout({ mode, setMode, onLogout, onReportBug, children 
               aria-current={mode === m ? 'page' : undefined}
               onClick={() => setMode(m)}
               className={cn(
-                'w-full flex items-center gap-3 px-3 py-2.5 rounded text-sm font-medium transition-colors duration-150',
+                'w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-all duration-150',
                 mode === m
-                  ? 'bg-brand-muted text-brand-300'
-                  : 'text-muted-foreground hover:text-foreground hover:bg-elevated',
+                  ? cn(
+                      'bg-gradient-to-r from-brand-muted to-brand/15 text-brand-300',
+                      'border border-brand/20 glow-active',
+                    )
+                  : 'text-muted-foreground hover:text-foreground hover:bg-elevated/80 hover:border hover:border-border/50',
               )}
             >
-              <Icon className="w-5 h-5" strokeWidth={1.75} />
+              <Icon className={cn('w-5 h-5 transition-colors duration-150', mode === m && 'text-brand')} strokeWidth={mode === m ? 2 : 1.75} />
               {label}
+              {mode === m && (
+                <div
+                  className="ml-auto w-1.5 h-1.5 rounded-full bg-brand animate-glow-pulse"
+                  aria-hidden="true"
+                />
+              )}
             </button>
           ))}
           <button
             data-testid="nav-new-post"
             onClick={() => setMode('feed')}
             className={cn(
-              'w-full flex items-center gap-3 px-3 py-2.5 rounded text-sm font-medium transition-colors duration-150 mt-4',
-              'text-muted-foreground hover:text-foreground hover:bg-elevated',
+              'w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-all duration-150 mt-4',
+              'text-muted-foreground hover:text-foreground hover:bg-elevated/80 hover:border hover:border-border/50',
             )}
           >
             <PlusCircle className="w-5 h-5" strokeWidth={1.75} />
             New post
           </button>
         </nav>
-        <div className="p-4 border-t border-border space-y-1">
+        <div className="relative p-4 border-t border-border space-y-1">
           <Button
             variant="ghost"
             data-testid="report-bug-button"
@@ -120,10 +137,16 @@ export default function Layout({ mode, setMode, onLogout, onReportBug, children 
               aria-label={label}
               onClick={() => setMode(m)}
               className={cn(
-                'flex-1 flex flex-col items-center justify-center gap-0.5 min-h-11 py-2.5 transition-colors duration-150',
+                'flex-1 flex flex-col items-center justify-center gap-0.5 min-h-11 py-2.5 transition-all duration-150 relative',
                 mode === m ? 'text-brand' : 'text-muted-foreground',
               )}
             >
+              {mode === m && (
+                <div
+                  className="absolute top-0 inset-x-0 h-0.5 bg-gradient-to-r from-brand to-brand-600 rounded-b-full mx-8"
+                  aria-hidden="true"
+                />
+              )}
               <Icon className="w-5 h-5" strokeWidth={mode === m ? 2 : 1.75} />
               <span className="text-[0.625rem] font-medium uppercase tracking-wide">{label}</span>
             </button>

--- a/marketing/web10-social/src/components/ui/badge.tsx
+++ b/marketing/web10-social/src/components/ui/badge.tsx
@@ -3,16 +3,18 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const badgeVariants = cva(
-  'inline-flex items-center rounded-full border px-2 py-0.5 text-[0.6875rem] font-medium uppercase tracking-wide transition-colors',
+  'inline-flex items-center rounded-full border px-2 py-0.5 text-[0.6875rem] font-medium uppercase tracking-wide transition-all duration-150',
   {
     variants: {
       variant: {
         default: 'border-transparent bg-secondary text-secondary-foreground',
         brand: 'border-transparent bg-brand-muted text-brand-300',
+        brand_glow: 'border border-brand/30 bg-brand-muted text-brand-300 shadow-sm shadow-brand/20',
         outline: 'border-border text-muted-foreground',
         success: 'border-transparent bg-success/15 text-success',
         warning: 'border-transparent bg-warning/15 text-warning',
         danger: 'border-transparent bg-danger-muted text-danger',
+        live: 'border border-success/40 bg-success/15 text-success animate-glow-pulse',
       },
     },
     defaultVariants: {

--- a/marketing/web10-social/src/components/ui/button.tsx
+++ b/marketing/web10-social/src/components/ui/button.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center whitespace-nowrap rounded text-sm font-medium transition-colors duration-150 ease-out disabled:pointer-events-none disabled:opacity-50',
+  'inline-flex items-center justify-center whitespace-nowrap rounded text-sm font-medium transition-all duration-150 ease-out disabled:pointer-events-none disabled:opacity-50',
   {
     variants: {
       variant: {
@@ -14,7 +14,8 @@ const buttonVariants = cva(
         secondary: 'bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80',
         ghost: 'hover:bg-accent hover:text-accent-foreground',
         link: 'text-primary underline-offset-4 hover:underline',
-        brand: 'bg-brand text-brand-foreground shadow hover:bg-brand-600 active:bg-brand-600',
+        brand: 'bg-gradient-to-r from-brand to-brand-600 text-brand-foreground shadow-lg shadow-brand/20 hover:shadow-xl hover:shadow-brand/30 hover:from-brand-400 hover:to-brand active:from-brand-600 active:to-brand active:shadow-md active:shadow-brand/15',
+        brand_subtle: 'bg-brand-muted text-brand-300 border border-brand/20 hover:bg-brand/20 hover:border-brand/40 hover:shadow-md hover:shadow-brand/10',
       },
       size: {
         default: 'h-9 px-4 py-2',

--- a/marketing/web10-social/src/components/ui/skeleton.tsx
+++ b/marketing/web10-social/src/components/ui/skeleton.tsx
@@ -1,12 +1,11 @@
 import { cn } from '@/lib/utils';
 
-// design.md §1/§7 — loading states are skeletons, not spinners. Pulses at
-// ~1.5s; content replaces it in place so nothing shifts.
+// design.md §1/§7 — loading states are skeletons, not spinners. Shimmer
+// gradient sweep at ~1.5s; content replaces it in place so nothing shifts.
 function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
   return (
     <div
-      className={cn('animate-pulse rounded bg-elevated', className)}
-      style={{ animationDuration: '1.5s' }}
+      className={cn('rounded skeleton-shimmer', className)}
       {...props}
     />
   );

--- a/marketing/web10-social/src/index.css
+++ b/marketing/web10-social/src/index.css
@@ -21,6 +21,11 @@
   --color-brand-muted: #2e1065;
   --color-brand-foreground: #fafafa;
 
+  /* glow — ambient light, social flagship only (§4) */
+  --color-glow: rgba(139, 92, 246, 0.15);
+  --color-glow-intense: rgba(139, 92, 246, 0.35);
+  --color-glow-danger: rgba(239, 68, 68, 0.25);
+
   /* semantic (§4) */
   --color-success: #22c55e;
   --color-warning: #f59e0b;
@@ -125,5 +130,165 @@
 
   .animate-overlay-in {
     animation: overlay-in 200ms ease-out;
+  }
+
+  /* design.md §7 — skeleton shimmer (gradient sweep, not solid pulse) */
+  @keyframes shimmer {
+    0% {
+      background-position: -200% 0;
+    }
+    100% {
+      background-position: 200% 0;
+    }
+  }
+
+  .skeleton-shimmer {
+    background: linear-gradient(
+      90deg,
+      var(--color-elevated) 0%,
+      var(--color-border) 50%,
+      var(--color-elevated) 100%
+    );
+    background-size: 200% 100%;
+    animation: shimmer 1.5s ease-in-out infinite;
+  }
+
+  /* design.md §7 — heart-burst on like (300ms scale + fade) */
+  @keyframes heart-burst {
+    0% {
+      transform: scale(1);
+    }
+    25% {
+      transform: scale(1.3);
+    }
+    50% {
+      transform: scale(0.9);
+    }
+    100% {
+      transform: scale(1);
+    }
+  }
+
+  .animate-heart-burst {
+    animation: heart-burst 300ms ease-out;
+  }
+
+  /* design.md §7 — glow-pulse for live/presence indicators (2s infinite) */
+  @keyframes glow-pulse {
+    0%, 100% {
+      opacity: 1;
+      box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.4);
+    }
+    50% {
+      opacity: 0.8;
+      box-shadow: 0 0 0 4px rgba(34, 197, 94, 0);
+    }
+  }
+
+  .animate-glow-pulse {
+    animation: glow-pulse 2s ease-in-out infinite;
+  }
+
+  /* design.md §7 — brand-glow-pulse for active nav / ambient energy */
+  @keyframes brand-glow-pulse {
+    0%, 100% {
+      box-shadow: 0 0 8px rgba(139, 92, 246, 0.15);
+    }
+    50% {
+      box-shadow: 0 0 16px rgba(139, 92, 246, 0.3);
+    }
+  }
+
+  .animate-brand-glow-pulse {
+    animation: brand-glow-pulse 3s ease-in-out infinite;
+  }
+
+  /* design.md §7 — login floating particles */
+  @keyframes float {
+    0%, 100% {
+      transform: translateY(0) translateX(0);
+    }
+    25% {
+      transform: translateY(-20px) translateX(10px);
+    }
+    50% {
+      transform: translateY(-10px) translateX(-10px);
+    }
+    75% {
+      transform: translateY(-30px) translateX(5px);
+    }
+  }
+
+  .animate-float-slow {
+    animation: float 8s ease-in-out infinite;
+  }
+
+  .animate-float-medium {
+    animation: float 6s ease-in-out infinite;
+  }
+
+  .animate-float-fast {
+    animation: float 4s ease-in-out infinite;
+  }
+
+  /* Custom scrollbar — dark theme */
+  ::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+
+  ::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background: var(--color-border);
+    border-radius: var(--radius-sm);
+  }
+
+  ::-webkit-scrollbar-thumb:hover {
+    background: var(--color-muted-foreground);
+  }
+
+  /* Glow utilities — social flagship (§4) */
+  .glow-card {
+    box-shadow: 0 0 0 1px rgba(139, 92, 246, 0), 0 0 16px rgba(139, 92, 246, 0);
+    transition: box-shadow 150ms ease-out;
+  }
+
+  .glow-card:hover {
+    box-shadow: 0 0 0 1px rgba(139, 92, 246, 0.1), 0 0 20px rgba(139, 92, 246, 0.1);
+  }
+
+  .glow-active {
+    box-shadow: 0 0 12px rgba(139, 92, 246, 0.2);
+  }
+
+  .glow-intense {
+    box-shadow: 0 0 20px rgba(139, 92, 246, 0.35);
+  }
+
+  /* Gradient border utility */
+  .gradient-border {
+    position: relative;
+  }
+
+  .gradient-border::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    padding: 1px;
+    background: linear-gradient(135deg, var(--color-brand), var(--color-brand-600));
+    mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+    mask-composite: xor;
+    -webkit-mask-composite: xor;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 150ms ease-out;
+  }
+
+  .gradient-border:hover::before {
+    opacity: 1;
   }
 }

--- a/parallel execution.txt
+++ b/parallel execution.txt
@@ -314,6 +314,12 @@ LANE D — docs / apps / mobile (owns: mobile/**, marketing/, examples/
       path alias (tsc -b had ~90 pre-existing errors) and the
       alternative.png-isn't-the-keys-mark bug (decisions.md D24,
       converged with D13).
+  [✓ 1.0.86] D12 vibrancy overhaul (follow-up): the social flagship was
+      muted — flat surfaces, no ambient light, zero interaction energy.
+      design.md §4 relaxed for social: glow tokens, shimmer skeletons,
+      heart-burst on like, card hover glow, gradient buttons, presence
+      dots, vibrant banner, media hover zoom, animated login. 195 tests
+      green, tsc clean, build clean.
   [✓ 1.0.63] D13. rebuild marketing-ui on the design system. bulma OUT
       entirely (D22), tailwind v4 + design.md §13 tokens, dark
       cinematic landing (lockup hero, tested reach-gap proof section —

--- a/plan.txt
+++ b/plan.txt
@@ -458,6 +458,17 @@ the three items below are PARALLEL — disjoint directories:
     and the legacy Crm/Mail/Bio vitest excludes (files no longer
     exist). 193 tests green, tsc+build clean. See decisions.md D24 for
     the alternative.png brand-asset correction (shared with D13).
+[✓ 1.0.86] web10-social vibrancy overhaul (lane D, D12 follow-up):
+    the social flagship was muted — flat surfaces, no ambient light,
+    zero interaction energy — compared to Kick's vibrant, alive feel.
+    design.md §4 relaxed for social: glow tokens added, new animations
+    (shimmer, heart-burst, glow-pulse, float), custom scrollbar,
+    gradient brand buttons with glow-on-hover, badge glow/live variants,
+    shimmer skeletons, sidebar gradient + active nav glow pill, card
+    hover glow, heart-burst on like, vibrant tags, gradient sent DM
+    bubbles, presence dots, vibrant profile banner, media hover zoom,
+    animated login background with floating orbs. 195 tests green,
+    tsc clean, build clean.
 [✓ 1.0.63] rebuild marketing-ui on the design system (lane D, item D13):
     bulma OUT entirely (already rejected in D22), tailwind v4 +
     design.md tokens, dark cinematic landing (lockup hero, reach-gap


### PR DESCRIPTION
## D12 follow-up: web10-social vibrancy overhaul

The social flagship was muted — flat surfaces, no ambient light, zero interaction energy — compared to Kick's vibrant, alive feel. This pass brings Kick-grade energy while keeping the token system intact.

### Design system (design.md)
- §4 relaxed for social flagship: glow tokens added, "glow is the texture, not the content"
- §7 social motion: heart-burst, shimmer, glow-pulse, float animations
- §10 web10-social direction updated: vibrant, alive, never muted

### CSS tokens & animations (index.css)
- New glow tokens: `--color-glow`, `--color-glow-intense`, `--color-glow-danger`
- Animations: shimmer, heart-burst, glow-pulse, brand-glow-pulse, float (slow/medium/fast)
- Custom dark scrollbar, glow utilities, gradient-border utility

### UI primitives
- **Button**: gradient brand variant with glow-on-hover, `brand_subtle` variant
- **Badge**: `brand_glow` and `live` (pulsing) variants
- **Skeleton**: gradient shimmer replaces solid pulse

### Components
- **Layout**: sidebar gradient, ambient glow orb, active nav glow pill with pulse dot, mobile nav gradient indicator
- **Feed**: card hover glow, heart-burst on like with danger drop-shadow, vibrant brand-tinted tags, origin badges with glow, gradient empty state icon, media hover zoom + overlay
- **Composer**: focus glow bar, media preview hover scale + ring
- **Profile**: vibrant banner gradient, avatar glow ring, gradient avatar fallback, gradient tab indicators, media grid hover zoom + overlay
- **DMs**: gradient sent bubbles with shadow, presence dots with pulse, conversation list presence indicators
- **Login**: animated gradient background, floating ambient orbs

### Verification
- 195 tests green
- tsc --noEmit clean
- vite build clean (443KB JS, 57KB CSS)

### Screenshots
*(Will add desktop + 375px screenshots per design.md §12)*