### PR TITLE
fix marketing-ui build: use setAttribute for SVG className

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+1.0.88 || 21.07.2026
+Fix marketing-ui build: SVG `className` assignment changed to `setAttribute('class', ...)` to avoid TS2540 read-only error on dynamically created SVG elements.
 1.0.86 || 20.07.2026
 Marketing-ui homepage: added a social-media-style tabbed feed preview section
 with placeholder content (For You / Following / Trending tabs, post cards with

--- a/marketing/marketing-ui/src/pages/AppStore.tsx
+++ b/marketing/marketing-ui/src/pages/AppStore.tsx
@@ -260,7 +260,7 @@ function AppStore() {
                           const parent = e.currentTarget.parentElement
                           if (parent) {
                             const fallback = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
-                            fallback.className = 'h-5 w-5 text-muted-foreground'
+                            fallback.setAttribute('class', 'h-5 w-5 text-muted-foreground')
                             fallback.setAttribute('strokeWidth', '1.5')
                             fallback.setAttribute('fill', 'none')
                             fallback.setAttribute('stroke', 'currentColor')


### PR DESCRIPTION
Line 263 in AppStore.tsx assigned to the read-only `className` property on an SVG element created via `document.createElementNS`. Changed to use `setAttribute('class', ...)` instead.

Fixes the `bun run build` exit code 1 error that was blocking both the docker and e2e CI workflows.