### PR TITLE
Homepage feed preview + discovery spec (D27, D28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+1.0.86 || 20.07.2026
+Marketing-ui homepage: added a social-media-style tabbed feed preview section
+with placeholder content (For You / Following / Trending tabs, post cards with
+avatars, media placeholders, engagement counts). The section sits between the
+hero and the reach-gap proof, giving the landing page a sense of life and
+activity. Avatar UI primitive added to marketing-ui. Placeholder data wired to
+tabs; ready to be replaced with live backend content.
 1.0.85 || 20.07.2026
 Remove Netlify integration. Deleted ui/netlify.toml so GitHub pushes no
 longer trigger Netlify builds. Removed web10social.netlify.app from the

--- a/decisions.md
+++ b/decisions.md
@@ -9,6 +9,45 @@ Status legend: [decided] intent set · [in-progress] · [open] still debating.
 
 ---
 
+### D28 — Schema-registry public ledger for flexible interactions [decided]
+A shared system collection `web10.public` holds structured public interactions
+(reactions, ratings, endorsements, custom events). Any authenticated user can
+write; anon can read. Entries reference a **schema** defined in `web10.schemas`.
+Schema IDs are `provider.uuid6` — globally unique across federated nodes.
+Schema authors can CRUD their own schemas; anyone can read and use them.
+Payloads are validated against the schema on write. This gives infinite
+flexibility (no hardcoded types) with structure (no schemaless chaos). The
+social app caches schemas locally and registers defaults (Reaction, etc.) on
+boot. Engagement counts are schema-agnostic: the discovery index aggregates
+public ledger entries by `schema_id` and attaches them to post previews.
+Rejects: hardcoded interaction types (limits flexibility), schemaless public
+data (dev nightmare), blockchain/append-only (no utility for this use case),
+and per-record visibility fields (terms + separate collections give bulk
+control and per-app permissions for free).
+
+### D27 — Posts are plaintext; E2E encryption is DMs only; visibility via separate collections [decided]
+Posts and comments are plaintext on the node by design. They are discoverable,
+searchable, and sortable — the node reads content to power discovery feeds,
+trending, and search. The `encrypted` field on posts/comments/reactions schemas
+is dead weight for those services; it applies to `dms` only. The mobile
+encryptor's crypto core (ed25519 + xchacha20) stays for DMs. The node is the
+honest broker: it enforces terms, never leaks.
+
+Visibility is controlled by **separate collections**, not per-record flags:
+`public_posts` (terms whitelist anon reads, discovery indexes it),
+`private_posts` (terms block anon, discovery ignores it). Each collection is
+a separate service with its own terms record. This gives bulk control
+("make all posts private" = change 1 terms record, instant), per-app
+permissions (App A reads public, App B reads both), and zero API filtering
+overhead. The social app abstracts this from the user — a visibility toggle
+routes to the right collection.
+
+Discovery surfaces only what terms allow anon to read. Rejects: E2E encryption
+for posts (blocks discovery by construction), per-record visibility fields
+(requires updating N records for bulk changes, adds API filtering complexity),
+and treating all data as equally private (the creator thesis requires
+discoverability).
+
 ### D26 — SDK npm publish stays tag-gated; no auto-publish on merge [decided]
 `cd.yml` publishes `web10-npm` to npm on a `v*` tag push (the `npm` job,
 gated on `startsWith(github.ref, 'refs/tags/v')`). The operator asked whether

--- a/marketing/marketing-ui/public/docs/discovery.md
+++ b/marketing/marketing-ui/public/docs/discovery.md
@@ -1,0 +1,598 @@
+# Discovery — the public layer on web10
+
+## Problem
+
+web10's data model is per-user collections (`mongodump alice` = full life,
+portable). This gives sovereignty but makes discovery impossible: you need to
+know a username to query their data. A new user with no follows sees nothing.
+
+Additionally, there is no shared public interaction layer. Reactions,
+endorsements, ratings, and custom events have no home — every app builds its
+own silo.
+
+## Decisions (D27, D28)
+
+**D27** — Posts are plaintext, discoverable by design. E2E encryption is DMs
+only. Discovery surfaces only what a user's terms already allow anon to read.
+
+**D28** — A schema-registry public ledger gives any app a flexible, validated
+way to publish structured public interactions. Schema IDs are
+`provider.uuid6` — globally unique across federated nodes.
+
+---
+
+## 1. The discovery index
+
+A flat system-level collection `web10.discovery_posts` mirrors public posts.
+It is a **pointer**, not a copy:
+
+```json
+{
+  "username": "alice",
+  "service": "public_posts",
+  "post_id": "ObjectId(...)",
+  "text": "first 280 characters of the post...",
+  "tags": ["webdev", "music"],
+  "media_count": 2,
+  "created_at": "2026-07-20T...",
+  "updated_at": "2026-07-20T..."
+}
+```
+
+The full post stays in `alice`'s collection. Discovery is the table of
+contents. Clicking through reads the full post via the normal CRUD endpoint
+(which checks terms).
+
+### Why separate collections for visibility
+
+Instead of a per-record `visibility` field, the social app routes posts into
+separate collections by visibility:
+
+```
+alice/public_posts   → terms: anon whitelisted    → discovery indexes here
+alice/private_posts  → terms: anon blocked        → discovery ignores this
+alice/friends_posts  → terms: specific users only → discovery ignores this
+```
+
+**Why this, not per-record visibility:**
+
+- **Bulk control**: "Make all my posts private" = change 1 terms record.
+  Instant. Not updating 10,000 records.
+- **Per-app permissions**: each collection is a separate service with its own
+  terms. App A can read `public_posts`, App B can read both `public_posts`
+  AND `private_posts`. The existing terms model already supports this.
+- **No API filtering needed**: the CRUD endpoint returns everything in the
+  service. Terms control who can read the service. Done.
+- **Discovery is simple**: the index only reads from services where anon is
+  whitelisted.
+
+**The social app abstracts this away from the user:**
+
+```js
+function createPost(text, visibility = "public") {
+  const service = visibility === "public" ? "public_posts" : "private_posts";
+  return wapi.create(username, service, { text, created_at: now() });
+}
+```
+
+The user sees a toggle. The app handles the routing.
+
+### Index write path (on post create/update)
+
+```
+1. Background task fires after post create/update
+2. Read the author's terms record for the service
+3. Does terms whitelist anon reads?
+   (get_approved("anon", PROVIDER, author, service, "read"))
+   - NO  → skip, don't index
+   - YES → upsert into web10.discovery_posts
+4. The indexed record is a projection: username, service, post_id, text[:280],
+   tags, media_count, created_at, updated_at. No full body.
+```
+
+### Index delete path (on post delete or terms change)
+
+```
+1. Post deleted → remove matching {username, service, post_id} from index
+2. Terms change (anon revoked) → remove all posts for that user+service
+3. Terms change (anon granted) → backfill all existing posts into index
+```
+
+### Why abuse is impossible
+
+- A user cannot directly write to the index. They write to their own collection
+  via CRUD. The background task is the only writer.
+- The background task checks terms before indexing. If terms don't allow anon,
+  the post never enters discovery.
+- The indexed record is a projection. A user can't smuggle extra fields.
+- If a user changes terms to revoke anon, their posts vanish from discovery
+  instantly.
+- The index is in the `web10` system database. User CRUD cannot target it —
+  `db.create(user, service, data)` always writes to `db[f"{user}"]`, never to
+  `web10`.
+
+---
+
+## 2. The public ledger
+
+A shared, system-level collection `web10.public` for cross-user interactions.
+Any authenticated user can write entries. Anon can read. No terms dance — it's
+public by definition.
+
+### Schema registry
+
+Entries in the public ledger reference a **schema** that defines their payload
+shape. Schemas are registered by any app developer and stored in
+`web10.schemas`.
+
+**Schema ID format:** `provider.uuid6`
+
+```
+api.web10.app.0194a2b0-1c8e-4f5d-8a3e-9c7b2d1e0f4a
+```
+
+UUID6 is time-ordered and globally unique. Combined with the provider, no two
+nodes can collide on a schema ID.
+
+### Schema CRUD
+
+```
+web10.schemas:
+  {
+    "_id": "api.web10.app.0194a2b0-...",
+    "title": "Reaction",
+    "author": "social-app",
+    "provider": "api.web10.app",
+    "payload": {
+      "type": "object",
+      "properties": { "emoji": { "type": "string" } },
+      "required": ["emoji"]
+    },
+    "version": 1,
+    "created_at": "2026-07-20T...",
+    "updated_at": "2026-07-20T..."
+  }
+```
+
+**Permissions:**
+
+| Action | Who |
+|--------|-----|
+| Create | Any authenticated user |
+| Read | Anyone (anon) |
+| Update | Schema author only (API enforces `token.username == schema.author`) |
+| Delete | Schema author only |
+
+**Versioning:** When an author updates a schema, `version` increments. Existing
+public ledger entries keep their reference to the schema ID. The API validates
+new entries against the current version. Old entries are not re-validated.
+
+### Public ledger entry
+
+```json
+{
+  "schema_id": "api.web10.app.0194a2b0-...",
+  "author": "bob",
+  "target": {
+    "user": "alice",
+    "service": "public_posts",
+    "id": "ObjectId(...)"
+  },
+  "payload": { "emoji": "🔥" },
+  "created_at": "2026-07-20T10:30:00Z"
+}
+```
+
+**Required fields:** `schema_id`, `author`, `target`, `payload`, `created_at`.
+
+**Validation on write:**
+1. Look up the schema by `schema_id` in `web10.schemas`
+2. Validate `payload` against `schema.payload` (JSON Schema)
+3. Reject if invalid
+
+**Why this is flexible:**
+
+- App dev registers a schema → gets a UUID → publishes it in their docs
+- Any app can use any schema by referencing its UUID
+- New interaction types don't need API changes — just register a schema
+- The social app caches schemas locally: `schema_id → schema definition`
+- Schemas can be anything: reactions, ratings, endorsements, reviews,
+  milestones, custom events
+
+**Example schemas:**
+
+```js
+// Reaction (social app)
+{ title: "Reaction", payload: { emoji: "string", required: ["emoji"] } }
+
+// Rating (review app)
+{ title: "Rating", payload: { value: "number", max: "number", required: ["value"] } }
+
+// Endorsement (professional network)
+{ title: "Endorsement", payload: { skill: "string", text: "string", required: ["skill"] } }
+
+// Custom event (any app)
+{ title: "Milestone", payload: { type: "string", value: "number", required: ["type", "value"] } }
+```
+
+### Public ledger permissions
+
+```
+web10.public terms:
+  whitelist: [
+    { "username": ".*", "provider": ".*", "read": true },
+    { "username": ".*", "provider": ".*", "create": true }
+  ]
+```
+
+Anon can read. Any authenticated user can create. Update/delete of individual
+entries is **author-only** (enforced by the API: `token.username == entry.author`).
+
+### Engagement aggregation
+
+The discovery index stores cached engagement counts, computed from public
+ledger entries:
+
+```json
+{
+  "username": "alice",
+  "service": "public_posts",
+  "post_id": "ObjectId(...)",
+  "engagement": {
+    "api.web10.app.0194a2b0-...": { "count": 2400, "schema_title": "Reaction" },
+    "api.web10.app.0194a2b1-...": { "count": 186, "schema_title": "Comment" }
+  }
+}
+```
+
+On public ledger entry create/delete, the background task updates the
+engagement cache for the target post. Schema IDs are the keys — any schema
+can contribute to engagement.
+
+---
+
+## 3. Endpoints
+
+All discovery endpoints are **system-level** (no `{user}` in the path). They
+accept a token but do not require authentication — an anon token is valid.
+
+### Schema endpoints
+
+#### `POST /schemas/register`
+
+Register a new schema. Returns the schema with its UUID6 ID.
+
+**Request body:**
+```json
+{
+  "token": "...",
+  "title": "Reaction",
+  "payload": {
+    "type": "object",
+    "properties": { "emoji": { "type": "string" } },
+    "required": ["emoji"]
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "_id": "api.web10.app.0194a2b0-1c8e-4f5d-8a3e-9c7b2d1e0f4a",
+  "title": "Reaction",
+  "author": "social-app",
+  "provider": "api.web10.app",
+  "payload": { ... },
+  "version": 1,
+  "created_at": "2026-07-20T..."
+}
+```
+
+#### `PATCH /schemas/{schema_id}`
+
+Fetch a schema by ID. (Anon OK.)
+
+**Response:** The schema record.
+
+#### `PUT /schemas/{schema_id}`
+
+Update a schema. Author only.
+
+**Request body:** Token + fields to update (`$set`).
+
+**Response:** Updated schema with incremented version.
+
+#### `DELETE /schemas/{schema_id}`
+
+Delete a schema. Author only. Existing public ledger entries keep their
+reference but are no longer validated on new writes.
+
+### Public ledger endpoints
+
+#### `POST /public/entries`
+
+Create a public ledger entry. Validates payload against the referenced schema.
+
+**Request body:**
+```json
+{
+  "token": "...",
+  "schema_id": "api.web10.app.0194a2b0-...",
+  "target": { "user": "alice", "service": "public_posts", "id": "..." },
+  "payload": { "emoji": "🔥" }
+}
+```
+
+**Response:**
+```json
+{
+  "_id": "ObjectId(...)",
+  "schema_id": "api.web10.app.0194a2b0-...",
+  "author": "bob",
+  "target": { ... },
+  "payload": { "emoji": "🔥" },
+  "created_at": "2026-07-20T10:30:00Z"
+}
+```
+
+#### `PATCH /public/entries`
+
+Query public ledger entries. (Anon OK.)
+
+**Query params:**
+- `schema_id`: filter by schema
+- `target_user`: filter by target user
+- `target_service`: filter by target service
+- `target_id`: filter by target record ID
+- `author`: filter by author
+- `limit`: int, default 20, max 100
+- `skip`: int, default 0
+
+**Response:** Array of public ledger entries.
+
+#### `PUT /public/entries/{entry_id}`
+
+Update a public ledger entry. Author only.
+
+#### `DELETE /public/entries/{entry_id}`
+
+Delete a public ledger entry. Author only.
+
+### Discovery endpoints
+
+#### `PATCH /discover/posts` — For You feed
+
+Returns public posts sorted by engagement or recency.
+
+**Query params:**
+- `sort`: `recent` (default) | `trending` (by engagement score)
+- `limit`: int, default 20, max 100
+- `skip`: int, default 0
+
+**Request body:** Token (can be null for anon).
+
+**Response:**
+```json
+[
+  {
+    "username": "alice",
+    "service": "public_posts",
+    "post_id": "ObjectId(...)",
+    "text": "Just shipped the new studio dashboard...",
+    "tags": ["webdev"],
+    "media_count": 1,
+    "created_at": "2026-07-20T10:30:00Z",
+    "engagement": {
+      "api.web10.app.0194a2b0-...": { "count": 2400, "schema_title": "Reaction" },
+      "api.web10.app.0194a2b1-...": { "count": 186, "schema_title": "Comment" }
+    }
+  }
+]
+```
+
+#### `PATCH /discover/users` — Suggested accounts
+
+Returns users who whitelist anon reads on their public posts, sorted by
+activity or follower count.
+
+**Query params:**
+- `sort`: `active` (default, most posts in last 7 days) | `followers`
+- `limit`: int, default 20, max 100
+- `skip`: int, default 0
+
+**Request body:** Token (can be null for anon).
+
+**Response:**
+```json
+[
+  {
+    "username": "alice",
+    "display_name": "Alice Chen",
+    "bio": "Creator, developer",
+    "avatar_ref": "ObjectId(...)",
+    "follower_count": 12400,
+    "post_count_7d": 14
+  }
+]
+```
+
+#### `PATCH /discover/search` — Content search
+
+Text search across public post content.
+
+**Query params:**
+- `q`: search query (required)
+- `limit`: int, default 20, max 100
+- `skip`: int, default 0
+
+**Request body:** Token (can be null for anon).
+
+**Response:** Same shape as `/discover/posts`.
+
+#### `PATCH /discover/topics` — Trending hashtags
+
+Returns most-used tags in public posts over a time window.
+
+**Query params:**
+- `limit`: int, default 20, max 50
+- `window`: `24h` (default) | `7d`
+
+**Request body:** Token (can be null for anon).
+
+**Response:**
+```json
+[
+  { "tag": "webdev", "count": 1240 },
+  { "tag": "music", "count": 890 }
+]
+```
+
+#### `PATCH /discover/post/{username}/{service}/{post_id}` — Single post lookup
+
+Returns the full post for a discovery click-through. Checks terms.
+
+**Request body:** Token (can be null for anon).
+
+**Response:** The full post record from the user's collection.
+
+---
+
+## 4. Federation (future)
+
+### Discovery across nodes
+
+```
+Node A receives /discover/posts request
+  → query local web10.discovery_posts
+  → for each federated peer, call peer's /discover/posts
+  → merge results, sort by engagement/recency
+  → return unified feed
+```
+
+Each node returns only its own public posts (terms already enforced locally).
+
+### Schema resolution across nodes
+
+Schema IDs include the provider. When Node A receives a public ledger entry
+with `schema_id: api.node-b.web10.app.0194a2b0-...`, it fetches the schema
+from Node B's `/schemas/{schema_id}` endpoint and caches it.
+
+### Public ledger federation
+
+Public ledger entries are node-local. Federation aggregates across nodes:
+
+```
+Node A receives /public/entries?target_id=...
+  → query local web10.public
+  → for each federated peer, call peer's /public/entries?target_id=...
+  → merge results
+```
+
+---
+
+## 5. Migration
+
+- Existing posts in `posts` (single collection) are NOT migrated. New posts
+  go to `public_posts` or `private_posts` based on the social app's routing.
+- The discovery index grows forward from deployment. Old posts enter discovery
+  when they are next updated, or via a one-time backfill script.
+- The social app registers its default schemas (Reaction, Rating, etc.) on
+  first boot and caches them locally.
+
+---
+
+## 6. What this does NOT do
+
+- Does not change the per-user collection model
+- Does not store full post bodies in the index (only projections)
+- Does not allow direct writes to the discovery index
+- Does not bypass terms (the index only contains what terms allow anon to read)
+- Does not handle encrypted content (DMs only, per D27)
+- Does not require blockchain, consensus, or append-only semantics
+- Does not hardcode interaction types (schemas are developer-defined)
+
+---
+
+## 7. Open questions
+
+- Repost model: is it a new service, a flag on posts, or a public ledger
+  entry with a "repost" schema?
+- The "For You" algorithm: engagement score formula or just chronological?
+- Rate limiting on discovery endpoints: how many requests per anon IP?
+- Public ledger entry limits: max payload size? max entries per author per
+  target?
+- Schema deprecation: when an author deletes a schema, should existing entries
+  be flagged as "schema retired"?
+- Backfill script for existing posts when the social app splits into
+  `public_posts` / `private_posts`
+
+---
+
+## 8. API implementation plan
+
+### New system collections
+
+```
+web10.discovery_posts  — the post index (write-protected, background task only)
+web10.schemas          — schema registry (CRUD, author-enforced)
+web10.public           — public ledger entries (any user can write, author-only update/delete)
+```
+
+### New API endpoints (in a new `discover` router)
+
+```
+POST   /schemas/register
+PATCH  /schemas/{schema_id}        — fetch
+PUT    /schemas/{schema_id}        — update (author only)
+DELETE /schemas/{schema_id}        — delete (author only)
+
+POST   /public/entries
+PATCH  /public/entries             — query
+PUT    /public/entries/{entry_id}  — update (author only)
+DELETE /public/entries/{entry_id}  — delete (author only)
+
+PATCH  /discover/posts
+PATCH  /discover/users
+PATCH  /discover/search
+PATCH  /discover/topics
+PATCH  /discover/post/{username}/{service}/{post_id}
+```
+
+### Background tasks (in existing CRUD endpoints)
+
+```
+On POST /{user}/{service} (create):
+  → enqueue index_upsert(user, service, post)
+  → if service is public_posts and anon whitelisted, upsert into discovery_posts
+
+On PUT /{user}/{service} (update):
+  → enqueue index_upsert(user, service, post)
+
+On DELETE /{user}/{service}:
+  → enqueue index_delete(user, service, post)
+
+On POST /public/entries:
+  → validate payload against schema
+  → enqueue engagement_update(target_user, target_service, target_id)
+```
+
+### Social app changes
+
+```
+1. Split posts into public_posts / private_posts services
+2. Create default terms for both services on user signup
+3. Register default schemas (Reaction, etc.) on first boot
+4. Cache schemas locally: schema_id → schema definition
+5. Route createPost by visibility toggle
+6. Wire feed preview to /discover/posts endpoint
+7. Wire reactions to /public/entries endpoint
+```
+
+### Marketing-ui changes
+
+```
+1. Replace FeedPreview placeholder data with /discover/posts
+2. Wire tab switching to sort params (recent, trending)
+3. Wire reaction buttons to /public/entries
+4. Fetch schema definitions for rendering interaction types
+```

--- a/marketing/marketing-ui/src/components/FeedPreview.tsx
+++ b/marketing/marketing-ui/src/components/FeedPreview.tsx
@@ -1,0 +1,283 @@
+import { useState } from 'react';
+import { Avatar, AvatarFallback } from '@/components/ui/avatar';
+import { Card } from '@/components/ui/card';
+import { Heart, MessageCircle, Repeat2, Share2, Image as ImageIcon, Film, Music2, TrendingUp, Users, Zap } from 'lucide-react';
+
+const TABS = [
+  { id: 'for-you', label: 'For You', icon: TrendingUp },
+  { id: 'following', label: 'Following', icon: Users },
+  { id: 'trending', label: 'Trending', icon: Zap },
+] as const;
+
+type TabId = (typeof TABS)[number]['id'];
+
+const PLACEHOLDER_POSTS: Record<TabId, Array<{
+  id: string;
+  name: string;
+  handle: string;
+  initial: string;
+  avatarColor: string;
+  time: string;
+  content: string;
+  media?: 'image' | 'video' | 'music';
+  likes: string;
+  comments: string;
+  reposts: string;
+}>> = {
+  'for-you': [
+    {
+      id: '1',
+      name: 'Sarah Chen',
+      handle: '@sarahchen',
+      initial: 'S',
+      avatarColor: 'bg-rose-500',
+      time: '2m',
+      content: 'Just shipped the new studio dashboard. The monetization flow is finally here. This is what ownership looks like.',
+      media: 'image',
+      likes: '2.4k',
+      comments: '186',
+      reposts: '412',
+    },
+    {
+      id: '2',
+      name: 'Marcus Rivera',
+      handle: '@marcusr',
+      initial: 'M',
+      avatarColor: 'bg-sky-500',
+      time: '14m',
+      content: 'Day 3 on web10 and every single one of my 40k followers saw my post. No algorithm, no shadow ban. Just... delivery. It\'s wild.',
+      media: 'video',
+      likes: '8.1k',
+      comments: '523',
+      reposts: '1.2k',
+    },
+    {
+      id: '3',
+      name: 'Aisha Patel',
+      handle: '@aishap',
+      initial: 'A',
+      avatarColor: 'bg-amber-500',
+      time: '1h',
+      content: 'New track dropping tonight. First time I know 100% of my audience will actually hear about it.',
+      media: 'music',
+      likes: '5.7k',
+      comments: '341',
+      reposts: '892',
+    },
+  ],
+  'following': [
+    {
+      id: '4',
+      name: 'James Okonkwo',
+      handle: '@jameso',
+      initial: 'J',
+      avatarColor: 'bg-emerald-500',
+      time: '5m',
+      content: 'Morning light in Lagos hits different. Shot this before heading to the studio.',
+      media: 'image',
+      likes: '1.1k',
+      comments: '67',
+      reposts: '89',
+    },
+    {
+      id: '5',
+      name: 'Yuki Tanaka',
+      handle: '@yukit',
+      initial: 'Y',
+      avatarColor: 'bg-violet-500',
+      time: '23m',
+      content: 'The new composer interface is buttery. Writing a thread feels like it should — no friction between thought and publish.',
+      media: 'image',
+      likes: '3.3k',
+      comments: '204',
+      reposts: '567',
+    },
+    {
+      id: '6',
+      name: 'Elena Vasquez',
+      handle: '@elenav',
+      initial: 'E',
+      avatarColor: 'bg-pink-500',
+      time: '47m',
+      content: 'Moved my newsletter audience here. They can actually see the posts now. The migration was painless, the delivery is instant.',
+      likes: '4.2k',
+      comments: '312',
+      reposts: '743',
+    },
+  ],
+  'trending': [
+    {
+      id: '7',
+      name: 'David Kim',
+      handle: '@davidk',
+      initial: 'D',
+      avatarColor: 'bg-indigo-500',
+      time: '1h',
+      content: 'Thread: Why I migrated 200k followers from three platforms to my web10 node in a weekend. (1/12)',
+      media: 'image',
+      likes: '24k',
+      comments: '1.8k',
+      reposts: '5.3k',
+    },
+    {
+      id: '8',
+      name: 'Priya Sharma',
+      handle: '@priyas',
+      initial: 'P',
+      avatarColor: 'bg-orange-500',
+      time: '2h',
+      content: 'The first creator to earn $10k on web10 just hit the milestone. No platform cut, no algorithm penalty. Pure audience relationship.',
+      media: 'video',
+      likes: '18k',
+      comments: '2.1k',
+      reposts: '4.7k',
+    },
+    {
+      id: '9',
+      name: 'Leo Martinez',
+      handle: '@leom',
+      initial: 'L',
+      avatarColor: 'bg-teal-500',
+      time: '3h',
+      content: 'Built a web10 lens that shows your posts as a podcast feed. The SDK makes this trivially easy. Anyone can build this now.',
+      likes: '11k',
+      comments: '892',
+      reposts: '3.1k',
+    },
+  ],
+};
+
+function MediaPlaceholder({ type }: { type: 'image' | 'video' | 'music' }) {
+  if (type === 'video') {
+    return (
+      <div className="relative aspect-video w-full overflow-hidden bg-elevated">
+        <div className="absolute inset-0 flex items-center justify-center">
+          <div className="flex h-12 w-12 items-center justify-center rounded-full bg-foreground/10 backdrop-blur-sm">
+            <Film className="h-5 w-5 text-foreground/60" />
+          </div>
+        </div>
+        <div className="absolute inset-0 bg-gradient-to-t from-background/40 to-transparent" />
+      </div>
+    );
+  }
+  if (type === 'music') {
+    return (
+      <div className="flex items-center gap-3 rounded-lg bg-elevated p-3">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded bg-brand-muted">
+          <Music2 className="h-5 w-5 text-brand-400" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="h-2 w-24 rounded-full bg-muted-foreground/30" />
+          <div className="mt-2 h-1 w-full rounded-full bg-muted-foreground/20">
+            <div className="h-full w-2/5 rounded-full bg-brand" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div className="aspect-[4/3] w-full overflow-hidden bg-elevated">
+      <div className="flex h-full w-full items-center justify-center">
+        <ImageIcon className="h-8 w-8 text-muted-foreground/30" />
+      </div>
+    </div>
+  );
+}
+
+function PostCard({ post }: { post: (typeof PLACEHOLDER_POSTS)['for-you'][number] }) {
+  return (
+    <Card className="bg-surface">
+      <div className="p-4">
+        <div className="flex gap-3">
+          <Avatar className={post.avatarColor}>
+            <AvatarFallback className="text-foreground">{post.initial}</AvatarFallback>
+          </Avatar>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-1.5">
+              <span className="text-sm font-semibold text-foreground">{post.name}</span>
+              <span className="text-sm text-muted-foreground">{post.handle}</span>
+              <span className="text-muted-foreground">·</span>
+              <span className="text-sm text-muted-foreground">{post.time}</span>
+            </div>
+            <p className="mt-1 text-sm leading-relaxed text-foreground">{post.content}</p>
+            {post.media && (
+              <div className="mt-3">
+                <MediaPlaceholder type={post.media} />
+              </div>
+            )}
+            <div className="mt-3 flex items-center gap-6">
+              <button className="group flex items-center gap-1.5 text-muted-foreground transition-colors hover:text-rose-400">
+                <Heart className="h-4 w-4" strokeWidth={1.5} />
+                <span className="text-xs">{post.likes}</span>
+              </button>
+              <button className="group flex items-center gap-1.5 text-muted-foreground transition-colors hover:text-sky-400">
+                <MessageCircle className="h-4 w-4" strokeWidth={1.5} />
+                <span className="text-xs">{post.comments}</span>
+              </button>
+              <button className="group flex items-center gap-1.5 text-muted-foreground transition-colors hover:text-emerald-400">
+                <Repeat2 className="h-4 w-4" strokeWidth={1.5} />
+                <span className="text-xs">{post.reposts}</span>
+              </button>
+              <button className="group ml-auto text-muted-foreground transition-colors hover:text-brand-400">
+                <Share2 className="h-4 w-4" strokeWidth={1.5} />
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+function FeedPreview() {
+  const [activeTab, setActiveTab] = useState<TabId>('for-you');
+
+  return (
+    <section className="border-b border-border bg-background px-4 py-24 sm:px-6 sm:py-32">
+      <div className="mx-auto max-w-2xl">
+        <div className="mb-10 text-center">
+          <h2 className="reveal font-display text-3xl font-bold tracking-[-0.02em] sm:text-4xl">
+            See what's happening.
+          </h2>
+          <p className="reveal mt-4 text-muted-foreground [animation-delay:80ms]">
+            A real-time feed, powered by your node. Every post, every follower, zero algorithm.
+          </p>
+        </div>
+
+        <div className="reveal mb-6 [animation-delay:160ms]">
+          <div className="flex border-b border-border">
+            {TABS.map(tab => {
+              const Icon = tab.icon;
+              const isActive = activeTab === tab.id;
+              return (
+                <button
+                  key={tab.id}
+                  onClick={() => setActiveTab(tab.id)}
+                  className={`relative flex flex-1 items-center justify-center gap-2 py-3 text-sm font-medium transition-colors ${
+                    isActive
+                      ? 'text-foreground'
+                      : 'text-muted-foreground hover:text-foreground'
+                  }`}
+                >
+                  <Icon className="h-4 w-4" strokeWidth={1.5} />
+                  {tab.label}
+                  {isActive && (
+                    <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-brand" />
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="reveal flex flex-col gap-3 [animation-delay:240ms]">
+          {PLACEHOLDER_POSTS[activeTab].map(post => (
+            <PostCard key={post.id} post={post} />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export { FeedPreview };

--- a/marketing/marketing-ui/src/components/ui/avatar.tsx
+++ b/marketing/marketing-ui/src/components/ui/avatar.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+const Avatar = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn('relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full', className)}
+    {...props}
+  />
+));
+Avatar.displayName = 'Avatar';
+
+const AvatarImage = React.forwardRef<
+  HTMLImageElement,
+  React.ImgHTMLAttributes<HTMLImageElement>
+>(({ className, ...props }, ref) => (
+  <img
+    ref={ref}
+    className={cn('aspect-square h-full w-full object-cover', className)}
+    {...props}
+  />
+));
+AvatarImage.displayName = 'AvatarImage';
+
+const AvatarFallback = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      'flex h-full w-full items-center justify-center rounded-full bg-muted text-muted-foreground text-sm font-medium',
+      className,
+    )}
+    {...props}
+  />
+));
+AvatarFallback.displayName = 'AvatarFallback';
+
+export { Avatar, AvatarImage, AvatarFallback };

--- a/marketing/marketing-ui/src/pages/Home.tsx
+++ b/marketing/marketing-ui/src/pages/Home.tsx
@@ -1,6 +1,7 @@
 import { Send, Inbox, ShieldCheck } from 'lucide-react'
 import { Button } from '../components/ui/button'
 import { Card, CardHeader, CardTitle, CardDescription } from '../components/ui/card'
+import { FeedPreview } from '../components/FeedPreview'
 import {
   REACH_GAP_EXAMPLE,
   WEB10_DELIVERY_PERCENT,
@@ -178,6 +179,7 @@ function Home() {
   return (
     <>
       <Hero />
+      <FeedPreview />
       <ReachGap />
       <HowItWorks />
       <Footer />

--- a/parallel execution.txt
+++ b/parallel execution.txt
@@ -580,9 +580,26 @@ points at an empty db. baseline fixes outrank polish, in this order:
        serves per-env origins; only social still needs D14. operator
        prerequisites: docker group for the ssh user, rotate the CF
        token exposed in the world-readable Caddyfile.
-  ws5: C6 e2e deep sweep + bug hunt (lane C — e2e/** only; local
-       stack, no deploy gate). signup-as-a-test + persona seed
-       fixtures; the honest bug list is the deliverable.
+ws5: C6 e2e deep sweep + bug hunt (lane C — e2e/** only; local
+        stack, no deploy gate). signup-as-a-test + persona seed
+        fixtures; the honest bug list is the deliverable.
+   ws-new: [✓ 1.0.86] D-homepage-feed. Social-media-style tabbed feed
+        preview on the marketing-ui homepage. Placeholder content with
+        For You / Following / Trending tabs, post cards with avatars,
+        media placeholders, engagement counts. Sits between hero and
+        reach-gap section. Ready for live backend content.
+   [ ] A5.5. DISCOVERY API — the public layer (Lane A, api/**):
+        discovery index (web10.discovery_posts, write-protected,
+        background task), schema registry (web10.schemas, CRUD with
+        author enforcement, provider.uuid6 IDs), public ledger
+        (web10.public, validated entries), discovery endpoints
+        (/discover/posts, /users, /search, /topics, /post/{user}/{service}/{id}),
+        engagement aggregation (cached counts on index, schema-agnostic).
+        See PHASE 5.5 in plan.txt and docs/discovery.md.
+   [ ] D5.5. SOCIAL APP PUBLIC LAYER — split posts into public_posts /
+        private_posts, default terms on signup, register default schemas,
+        wire reactions to /public/entries, wire feed to /discover/posts.
+        See PHASE 5.5 in plan.txt.
 
   merge-order notes: B5/D12/D13 don't gate each other; merge each as
   it passes design.md §12. D13 owns the cross-app asset generation

--- a/plan.txt
+++ b/plan.txt
@@ -788,6 +788,69 @@ swappable per node.
     separate container. only minio remains in compose for blobs.
 
 
+PHASE 5.5 — the public layer (discovery + schema registry + public ledger)
+--------------------------------------------------------------------------
+D27: posts are plaintext, discoverable by design. E2E encryption is DMs
+only. D28: a schema-registry public ledger gives any app a flexible,
+validated way to publish structured public interactions.
+
+The social app splits posts into separate collections by visibility:
+`public_posts` (anon whitelisted, discovery indexes it) and
+`private_posts` (anon blocked, discovery ignores it). Each collection is
+a separate service with its own terms record, so bulk control is instant
+("make all posts private" = change 1 terms record) and per-app
+permissions work (App A reads public, App B reads both).
+
+API side (Lane A):
+[ ] discovery index: `web10.discovery_posts` system collection,
+    write-protected (background task only). On post create/update in a
+    service where anon is whitelisted, upsert a projection into the
+    index. On post delete or terms change, remove backfill accordingly.
+[ ] schema registry: `web10.schemas` system collection.
+    - POST /schemas/register — any user, returns provider.uuid6 ID
+    - PATCH /schemas/{id} — fetch (anon OK)
+    - PUT /schemas/{id} — update (author only, API enforces ownership)
+    - DELETE /schemas/{id} — delete (author only)
+    - Schemas store JSON Schema for payload validation
+[ ] public ledger: `web10.public` system collection.
+    - POST /public/entries — create (any authenticated user, validates
+      payload against schema)
+    - PATCH /public/entries — query (anon OK, filter by schema_id,
+      target, author)
+    - PUT /public/entries/{id} — update (author only)
+    - DELETE /public/entries/{id} — delete (author only)
+[ ] discovery endpoints (new `discover` router):
+    - PATCH /discover/posts — for you feed (recent/trending sort)
+    - PATCH /discover/users — suggested accounts
+    - PATCH /discover/search — full-text search (Mongo $text index)
+    - PATCH /discover/topics — trending hashtags
+    - PATCH /discover/post/{user}/{service}/{id} — single post lookup
+[ ] engagement aggregation: background task updates cached engagement
+    counts on the discovery index when public ledger entries are created
+    or deleted. Engagement is schema-agnostic (keyed by schema_id).
+[ ] engagement score: formula for trending sort
+    (likes * 1 + comments * 3 + reposts * 5? or just chronological)
+
+Social app side (Lane D):
+[ ] split posts into public_posts / private_posts services
+[ ] create default terms for both services on user signup
+[ ] register default schemas (Reaction, etc.) on first boot
+[ ] cache schemas locally: schema_id → schema definition
+[ ] route createPost by visibility toggle
+[ ] wire reactions to /public/entries endpoint
+[ ] wire feed preview to /discover/posts endpoint (replace placeholder)
+
+Marketing-ui side (Lane D):
+[ ] replace FeedPreview placeholder data with /discover/posts
+[ ] wire tab switching to sort params (recent, trending)
+[ ] wire reaction buttons to /public/entries
+[ ] fetch schema definitions for rendering interaction types
+
+Federation (later):
+[ ] cross-node discovery: /discover/posts aggregates from federated peers
+[ ] schema resolution: fetch remote schemas by provider.uuid6
+[ ] public ledger federation: /public/entries aggregates across nodes
+
 PHASE 6 — wapi.js revamp (the sdk)
 ----------------------------------
 wapi.js is how frontend devs build web10 apps. it deserves the same


### PR DESCRIPTION
Adds a social-media-style tabbed feed preview section to the marketing-ui homepage (For You / Following / Trending tabs with placeholder post cards, avatars, media placeholders, and engagement counts). Records D27 (posts plaintext, E2E DMs only, visibility via separate collections) and D28 (schema-registry public ledger with provider.uuid6 IDs). Includes a comprehensive discovery spec (docs/discovery.md) covering the discovery index, schema registry, public ledger, 12 endpoints, engagement aggregation, and federation path. Queues Phase 5.5 in plan.txt with Lane A and Lane D items for the full public layer implementation.