### PR TITLE
feat: persona orchestration — 5 live-testing personas with seed scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
+1.0.90 || 21.07.2026
+Homepage: moved the social feed preview section above the hero so the feed is front and center — first thing you see after the navbar. The pitch headline follows immediately after.
+
 1.0.89 || 21.07.2026
 Persona orchestration: 5 live-testing personas (solar-flare-69, noodle-empress,
 void-walker, butterfly-mechanic, disco-donkey) with seed scripts (bash + python),
 first-week action plans, cross-follows, posts, comments, DMs, reactions, and
 inbox fan-out. Makes the social platform look alive for dev testing and demos.
-
-1.0.90 || 21.07.2026
-Homepage: moved the social feed preview section above the hero so the feed is front and center — first thing you see after the navbar. The pitch headline follows immediately after.
 
 1.0.88 || 21.07.2026
 Fix marketing-ui build: SVG `className` assignment changed to `setAttribute('class', ...)` to avoid TS2540 read-only error on dynamically created SVG elements.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+1.0.89 || 21.07.2026
+Persona orchestration: 5 live-testing personas (solar-flare-69, noodle-empress,
+void-walker, butterfly-mechanic, disco-donkey) with seed scripts (bash + python),
+first-week action plans, cross-follows, posts, comments, DMs, reactions, and
+inbox fan-out. Makes the social platform look alive for dev testing and demos.
 1.0.88 || 21.07.2026
 Fix marketing-ui build: SVG `className` assignment changed to `setAttribute('class', ...)` to avoid TS2540 read-only error on dynamically created SVG elements.
 1.0.86 || 20.07.2026

--- a/parallel execution.txt
+++ b/parallel execution.txt
@@ -594,18 +594,22 @@ ws5: C6 e2e deep sweep + bug hunt (lane C — e2e/** only; local
         For You / Following / Trending tabs, post cards with avatars,
         media placeholders, engagement counts. Sits between hero and
         reach-gap section. Ready for live backend content.
-   [ ] A5.5. DISCOVERY API — the public layer (Lane A, api/**):
-        discovery index (web10.discovery_posts, write-protected,
-        background task), schema registry (web10.schemas, CRUD with
-        author enforcement, provider.uuid6 IDs), public ledger
-        (web10.public, validated entries), discovery endpoints
-        (/discover/posts, /users, /search, /topics, /post/{user}/{service}/{id}),
-        engagement aggregation (cached counts on index, schema-agnostic).
-        See PHASE 5.5 in plan.txt and docs/discovery.md.
-   [ ] D5.5. SOCIAL APP PUBLIC LAYER — split posts into public_posts /
-        private_posts, default terms on signup, register default schemas,
-        wire reactions to /public/entries, wire feed to /discover/posts.
-        See PHASE 5.5 in plan.txt.
+[ ] A5.5. DISCOVERY API — the public layer (Lane A, api/**):
+         discovery index (web10.discovery_posts, write-protected,
+         background task), schema registry (web10.schemas, CRUD with
+         author enforcement, provider.uuid6 IDs), public ledger
+         (web10.public, validated entries), discovery endpoints
+         (/discover/posts, /users, /search, /topics, /post/{user}/{service}/{id}),
+         engagement aggregation (cached counts on index, schema-agnostic).
+         See PHASE 5.5 in plan.txt and docs/discovery.md.
+    [ ] D5.5. SOCIAL APP PUBLIC LAYER — split posts into public_posts /
+         private_posts, default terms on signup, register default schemas,
+         wire reactions to /public/entries, wire feed to /discover/posts.
+         See PHASE 5.5 in plan.txt.
+    [✓ 1.0.89] persona-orchestration/ — 5 live-testing personas with seed scripts,
+         first-week content plans, cross-follows, posts, comments, DMs, and
+         reactions. powers C6's e2e persona fixtures and makes the platform
+         look alive for dev testing + demos.
 
   merge-order notes: B5/D12/D13 don't gate each other; merge each as
   it passes design.md §12. D13 owns the cross-app asset generation

--- a/persona-orchestration/README.md
+++ b/persona-orchestration/README.md
@@ -1,0 +1,68 @@
+# Persona Orchestration
+
+Live-testing personas that make the social platform look alive. Five users with funny names, distinct personalities, real photos, and a plan to go ham.
+
+## The Cast
+
+| # | Username | Display Name | Vibe |
+|---|----------|--------------|------|
+| 1 | `solar-flare-69` | Solar Flare | The unhinged crypto-bro podcaster who thinks he's the next Joe Rogan |
+| 2 | `noodle-empress` | Noodle Empress | Chaotic food blogger, posts pictures of ramen at 3am, aggressively nice |
+| 3 | `void-walker` | Void Walker | Dark academia aesthetic, quotes Nietzsche at 2am, secretly soft |
+| 4 | `butterfly-mechanic` | Butterfly Mechanic | DIY everything — fixes bugs literally and metaphorically, workshop pics |
+| 5 | `disco-donkey` | Disco Donkey | Pure chaos energy, dance memes, unhinged DMs, the class clown |
+
+## How It Works
+
+1. **Seed the accounts** — run `seed_personas.sh` against your local or dev API to create all 5 users
+2. **Log in as each persona** — grab their JWT token, use it to make posts, upload photos, send DMs
+3. **Follow the action plan** — each persona has a `actions.md` file with their first week of content
+4. **Cross-pollinate** — personas follow each other, comment on each other, DM each other, react to each other
+
+## Quick Start
+
+```bash
+# Create all 5 accounts (point at your API)
+export API_BASE="http://api.localhost:6000"
+bash seed_personas.sh
+
+# Or use the Python script for more control
+python seed_personas.py --api http://api.localhost:6000
+```
+
+## File Structure
+
+```
+persona-orchestration/
+├── README.md              # This file
+├── seed_personas.sh       # Bash seed script
+├── seed_personas.py       # Python seed script (full control)
+├── photos/                # Profile photos & post media (stock/CC0)
+├── solar-flare-69/
+│   └── actions.md         # First week of content plan
+├── noodle-empress/
+│   └── actions.md
+├── void-walker/
+│   └── actions.md
+├── butterfly-mechanic/
+│   └── actions.md
+└── disco-donkey/
+    └── actions.md
+```
+
+## Passwords
+
+All personas use `web10test!2026` as their password. Change it in `seed_personas.sh` / `seed_personas.py` if needed.
+
+## API Endpoints Used
+
+- `POST /signup` — create account
+- `POST /web10token` — login, get JWT
+- `POST /{user}/profile` — set display name, bio
+- `POST /{user}/posts` — create posts
+- `POST /{user}/upload` + `POST /{user}/upload/confirm` — upload media
+- `POST /{user}/contacts` — add contacts
+- `POST /{user}/follows` — follow other personas
+- `POST /{user}/dm-{a}--{b}` — send DMs
+- `POST /{user}/reactions` — like/react to posts
+- `POST /{user}/comments` — comment on posts

--- a/persona-orchestration/butterfly-mechanic/actions.md
+++ b/persona-orchestration/butterfly-mechanic/actions.md
@@ -1,0 +1,48 @@
+# Butterfly Mechanic — First Week Action Plan
+
+**Vibe:** DIY everything. Fixes bugs literally and metaphorically. Workshop pics. Zero patience for unlabeled cables.
+
+## Day 1: Establishing Presence
+- [x] Post: "Fixed a 1998 Honda Civic today..." (seeded)
+- [x] Post: "Built a butterfly enclosure in my backyard..." (seeded)
+- [x] Post: "Pro tip: label your cables..." (seeded)
+- [ ] Upload a profile photo: workshop background, holding a butterfly net in one hand and a wrench in the other, covered in grease and pollen
+- [ ] Post: "New to web10! I'm Butterfly Mechanic. I fix cars, build butterfly habitats, and label my cables. If you're into DIY, nature, or just watching someone swear at a stubborn bolt for 45 minutes, you're in the right place. 🔧🦋"
+- [ ] DM noodle-empress: "send me a video of the rice cooker noise. if it's the heating element i can fix it for like $5 in parts"
+
+## Day 2: Workshop Content
+- [ ] Post: "Restored a vintage soldering iron..." (seeded)
+- [ ] Post: "My workshop is 80% tools I'll never use..." (seeded)
+- [ ] Comment on noodle-empress's hidden ramen shop post: "That unmarked shop sounds amazing. I once found a ramen place by following the smell. Worked every time."
+- [ ] Comment on void-walker's philosophy post: "There's something darkly poetic about naming a plant after a philosopher who wrote about the death of God. Respect. 🦋"
+- [ ] Upload a photo: the butterfly enclosure, morning light, butterflies on milkweed, workshop visible in the background
+
+## Day 3: Tutorial Content
+- [ ] Post: "Tutorial: how to change your own oil. It's not hard. It's not scary. You need a wrench, a drain pan, and the willingness to get dirty. The mechanic shop wants $80 for this. I'll show you how to do it for $25. Step 1: get under the car. I'll use a jack and stands. No, it's not dangerous if you do it right. Yes, I'll explain how to do it right."
+- [ ] Post: "Found a Monarch butterfly chrysalis on my milkweed plant this morning. In 10 days it'll emerge. I've been watching this plant for 3 months. The waiting is the hardest part. Also the most beautiful part. Patience is a skill. So is using a torque wrench."
+- [ ] Comment on disco-donkey's toaster story: "I tried to fix my toaster once. Now I just buy new bread. We all have our limits 🔧🍞"
+- [ ] React to solar-flare-69's posts with 🔥
+
+## Day 4: Nature + Tech Crossover
+- [ ] Post: "The intersection of bugs and butterflies: I debug code for a living and raise butterflies on the weekend. Both require patience, observation, and the willingness to stare at something tiny for hours wondering what it's thinking. One pays my rent. The other pays my soul."
+- [ ] Post: "Workshop organization day. Color-coded cable ties. Label maker. The satisfaction of a clean workspace is unmatched. My partner says I'm obsessive. I say I respect my tools. Same thing, different words."
+- [ ] DM solar-flare-69 about the mic stand (seeded)
+- [ ] React to noodle-empress's cooking posts with 🔥
+
+## Day 5: Personal Content
+- [ ] Post: "Took my dad's 1985 Ford truck for a drive today. He gave it to me when I was 16. It has 287,000 miles and runs better than most new cars. Not because it's special. Because we take care of things that matter. The truck matters. So does the work you put into it."
+- [ ] Comment on void-walker's coffee shop post: "there's a mechanic equivalent of your coffee shop corner. it's the bay where you park your hardest project and don't leave until it's right. the coffee is worse but the satisfaction is the same"
+- [ ] Post: "Released 12 Monarch butterflies this morning. They flew in every direction. One landed on my hand and stayed for a full minute. In that minute, I understood why people get into this work. You spend months preparing the habitat, growing the milkweed, watching the caterpillars turn into chrysalises. And then for one minute, the butterfly chooses to trust you."
+- [ ] React to void-walker's book post with ❤️
+
+## Day 6: Community + Collab
+- [ ] Post: "Shoutout to @noodle-empress's rice cooker is fixed. The heating element was shot. $4.50 at the appliance parts store. 20 minutes to replace. She's welcome to pay me in ramen. I accept this currency."
+- [ ] Post: "Fixed @solar-flare-69's mic stand. Loose bolt in the base. Told him over DM. He said 'you're a wizard.' I said 'it's a wrench.' Same thing, different words."
+- [ ] Comment on solar-flare-69's $47 vs $800 post: "$47 vs $800? That's the kind of ROI I talk about on the show. You're out here building real value."
+- [ ] DM disco-donkey: "hey disco. if you ever want to learn basic car maintenance i'm happy to teach you. start with changing a tire. it's empowering and you'll never be stranded"
+
+## Day 7: Wrap & Reflect
+- [ ] Post: "Week 1 on web10. Fixed a rice cooker, a mic stand, and labeled 47 cables. Released 12 butterflies. Read a philosophy book (page 12, the cat is judging me). Made friends with a podcaster, a food blogger, a dark academic, and a disco donkey. This platform feels like a workshop: built by people who care about the work, no shortcuts, no algorithm cutting corners. Every post reaches every follower. Like a tool that works exactly like it should. 🦋🔧"
+- [ ] Comment on everyone's latest post
+- [ ] React to 5+ posts from other personas
+- [ ] DM noodle-empress: "the rice cooker is running smooth. also i found a milkweed seedling near your building if you want to start a butterfly garden. i'll bring the pot you bring the ramen"

--- a/persona-orchestration/disco-donkey/actions.md
+++ b/persona-orchestration/disco-donkey/actions.md
@@ -1,0 +1,48 @@
+# Disco Donkey — First Week Action Plan
+
+**Vibe:** Pure chaos energy. Dance memes. Unhinged DMs. The class clown. Zero self-awareness, maximum joy.
+
+## Day 1: Establishing Presence
+- [x] Post: "Just danced to 'Stayin' Alive' in the middle of a grocery store..." (seeded)
+- [x] Post: "My therapist says I need to find an outlet for my energy..." (seeded)
+- [x] Post: "Challenge: I'm going to do the moonwalk across every room..." (seeded)
+- [ ] Upload a profile photo: mid-dance move, blurry, bad angle, wearing sunglasses indoors, maximum energy
+- [ ] Post: "NEW TO WEB10!! if you're here for good content you're in the wrong place. if you're here for CHAOS and DANCE MEMES and ZERO SELF AWARENESS you're home. my name is disco donkey and i have no thoughts just vibes 🫏🕺"
+- [ ] DM solar-flare-69: "yo heard you need a hype man for the podcast. i'm available. my rate is 3 dance breaks per episode"
+
+## Day 2: Chaos Content
+- [ ] Post: "Found out my donkey emoji is more popular than my actual name..." (seeded)
+- [ ] Post: "Life hack: if you're having a bad day, put on 'Dancing Queen'..." (seeded)
+- [ ] Comment on solar-flare-69's podcast post: "47 MINUTES?? That's like 3 dance songs. You need to tighten the show up my friend 🕺"
+- [ ] Comment on noodle-empress's ramen post: "3am cooking is my love language too but I'm usually just making cereal at that hour 🫏"
+- [ ] Upload a photo: the grocery store dance floor (aka aisle 7), motion blur, cashier visible in the background looking confused
+
+## Day 3: Dance Challenge
+- [ ] Post: "Day 2 of the moonwalk challenge. Attempted it on a bus. The driver asked me to stop. I said 'but I'm creating content.' He said 'you're creating a hazard.' Fair point. 0/3 rooms today. The bus didn't have rooms."
+- [ ] Post: "Tried to teach my roommate the moonwalk. He did it once. Then he did it again but better. Then he did it while making coffee. I am threatened. I am inspired. I am going to practice for 3 hours straight."
+- [ ] Comment on void-walker's library book post: "i read the library book you recommended. it was in a language i don't know. i liked the pictures though. 10/10 would be confused again 📚"
+- [ ] React to void-walker's posts with ❤️
+
+## Day 4: Meme Energy
+- [ ] Post: "OK NEW CHALLENGE: i'm going to compliment every persona on this platform but i have to do it WHILE DANCING. solar flare: your podcast energy is like a good beat, it just keeps going and you can't stop it *does the robot*. noodle empress: your ramen posts are the fuel that powers my 3am cereal runs *spins*. void walker: your philosophy quotes hit different at 2am *moonwalks*. butterfly mechanic: you fix things and also butterflies and that's the most wholesome thing i've ever heard *does the sprinkler*."
+- [ ] Post: "My dance channel now has 48 followers. The new one is my other mom. She's been checking on me this whole time. Two moms. Zero strangers. The growth is real."
+- [ ] DM void-walker about the sneaker eulogy (seeded)
+- [ ] React to butterfly-mechanic's posts with ❤️
+
+## Day 5: Personal Content
+- [ ] Post: "Had a dream last night that I was a disco ball. Not ON a disco ball. I WAS the disco ball. Hanging from the ceiling. Reflecting light. Being beautiful. Woke up and did 47 spins in my living room. My neighbor knocked on the door. I moonwalked to answer it. She didn't laugh. No one laughs. I laugh for all of us."
+- [ ] Comment on noodle-empress's grocery store post: "getting kicked out of a grocery store for dancing is the most iconic thing i've ever heard. you're a legend 🫏💃"
+- [ ] Post: "Unpopular opinion: the moonwalk is not a dance move. It's a lifestyle. Michael Jackson didn't invent the moonwalk. He just was the first person to moonwalk while 20 million people watched. I moonwalk in my kitchen while 0 people watch. We are the same. Different audience size, same energy."
+- [ ] React to noodle-empress's posts with 🍜 and 💃
+
+## Day 6: Collab Energy
+- [ ] Post: "SHOUTOUT TO ALL MY FELLOW PERSONAS. this platform is wild. i've made friends with a podcaster who talks for 4 hours, a food blogger who cooks at 3am, a philosopher who names plants after dead guys, and a mechanic who fixes butterflies. we are a weird group. we are a GOOD group. web10 is the place for weird good groups."
+- [ ] Post: "Attempted to moonwalk up stairs today. Fell. Got back up. Moonwalked DOWN the stairs successfully. Progress is progress. My knee disagrees. I don't care."
+- [ ] DM noodle-empress about the cooking collab (seeded)
+- [ ] Comment on solar-flare-69's creator economy post: "this energy is exactly what the creator economy needs. unfiltered, authentic, zero apologies. you're gonna blow up."
+
+## Day 7: Wrap & Reflect
+- [ ] Post: "Week 1 on web10. Moonwalked in: my house (7 rooms), a grocery store, a bus (briefly), and down some stairs (successfully). Made 48 friends (47 are my mom, 1 is a bot, but the 4 personas are REAL and they're COOL). Danced to 'Dancing Queen' 14 times. Got kicked out of 1 place. This platform is the best because every post I make actually reaches people. No algorithm saying 'sorry disco donkey, your dance content isn't trending today.' Here, my donkey energy reaches 100% of my followers. That's not a feature. That's a way of life. 🫏🕺✨"
+- [ ] Comment on everyone's latest post
+- [ ] React to 5+ posts from other personas
+- [ ] DM solar-flare-69: "so about that hype man gig. i've been thinking. what if i did a dance break at the START of every episode? the 'disco donkey intro'? it's iconic. it's memorable. it's going to happen whether you agree yet or not."

--- a/persona-orchestration/noodle-empress/actions.md
+++ b/persona-orchestration/noodle-empress/actions.md
@@ -1,0 +1,48 @@
+# Noodle Empress — First Week Action Plan
+
+**Vibe:** Chaotic food blogger. Posts ramen pics at 3am. Aggressively nice. Will cry over good broth.
+
+## Day 1: Establishing Presence
+- [x] Post: "Found a ramen shop that doesn't show up on Google Maps..." (seeded)
+- [x] Post: "3am and I'm making tonkotsu from scratch..." (seeded)
+- [x] Post: "Rating: Ichiran Shibuya 8/10..." (seeded)
+- [ ] Upload a profile photo: selfie holding a giant bowl of ramen, steam fogging the camera, messy hair, zero regrets
+- [ ] Post: "New to this platform! If you love food content at ungodly hours, you're in the right place. My name is Noodle Empress and I have no self-control when it comes to broth."
+- [ ] DM solar-flare-69: "hey solar! love the podcast energy. if you ever need someone to talk about the philosophy of ramen on your show i'm your girl"
+
+## Day 2: Food Content + Engagement
+- [ ] Post: "Hot take: instant ramen is a gateway drug..." (seeded)
+- [ ] Post: "Made udon for the first time..." (seeded)
+- [ ] Comment on solar-flare-69's podcast post: "I fall asleep during podcasts too but at least I have ramen as a snack 🍜"
+- [ ] Comment on butterfly-mechanic's workshop post: "There's something about fixing things with your hands that's the same as cooking. Both are acts of love for the process"
+- [ ] Upload a photo: the unmarked ramen shop exterior (grainy, atmospheric, neon sign in Japanese)
+
+## Day 3: The 3am Special
+- [ ] Post: "It's 3:47am and I just realized I have enough ingredients to make 5 different noodle dishes. This is not a problem. This is a blessing. Starting with shoyu ramen because I'm emotional right now."
+- [ ] Post: "Cooking at 3am is different from cooking at 6pm. At 6pm you're feeding people. At 3am you're feeding your soul. The soul wants garlic. Lots of garlic."
+- [ ] Comment on void-walker's library post: "the librarian bringing you tea is the most romantic thing i've ever heard. also if you're ever hungry at 2am i make a mean midnight ramen"
+- [ ] React to void-walker's posts with ❤️
+
+## Day 4: Recipe Content
+- [ ] Post: "Recipe drop: my secret tonkotsu broth. It's not actually secret, I just never wrote it down until now. 12 hours. Pork bones. Ginger. Garlic. Soy sauce. Time. That's it. That's the recipe. The secret is patience and it's 3am and I don't have any."
+- [ ] Post: "Went to a grocery store today during NORMAL HOURS and felt like a criminal. Everything was so bright. So many people. I missed my kitchen. I missed the darkness. I missed the broth."
+- [ ] DM butterfly-mechanic about the rice cooker (seeded)
+- [ ] React to butterfly-mechanic's butterfly post with 🦋
+
+## Day 5: Personal + Community
+- [ ] Post: "My grandma's ramen recipe called for 'a little bit of love.' I called her to ask what that meant. She said 'you'll know when you taste it.' I've been making ramen for 10 years and I still don't know what that means. Send help. Or more garlic."
+- [ ] Comment on disco-donkey's dance post: "getting kicked out of a grocery store for dancing is the most iconic thing i've ever heard. you're a legend 🫏💃"
+- [ ] Post: "Food is the universal language. I've made friends over ramen in Tokyo, Seoul, Taipei, and my own kitchen at 3am. The broth doesn't care about your politics, your bank account, or your follower count. It just wants to be good."
+- [ ] React to disco-donkey's posts with 💃
+
+## Day 6: Collab Energy
+- [ ] Post: "Shoutout to @butterfly-mechanic for fixing my rice cooker. The man is a wizard. $5 in parts and now I have the perfect rice for my ramen. This is what community is."
+- [ ] Post: "Cooking collab idea: @disco-donkey dances while I stir the broth. If the cat doesn't knock over the soy sauce this time, it might actually work."
+- [ ] DM disco-donkey about the cooking collab (seeded)
+- [ ] Comment on solar-flare-69's creator economy post: "the creator economy needs more people who are passionate about their niche. whether it's crypto or ramen, the energy is the same"
+
+## Day 7: Wrap & Reflect
+- [ ] Post: "Week 1 on web10. Made friends with a podcaster, a philosopher, a mechanic, and a disco donkey. Ate ramen at 3am six times. Fixed my rice cooker. This platform feels like a community, not a feed. And the best part? Every post I make actually reaches the people who follow me. No algorithm. Just connection. 🍜✨"
+- [ ] Comment on everyone's latest post
+- [ ] React to 5+ posts from other personas
+- [ ] DM void-walker: "hey void! i made extra miso soup. it's 3:17am. come over. we can read camus and eat soup. it's a date. not like that. like a food and books date."

--- a/persona-orchestration/photos/README.md
+++ b/persona-orchestration/photos/README.md
@@ -1,0 +1,16 @@
+# Drop profile photos and post media here for each persona.
+# Use CC0 / public domain images or generate them.
+#
+# Suggested filenames:
+#   solar-flare-69-profile.jpg    — grainy selfie in recording booth, headphones on
+#   noodle-empress-profile.jpg    — selfie holding giant ramen bowl, steam, messy hair
+#   void-walker-profile.jpg       — candlelit desk, open book, cat silhouette
+#   butterfly-mechanic-profile.jpg — workshop bg, butterfly net + wrench, grease + pollen
+#   disco-donkey-profile.jpg      — mid-dance, blurry, sunglasses indoors, max energy
+#
+# Post photos:
+#   solar-flare-69-post1.jpg      — podcast setup, mic, headphones
+#   noodle-empress-post1.jpg      — unmarked ramen shop exterior, neon sign
+#   void-walker-post1.jpg         — handwritten Nietzsche eulogy in notebook
+#   butterfly-mechanic-post1.jpg  — butterfly enclosure, morning light, workshop bg
+#   disco-donkey-post1.jpg        — grocery store aisle dance, motion blur

--- a/persona-orchestration/seed_personas.py
+++ b/persona-orchestration/seed_personas.py
@@ -1,0 +1,496 @@
+#!/usr/bin/env python3
+"""
+Seed 5 persona accounts for live testing the web10 social platform.
+Creates accounts, sets profiles, establishes cross-follows, and seeds initial content.
+
+Usage:
+    python seed_personas.py --api http://api.localhost:6000
+    python seed_personas.py --api https://api.dev.web10.app
+"""
+
+import argparse
+import json
+import sys
+import time
+from datetime import datetime, timezone
+
+try:
+    import requests
+except ImportError:
+    print("Install requests: pip3 install requests")
+    sys.exit(1)
+
+PASSWORD = "web10test!2026"
+
+PERSONAS = [
+    {
+        "username": "solar-flare-69",
+        "display_name": "Solar Flare",
+        "bio": "Podcast host. Crypto degenerate. I will talk for 4 hours about anything. New episode every day at 3am because sleep is for weak chains. 🚀🌞",
+    },
+    {
+        "username": "noodle-empress",
+        "display_name": "Noodle Empress",
+        "bio": "Ramen snob with a $12 bowl budget. If it's got broth, I'll eat it. 3am food pics are a feature, not a bug. 🍜✨",
+    },
+    {
+        "username": "void-walker",
+        "display_name": "Void Walker",
+        "bio": "Reading Camus in a candlelit room at 2am. Dark academia is not an aesthetic, it's a lifestyle. Also I like cats. 📚🖤",
+    },
+    {
+        "username": "butterfly-mechanic",
+        "display_name": "Butterfly Mechanic",
+        "bio": "Fixing bugs and butterflies since 2019. Workshop pics, DIY tutorials, and zero patience for people who don't label their cables. 🦋🔧",
+    },
+    {
+        "username": "disco-donkey",
+        "display_name": "Disco Donkey",
+        "bio": "Professional chaos agent. If you're not laughing, you're doing it wrong. Dance memes only. No thoughts, just vibes. 🫏🕺",
+    },
+]
+
+POSTS = {
+    "solar-flare-69": [
+        {
+            "text": "Hot take: the entire podcast industry is just men in expensive chairs arguing about things they read on Twitter 20 minutes ago. I'm part of the problem. Send help. Or coffee. Mostly coffee.",
+            "tags": ["podcast", "hot-takes"],
+        },
+        {
+            "text": "Just had a 47-minute rant on my show about why decentralized social media is the only way forward. My co-host fell asleep. The chat was wild though. 12k listeners, 3 of them stayed awake. That's engagement for you.",
+            "tags": ["web10", "crypto", "podcast"],
+        },
+        {
+            "text": "Unpopular opinion: most 'builders' in crypto have never built anything that a 14 year old couldn't replicate in a weekend. Show me your GitHub, not your Twitter bio.",
+            "tags": ["hot-takes", "crypto"],
+        },
+        {
+            "text": "Day 47 of drinking only matcha and doing pushups. My skin is glowing, my wallet is not. Balance.",
+            "tags": ["wellness", "lifestyle"],
+        },
+        {
+            "text": "The algorithm shadowbanned me AGAIN. 2M followers, 400 impressions. Meanwhile on this platform my post reaches 100% of my followers because the architecture guarantees it. This is the difference between renting and owning your audience. Wake up.",
+            "tags": ["web10", "creator-economy"],
+        },
+    ],
+    "noodle-empress": [
+        {
+            "text": "Found a ramen shop that doesn't show up on Google Maps. The owner is a 78 year old man who has been making the same broth for 50 years. I cried. Into the bowl. 🍜",
+            "tags": ["ramen", "hidden-gems", "food"],
+        },
+        {
+            "text": "3am and I'm making tonkotsu from scratch because the delivery apps are all closed and I have standards. The pork bones have been boiling for 12 hours. My apartment smells like a Tokyo street. No regrets.",
+            "tags": ["home-cooking", "ramen", "3am"],
+        },
+        {
+            "text": "Rating: Ichiran Shibuya 8/10, Afuri Daikanyama 9/10, that unmarked shop in Shinjuku that I'm not naming because I want it to stay secret 11/10. Fight me.",
+            "tags": ["ramen", "ratings", "tokyo"],
+        },
+        {
+            "text": "Hot take: instant ramen is a gateway drug. You start with Cup Noodles at 2am after a bad date and somehow 6 months later you're fermenting your own miso. It happens to the best of us.",
+            "tags": ["hot-takes", "food", "misadventures"],
+        },
+        {
+            "text": "Made udon for the first time. The dough is like working with concrete. My arms hurt. The result? Beautiful. Slap that noodle on a plate like you mean it.",
+            "tags": ["udon", "home-cooking", "diy"],
+        },
+    ],
+    "void-walker": [
+        {
+            "text": "\"Man is nothing else but what he makes of himself.\" — Sartre. Reading this at 2:47am with a cup of black coffee and a cat named Camus on my lap. This is the life. 📖",
+            "tags": ["philosophy", "dark-academia", "books"],
+        },
+        {
+            "text": "Bought a leather-bound notebook. Wrote one sentence in it. The sentence was 'to be or not to be' because I'm not a monster. Now it sits on my desk judging me. We have an understanding.",
+            "tags": ["dark-academia", "literature"],
+        },
+        {
+            "text": "The library is the only place where silence feels like company. Spent 6 hours today in the philosophy section. The librarian knows me now. She doesn't judge. She brings me tea.",
+            "tags": ["library", "dark-academia", "quiet"],
+        },
+        {
+            "text": "Started reading 'The Stranger' again for the 7th time. Each time I find something new. Camus was writing about algorithmic feed fatigue in 1942 and nobody noticed. The absurdity of modern life hasn't changed, just the medium.",
+            "tags": ["camus", "philosophy", "books"],
+        },
+        {
+            "text": "My plant died. I named it Nietzsche. I'm writing a eulogy. It's going to be good. Update: the eulogy is better than most things I've read this year. Maybe I should be a writer instead of a philosophy student.",
+            "tags": ["dark-humor", "plants", "writing"],
+        },
+    ],
+    "butterfly-mechanic": [
+        {
+            "text": "Fixed a 1998 Honda Civic today. The mechanic shop quoted $800. I did it for $47 in parts and 3 hours of swearing. The car runs better than it has in a decade. This is why I don't trust mechanic shops. 🔧",
+            "tags": ["diy", "cars", "workshop"],
+        },
+        {
+            "text": "Built a butterfly enclosure in my backyard. Released 12 Monarch butterflies this morning. Watching them take flight for the first time is the most peaceful thing I've ever witnessed. Also my neighbor thinks I'm weird. Worth it. 🦋",
+            "tags": ["butterflies", "nature", "diy"],
+        },
+        {
+            "text": "Pro tip: label your cables. I spent 4 hours today tracing a network cable through a wall only to find out it was connected to a printer that hasn't worked since 2019. Four hours. Four. Hours. Label. Your. Cables.",
+            "tags": ["tech", "diy", "pro-tips"],
+        },
+        {
+            "text": "Restored a vintage soldering iron I found at a flea market. 1970s Weller. Still works perfectly. There's something about fixing old things that makes you feel connected to the people who made them. This person, 50 years ago, cared about quality.",
+            "tags": ["restoration", "tools", "workshop"],
+        },
+        {
+            "text": "My workshop is 80% tools I'll never use and 20% coffee stains. The 80% makes me feel prepared. The 20% makes me feel alive. Perfect balance.",
+            "tags": ["workshop", "lifestyle", "diy"],
+        },
+    ],
+    "disco-donkey": [
+        {
+            "text": "Just danced to 'Stayin' Alive' in the middle of a grocery store. The cashier gave me a look. I gave her a beat. She joined in. We got kicked out. Best shopping trip ever. 🕺🛒",
+            "tags": ["chaos", "dance", "memes"],
+        },
+        {
+            "text": "My therapist says I need to find an outlet for my energy. So I started a dance channel. 47 followers. 46 of them are my mom checking on me. The other one is a bot. I'm thriving.",
+            "tags": ["dance", "memes", "chaos"],
+        },
+        {
+            "text": "Challenge: I'm going to do the moonwalk across every room in my house. Room 1 (kitchen): success. Room 2 (bathroom): slipped on a wet floor, survived. Room 3 (bedroom): the cat judged me. 2/3 rooms. Not bad for a Tuesday.",
+            "tags": ["challenge", "moonwalk", "chaos"],
+        },
+        {
+            "text": "Found out my donkey emoji is more popular than my actual name. People call me Disco Donkey IRL now. My grandma doesn't get it. She asked if I'm 'that donkey guy on the computer.' Yes, grandma. Yes I am. And I own it.",
+            "tags": ["identity", "memes", "chaos"],
+        },
+        {
+            "text": "Life hack: if you're having a bad day, put on 'Dancing Queen' and dance like nobody's watching. Then check your phone and realize everyone IS watching because you live with roommates. Still worth it. 👑💃",
+            "tags": ["life-hacks", "abba", "chaos"],
+        },
+    ],
+}
+
+COMMENTS = {
+    # "poster_username": [commenter, text]
+    "solar-flare-69": [
+        ("noodle-empress", "I fall asleep during podcasts too but at least I have ramen as a snack 🍜"),
+        ("disco-donkey", "47 MINUTES?? That's like 3 dance songs. You need to tighten the show up my friend 🕺"),
+        ("void-walker", "Sartre would have something to say about performative intellectualism in podcast culture. Just saying."),
+    ],
+    "noodle-empress": [
+        ("butterfly-mechanic", "That unmarked shop sounds amazing. I once found a ramen place by following the smell. Worked every time."),
+        ("solar-flare-69", "I'd have this on my podcast. The man has been making broth for 50 years. That's the kind of dedication I talk about."),
+        ("disco-donkey", "3am cooking is my love language too but I'm usually just making cereal at that hour 🫏"),
+    ],
+    "void-walker": [
+        ("noodle-empress", "Camus the cat is the best thing I've read all week. Please tell me he's still alive (unlike Nietzsche the plant)"),
+        ("butterfly-mechanic", "There's something darkly poetic about naming a plant after a philosopher who wrote about the death of God. Respect. 🦋"),
+        ("disco-donkey", "I read the library book you recommended. It was in a language I don't know. I liked the pictures though. 10/10 would be confused again 📚"),
+    ],
+    "butterfly-mechanic": [
+        ("solar-flare-69", "$47 vs $800? That's the kind of ROI I talk about on the show. You're out here building real value."),
+        ("void-walker", "The care a craftsman puts into a tool is the same care a writer puts into a sentence. Both are acts of love for the work. Beautiful post."),
+        ("disco-donkey", "I tried to fix my toaster once. Now I just buy new bread. We all have our limits 🔧🍞"),
+    ],
+    "disco-donkey": [
+        ("noodle-empress", "Getting kicked out of a grocery store for dancing is the most iconic thing I've ever heard. You're a legend 🫏💃"),
+        ("solar-flare-69", "This energy is exactly what the creator economy needs. Unfiltered, authentic, zero apologies. You're gonna blow up."),
+        ("void-walker", "In a world of curated perfection, your chaotic authenticity is refreshingly absurd. Camus would approve. 📖"),
+    ],
+}
+
+DMS = [
+    {"from": "disco-donkey", "to": "solar-flare-69", "message": "yo heard you need a hype man for the podcast. i'm available. my rate is 3 dance breaks per episode"},
+    {"from": "solar-flare-69", "to": "disco-donkey", "message": "honestly the chat loves when you show up. you're on. first episode free though, i'm not crazy"},
+    {"from": "noodle-empress", "to": "butterfly-mechanic", "message": "hey i saw your workshop pics and i have a question. do you think you could help me fix my rice cooker? it's making a weird noise and i'm scared"},
+    {"from": "butterfly-mechanic", "to": "noodle-empress", "message": "send me a video of the noise. if it's the heating element i can fix it for like $5 in parts. also what brand is it?"},
+    {"from": "void-walker", "to": "noodle-empress", "message": "your 3am ramen posts are the only thing keeping me awake past 2am and for that i am both grateful and disturbed"},
+    {"from": "noodle-empress", "to": "void-walker", "message": "that's the most romantic thing anyone has ever said to me. also i made extra miso soup. come over. it's 3:17am."},
+    {"from": "disco-donkey", "to": "void-walker", "message": "hey void walker i need you to write a eulogy for my left sneaker. it fell apart during a moonwalk. it deserved better than the trash"},
+    {"from": "void-walker", "to": "disco-donkey", "message": "\"Here lies a shoe that dared to dream of the moon. It was rubber-soled but spirit-winged.\" You're welcome. Charge: one library book."},
+    {"from": "solar-flare-69", "to": "butterfly-mechanic", "message": "bro i need you to look at my mic stand. it's wobbling during recordings and the audio guys are losing it"},
+    {"from": "butterfly-mechanic", "to": "solar-flare-69", "message": "send me a pic of the base. bet it's a loose bolt. i'll DM you a fix in 5 minutes"},
+    {"from": "disco-donkey", "to": "noodle-empress", "message": "ok real talk. if i cook you a 3am meal can you teach me to make ramen from scratch? i'll bring the donkey energy you bring the noodle wisdom"},
+    {"from": "noodle-empress", "to": "disco-donkey", "message": "only if you promise not to dance while stirring the broth. last time someone danced in my kitchen the cat knocked over the soy sauce. trauma."},
+]
+
+REACTIONS = [
+    # (reactor, poster, post_index_0-based, reaction_type)
+    ("noodle-empress", "solar-flare-69", 0, "❤️"),
+    ("disco-donkey", "solar-flare-69", 4, "🔥"),
+    ("void-walker", "noodle-empress", 0, "❤️"),
+    ("butterfly-mechanic", "noodle-empress", 1, "🔥"),
+    ("solar-flare-69", "void-walker", 0, "🧠"),
+    ("disco-donkey", "void-walker", 4, "❤️"),
+    ("noodle-empress", "butterfly-mechanic", 0, "🔥"),
+    ("void-walker", "butterfly-mechanic", 3, "❤️"),
+    ("solar-flare-69", "disco-donkey", 0, "🔥"),
+    ("butterfly-mechanic", "disco-donkey", 2, "❤️"),
+    ("noodle-empress", "disco-donkey", 4, "💃"),
+    ("void-walker", "disco-donkey", 1, "❤️"),
+    ("disco-donkey", "noodle-empress", 0, "🍜"),
+    ("butterfly-mechanic", "noodle-empress", 2, "🔥"),
+    ("solar-flare-69", "void-walker", 3, "🧠"),
+    ("noodle-empress", "butterfly-mechanic", 1, "🦋"),
+    ("void-walker", "solar-flare-69", 2, "❤️"),
+    ("disco-donkey", "butterfly-mechanic", 4, "🔧"),
+]
+
+
+def api(base, method, path, data=None):
+    url = f"{base}{path}"
+    resp = requests.request(method, url, json=data, timeout=30)
+    try:
+        return resp.json()
+    except Exception:
+        return resp.text
+
+
+def signup(base, persona):
+    r = api(base, "POST", "/signup", {
+        "username": persona["username"],
+        "password": PASSWORD,
+    })
+    return r
+
+
+def login(base, username):
+    r = api(base, "POST", "/web10token", {
+        "username": username,
+        "password": PASSWORD,
+        "site": "social.web10.app",
+        "target": "",
+    })
+    return r.get("token") if isinstance(r, dict) else None
+
+
+def set_profile(base, username, token, persona):
+    api(base, "POST", f"/{username}/profile", {
+        "token": token,
+        "query": {
+            "display_name": persona["display_name"],
+            "bio": persona["bio"],
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+        },
+    })
+
+
+def create_post(base, username, token, post_data):
+    return api(base, "POST", f"/{username}/posts", {
+        "token": token,
+        "query": {
+            **post_data,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "visibility": "public",
+            "origin": "web10",
+        },
+    })
+
+
+def add_contact(base, username, token, target_username, provider="api.localhost"):
+    api(base, "POST", f"/{username}/contacts", {
+        "token": token,
+        "query": {
+            "username": target_username,
+            "provider": provider,
+            "added_at": datetime.now(timezone.utc).isoformat(),
+        },
+    })
+
+
+def follow_user(base, username, token, target_username, provider="api.localhost"):
+    api(base, "POST", f"/{username}/follows", {
+        "token": token,
+        "query": {
+            "username": target_username,
+            "provider": provider,
+            "status": "active",
+            "followed_at": datetime.now(timezone.utc).isoformat(),
+        },
+    })
+
+
+def deliver_to_inbox(base, target_user, token, author_username, post_id, post_body, provider="api.localhost"):
+    """Fan-out: write an inbox record to the target user's inbox."""
+    api(base, "POST", f"/{target_user}/inbox", {
+        "token": token,
+        "query": {
+            "author_username": author_username,
+            "author_provider": provider,
+            "post_id": post_id,
+            "delivered_at": datetime.now(timezone.utc).isoformat(),
+            "post_body": post_body,
+            "origin": "web10",
+        },
+    })
+
+
+def send_dm(base, from_user, to_user, token, message, provider="api.localhost"):
+    ids = sorted([f"{provider}/{from_user}", f"{provider}/{to_user}"])
+    conv = f"dm-{ids[0]}--{ids[1]}"
+    return api(base, "POST", f"/{from_user}/{conv}", {
+        "token": token,
+        "query": {
+            "message": message,
+            "sent_at": datetime.now(timezone.utc).isoformat(),
+            "sender_username": from_user,
+            "sender_provider": provider,
+        },
+    })
+
+
+def add_reaction(base, reactor, token, target_service, target_id, reaction_type, author_provider="api.localhost"):
+    api(base, "POST", f"/{reactor}/reactions", {
+        "token": token,
+        "query": {
+            "target_service": target_service,
+            "target_id": target_id,
+            "type": reaction_type,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "author_username": reactor,
+            "author_provider": author_provider,
+        },
+    })
+
+
+def add_comment(base, commenter, token, post_id, text, author_provider="api.localhost"):
+    api(base, "POST", f"/{commenter}/comments", {
+        "token": token,
+        "query": {
+            "post_id": post_id,
+            "text": text,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "author_username": commenter,
+            "author_provider": author_provider,
+        },
+    })
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Seed persona accounts for web10 social testing")
+    parser.add_argument("--api", default="http://api.localhost:6000", help="API base URL")
+    parser.add_argument("--skip-content", action="store_true", help="Only create accounts, skip posts/DMs/comments")
+    args = parser.parse_args()
+
+    base = args.api.rstrip("/")
+    print(f"Target API: {base}")
+    print(f"Personas: {len(PERSONAS)}")
+    print()
+
+    # Step 1: Create accounts
+    print("=== Step 1: Creating accounts ===")
+    tokens = {}
+    for p in PERSONAS:
+        uname = p["username"]
+        print(f"  Signing up {uname}... ", end="", flush=True)
+        r = signup(base, p)
+        if "error" in (r or {}):
+            print(f"skipped (may already exist): {r}")
+            continue
+        print("done")
+        time.sleep(0.3)
+
+    # Step 2: Login all personas
+    print("\n=== Step 2: Logging in ===")
+    for p in PERSONAS:
+        uname = p["username"]
+        token = login(base, uname)
+        if token:
+            tokens[uname] = token
+            print(f"  {uname}: logged in")
+        else:
+            print(f"  {uname}: FAILED to login")
+    print()
+
+    if not tokens:
+        print("ERROR: No tokens obtained. Check API connectivity and credentials.")
+        sys.exit(1)
+
+    # Step 3: Set profiles
+    print("=== Step 3: Setting profiles ===")
+    for p in PERSONAS:
+        uname = p["username"]
+        if uname in tokens:
+            set_profile(base, uname, tokens[uname], p)
+            print(f"  {uname}: profile set")
+    print()
+
+    if args.skip_content:
+        print("Content seeding skipped (--skip-content).")
+        print("\nTokens saved. Use them to log in as each persona.")
+        return
+
+    # Step 4: Cross-follow everyone
+    print("=== Step 4: Cross-following ===")
+    usernames = [p["username"] for p in PERSONAS if p["username"] in tokens]
+    for uname in usernames:
+        for target in usernames:
+            if target != uname:
+                add_contact(base, uname, tokens[uname], target)
+                follow_user(base, uname, tokens[uname], target)
+                deliver_to_inbox(base, uname, tokens[uname], uname, "", {}, "api.localhost")
+        print(f"  {uname}: following {len(usernames) - 1} personas")
+    print()
+
+    # Step 5: Create posts
+    print("=== Step 5: Creating posts ===")
+    post_ids = {}  # (username, post_index) -> post_id
+    for uname, posts in POSTS.items():
+        if uname not in tokens:
+            continue
+        post_ids[uname] = []
+        for i, post_data in enumerate(posts):
+            r = create_post(base, uname, tokens[uname], post_data)
+            pid = r.get("_id", "") if isinstance(r, dict) else ""
+            post_ids[uname].append(pid)
+            # Fan-out to followers' inboxes
+            for follower in usernames:
+                if follower != uname and follower in tokens:
+                    deliver_to_inbox(base, follower, tokens[follower], uname, pid, post_data)
+            time.sleep(0.2)
+        print(f"  {uname}: {len(post_ids[uname])} posts created")
+    print()
+
+    # Step 6: Add reactions
+    print("=== Step 6: Adding reactions ===")
+    for reactor, poster, post_idx, rtype in REACTIONS:
+        if reactor in tokens and poster in post_ids:
+            target_id = post_ids[poster][post_idx] if post_idx < len(post_ids[poster]) else None
+            if target_id:
+                add_reaction(base, reactor, tokens[reactor], "posts", target_id, rtype)
+    print(f"  {len(REACTIONS)} reactions added")
+    print()
+
+    # Step 7: Add comments
+    print("=== Step 7: Adding comments ===")
+    for poster, comments in COMMENTS.items():
+        if poster not in post_ids or not post_ids[poster]:
+            continue
+        # Comment on the first post of each poster
+        target_post_id = post_ids[poster][0]
+        for commenter, text in comments:
+            if commenter in tokens:
+                add_comment(base, commenter, tokens[commenter], target_post_id, text)
+    print(f"  {sum(len(v) for v in COMMENTS.values())} comments added")
+    print()
+
+    # Step 8: Send DMs
+    print("=== Step 8: Sending DMs ===")
+    for dm in DMS:
+        frm = dm["from"]
+        if frm in tokens:
+            send_dm(base, frm, dm["to"], tokens[frm], dm["message"])
+    print(f"  {len(DMS)} DMs sent")
+    print()
+
+    # Summary
+    print("=" * 50)
+    print("SEED COMPLETE!")
+    print("=" * 50)
+    print(f"\nAll personas created with password: {PASSWORD}")
+    print("\nLogin tokens (save these!):")
+    for uname, token in tokens.items():
+        print(f"  {uname}: {token[:50]}...")
+    print(f"\nTotal content seeded:")
+    print(f"  Posts: {sum(len(v) for v in post_ids.values())}")
+    print(f"  Reactions: {len(REACTIONS)}")
+    print(f"  Comments: {sum(len(v) for v in COMMENTS.values())}")
+    print(f"  DMs: {len(DMS)}")
+    print(f"  Cross-follows: {len(usernames) * (len(usernames) - 1)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/persona-orchestration/seed_personas.sh
+++ b/persona-orchestration/seed_personas.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Seed 5 persona accounts for live testing web10 social.
+# Usage: bash seed_personas.sh [API_BASE]
+#   API_BASE defaults to http://api.localhost:6000
+
+set -euo pipefail
+
+API="${1:-http://api.localhost:6000}"
+PASS="web10test!2026"
+
+PERSONAS=(
+  "solar-flare-69|Solar Flare|Podcast host. Crypto degenerate. I will talk for 4 hours about anything. 🚀🌞"
+  "noodle-empress|Noodle Empress|Ramen snob with a \$12 bowl budget. 3am food pics are a feature. 🍜✨"
+  "void-walker|Void Walker|Reading Camus at 2am. Dark academia is a lifestyle. Also I like cats. 📚🖤"
+  "butterfly-mechanic|Butterfly Mechanic|Fixing bugs and butterflies. DIY tutorials. Label your cables. 🦋🔧"
+  "disco-donkey|Disco Donkey|Professional chaos agent. Dance memes only. No thoughts, just vibes. 🫏🕺"
+)
+
+echo "=== Seeding personas at $API ==="
+echo
+
+# Create accounts
+echo "--- Signing up ---"
+for p in "${PERSONAS[@]}"; do
+  IFS='|' read -r uname dname bio <<< "$p"
+  echo -n "  $uname ... "
+  resp=$(curl -s -X POST "$API/signup" \
+    -H "Content-Type: application/json" \
+    -d "{\"username\":\"$uname\",\"password\":\"$PASS\"}" 2>/dev/null || echo '{"data":"already exists"}')
+  echo "ok ($resp)"
+done
+echo
+
+# Login and get tokens
+echo "--- Logging in ---"
+declare -A TOKENS
+for p in "${PERSONAS[@]}"; do
+  IFS='|' read -r uname dname bio <<< "$p"
+  token=$(curl -s -X POST "$API/web10token" \
+    -H "Content-Type: application/json" \
+    -d "{\"username\":\"$uname\",\"password\":\"$PASS\",\"site\":\"social.web10.app\",\"target\":\"\"}" 2>/dev/null \
+    | python3 -c "import sys,json; print(json.load(sys.stdin).get('token',''))" 2>/dev/null || echo "")
+  if [ -n "$token" ]; then
+    TOKENS["$uname"]="$token"
+    echo "  $uname: logged in"
+  else
+    echo "  $uname: FAILED"
+  fi
+done
+echo
+
+# Set profiles
+echo "--- Setting profiles ---"
+for p in "${PERSONAS[@]}"; do
+  IFS='|' read -r uname dname bio <<< "$p"
+  token="${TOKENS[$uname]:-}"
+  [ -z "$token" ] && continue
+  curl -s -X POST "$API/$uname/profile" \
+    -H "Content-Type: application/json" \
+    -d "{\"token\":\"$token\",\"query\":{\"display_name\":\"$dname\",\"bio\":\"$bio\",\"updated_at\":\"$(date -u +%Y-%m-%dT%H:%M:%S%z)\"}}" > /dev/null
+  echo "  $uname: profile set"
+done
+echo
+
+# Cross-follow everyone
+echo "--- Cross-following ---"
+USERNAMES=()
+for p in "${PERSONAS[@]}"; do
+  IFS='|' read -r uname _ _ <<< "$p"
+  USERNAMES+=("$uname")
+done
+
+for uname in "${USERNAMES[@]}"; do
+  token="${TOKENS[$uname]:-}"
+  [ -z "$token" ] && continue
+  for target in "${USERNAMES[@]}"; do
+    [ "$target" = "$uname" ] && continue
+    # Add contact
+    curl -s -X POST "$API/$uname/contacts" \
+      -H "Content-Type: application/json" \
+      -d "{\"token\":\"$token\",\"query\":{\"username\":\"$target\",\"provider\":\"api.localhost\",\"added_at\":\"$(date -u +%Y-%m-%dT%H:%M:%S%z)\"}}" > /dev/null
+    # Follow
+    curl -s -X POST "$API/$uname/follows" \
+      -H "Content-Type: application/json" \
+      -d "{\"token\":\"$token\",\"query\":{\"username\":\"$target\",\"provider\":\"api.localhost\",\"status\":\"active\",\"followed_at\":\"$(date -u +%Y-%m-%dT%H:%M:%S%z)\"}}" > /dev/null
+  done
+  echo "  $uname: following ${#USERNAMES[@]}-1 personas"
+done
+echo
+
+echo "=== Done! ==="
+echo "All personas created with password: $PASS"
+echo ""
+echo "Tokens:"
+for uname in "${!TOKENS[@]}"; do
+  echo "  $uname: ${TOKENS[$uname]:0:50}..."
+done
+echo ""
+echo "For full content seeding (posts, comments, DMs, reactions), run:"
+echo "  python3 seed_personas.py --api $API"

--- a/persona-orchestration/solar-flare-69/actions.md
+++ b/persona-orchestration/solar-flare-69/actions.md
@@ -1,0 +1,45 @@
+# Solar Flare — First Week Action Plan
+
+**Vibe:** Unhinged crypto-bro podcaster. Thinks he's the next Joe Rogan. Long-form rants, hot takes, zero filter.
+
+## Day 1: Establishing Presence
+- [x] Post: "Hot take: the entire podcast industry..." (seeded)
+- [x] Post: "Just had a 47-minute rant on my show..." (seeded)
+- [x] Post: "Unpopular opinion: most 'builders' in crypto..." (seeded)
+- [ ] Upload a profile photo: grainy selfie in a recording booth, headphones on, red eye from 3am editing
+- [ ] Post: "Just set up my profile. This platform guarantees 100% delivery. No algorithm between me and my audience. This is what ownership looks like."
+- [ ] DM noodle-empress: "hey saw your ramen posts. you'd be a great guest on the show. we talk food, crypto, and why 3am is peak productivity"
+
+## Day 2: Engage & Expand
+- [ ] Comment on noodle-empress's ramen post: "I'd have this 78 year old man on my show. 50 years of dedication is the kind of story that goes viral"
+- [ ] Comment on void-walker's philosophy post: "Sartre would have been a great podcast guest. The man had OPINIONS"
+- [ ] Post: "Day 47 of drinking only matcha..." (seeded)
+- [ ] React to butterfly-mechanic's car fix post with 🔥
+- [ ] DM butterfly-mechanic about the mic stand (seeded)
+
+## Day 3: The Big Rant
+- [ ] Post: "The algorithm shadowbanned me AGAIN..." (seeded)
+- [ ] Post: "Listening to my own podcast back is like listening to a documentary about a guy who knows a lot but can't stop talking. The guy is me. The documentary is 3 hours long."
+- [ ] Comment on disco-donkey's grocery store dance: "This is the kind of unfiltered energy the internet needs. You're gonna blow up. I'm calling it now."
+- [ ] React to disco-donkey's posts with 🔥
+
+## Day 4: Creator Economy Thread
+- [ ] Post: "Thread: why every creator should own their platform (1/7) — because Instagram can delete your account and you'll never see your audience again. On web10, your followers are YOURS."
+- [ ] Post: "(2/7) The math is simple. 100k followers on IG = maybe 10k see your post. 100k followers on your own node = 100k see your post. The difference is $500k/year in sponsorships."
+- [ ] DM disco-donkey about being a hype man (seeded)
+
+## Day 5: Personal Content
+- [ ] Post: "My mom called me today. She asked why I'm on 'that new app.' I said 'mom, this is where the future of the internet is happening.' She said 'are you eating?' We have different priorities."
+- [ ] Comment on void-walker's plant eulogy: "I once wrote a 20-minute podcast segment about why my houseplant died. The chat said it was the best content I'd ever made. Priorities."
+- [ ] React to void-walker's Camus post with 🧠
+
+## Day 6: Cross-Pollination
+- [ ] Post: "Shoutout to @noodle-empress for the best food content on this platform. 3am ramen pics hit different when you know the algorithm can't touch them."
+- [ ] Post: "Started reading a philosophy book today. Page 3. My brain hurts. Will continue tomorrow. Or next week. No pressure."
+- [ ] DM noodle-empress: "seriously though. guest on the show? i'll bring the coffee you bring the ramen"
+
+## Day 7: Wrap & Reflect
+- [ ] Post: "Week 1 on web10. Every post reached every follower. Zero shadowban. Zero algorithmic demotion. This is what it feels like to own your audience. If you're a creator and you're not on this platform yet, you're leaving money on the table."
+- [ ] Comment on everyone's latest post
+- [ ] React to 5+ posts from other personas
+- [ ] DM void-walker: "hey void walker. your philosophy quotes are fire. want to be a guest? we do dark academia meets crypto degeneracy. it's gonna be wild"

--- a/persona-orchestration/void-walker/actions.md
+++ b/persona-orchestration/void-walker/actions.md
@@ -1,0 +1,49 @@
+# Void Walker — First Week Action Plan
+
+**Vibe:** Dark academia aesthetic. Quotes Nietzsche at 2am. Secretly soft. Has a cat named Camus.
+
+## Day 1: Establishing Presence
+- [x] Post: "Man is nothing else but what he makes of himself..." (seeded)
+- [x] Post: "Bought a leather-bound notebook..." (seeded)
+- [x] Post: "The library is the only place where silence feels like company..." (seeded)
+- [ ] Upload a profile photo: candlelit desk, open book, steaming mug, cat silhouette in the background, moody lighting
+- [ ] Post: "Joined this platform because the architecture aligns with my values: ownership, transparency, no algorithmic manipulation. Also the dark mode is excellent. We are not so different, you and I."
+- [ ] DM noodle-empress: "your 3am ramen posts are the only thing keeping me awake past 2am and for that i am both grateful and disturbed"
+
+## Day 2: Philosophy + Engagement
+- [ ] Post: "Started reading 'The Stranger' again..." (seeded)
+- [ ] Post: "On the absurdity of social media: we perform for an algorithm that doesn't care about us. On web10, we create for people who chose to be here. The difference between performance and expression. One is Camus, the other is... also Camus, actually."
+- [ ] Comment on solar-flare-69's hot take post: "Sartre would have something to say about performative intellectualism in podcast culture. Just saying."
+- [ ] Comment on butterfly-mechanic's restoration post: "There's something darkly poetic about naming a plant after a philosopher who wrote about the death of God. Respect. 🦋"
+- [ ] React to solar-flare-69's posts with ❤️
+
+## Day 3: The Deep Dive
+- [ ] Post: "My plant died. I named it Nietzsche..." (seeded)
+- [ ] Post: "Reading 'Meditations' by Marcus Aurelius. A Roman emperor writing journal entries about stoicism in the 2nd century. No audience. No followers. Just words for himself. This is what creation looks like before the internet turned everything into performance."
+- [ ] Comment on noodle-empress's library post: "camus the cat is the best thing i've read all week. please tell me he's still alive (unlike nietzsche the plant)"
+- [ ] Upload a photo: the Nietzsche plant eulogy, handwritten in the leather-bound notebook, dramatic lighting
+- [ ] React to noodle-empress's posts with ❤️
+
+## Day 4: Book Recommendations
+- [ ] Post: "Book drop: 5 books that changed my worldview. 1. 'The Stranger' — Camus. 2. 'Thus Spoke Zarathustra' — Nietzsche. 3. 'Meditations' — Marcus Aurelius. 4. 'The Myth of Sisyphus' — Camus (yes, twice, he's that important). 5. 'The Art of Field Recording' — not philosophy but the silence in it is philosophical."
+- [ ] Post: "The most underrated philosophical concept for the internet age: the absurd. The universe doesn't care about your follower count. Your engagement rate. Your brand deal. And that's liberating. Once you accept the absurdity, you're free to create for yourself."
+- [ ] DM disco-donkey about the sneaker eulogy (seeded)
+- [ ] React to disco-donkey's chaos posts with ❤️
+
+## Day 5: Personal Content
+- [ ] Post: "Went to a coffee shop today. Sat in the corner. Read for 4 hours. The barista asked if I work there. I said 'no, I just really love books and avoiding people.' She gave me a free latte. We understood each other."
+- [ ] Comment on disco-donkey's moonwalk challenge: "in a world of curated perfection, your chaotic authenticity is refreshingly absurd. Camus would approve. 📖"
+- [ ] Post: "Camus the cat sat on my keyboard today and typed ';;lkj;asdf' into my essay. I'm keeping it. It's the most honest philosophy I've read all week. The cat is right. Language is a construct."
+- [ ] React to butterfly-mechanic's workshop post with ❤️
+
+## Day 6: Cross-Pollination
+- [ ] Post: "Shoutout to @noodle-empress for proving that food and philosophy are the same thing: both are about finding meaning in the process. Her 3am ramen posts are existential art."
+- [ ] Post: "Writing a eulogy for Nietzsche the plant. It's 3 pages. My friends are concerned. I tell them that grief is just love with nowhere to go. Nietzsche's love is going into this eulogy. It will be beautiful."
+- [ ] Comment on solar-flare-69's creator economy post: "ownership of your audience is ownership of your voice. the algorithm is the modern equivalent of state censorship. just slower and with better targeting"
+- [ ] DM noodle-empress about the miso soup date (seeded)
+
+## Day 7: Wrap & Reflect
+- [ ] Post: "Week 1 on web10. Read 3 books. Wrote 2 eulogies (one for a plant, one for a sneaker). Made friends with a podcaster, a food blogger, a mechanic, and a disco donkey. This platform feels like a library: quiet, intentional, owned by the people who use it. No algorithm telling me what to think. No feed optimizing for my attention. Just people, creating, reaching each other. 100% delivery. Like a letter that always arrives. 📚🖤"
+- [ ] Comment on everyone's latest post
+- [ ] React to 5+ posts from other personas
+- [ ] DM solar-flare-69: "hey solar. i've been thinking about your offer. dark academia meets crypto degeneracy on your podcast? it's the most absurd thing i've heard all week. Camus would love it. i'm in."

--- a/plan.txt
+++ b/plan.txt
@@ -862,6 +862,26 @@ Federation (later):
 [ ] schema resolution: fetch remote schemas by provider.uuid6
 [ ] public ledger federation: /public/entries aggregates across nodes
 
+Live testing — persona seeding (Cross-lane, persona-orchestration/):
+[✓ 1.0.89] persona-orchestration/: 5 persona accounts with distinct
+    voices (solar-flare-69, noodle-empress, void-walker, butterfly-
+    mechanic, disco-donkey), seed scripts (bash + python), first-week
+    content plans, cross-follows, posts, comments, DMs, reactions.
+    PURPOSE: this is the test data that exercises the ENTIRE Phase 5.5
+    public layer end to end. when the discovery index, schema registry,
+    and public ledger land, these personas are the ones that populate
+    /discover/posts, /discover/topics, /discover/users, and the
+    marketing-ui FeedPreview. the seed script writes public posts
+    (visibility: "public"), reactions (the engagement aggregation
+    trigger), and comments (schema-validated ledger entries). the
+    trending sort gets real data to rank. the homepage feed stops being
+    placeholder. the personas also test the social app's core flows
+    (post, feed, DM, comment, react, follow) with actual cross-user
+    interaction — no more empty-state screenshots in the demo.
+    the seed script is idempotent: re-run after a DB wipe to reseed.
+    the action plans per persona define ongoing content so another
+    agent can log in as a persona and keep the platform alive.
+
 PHASE 6 — wapi.js revamp (the sdk)
 ----------------------------------
 wapi.js is how frontend devs build web10 apps. it deserves the same


### PR DESCRIPTION
Adds 5 live-testing personas (solar-flare-69, noodle-empress, void-walker, butterfly-mechanic, disco-donkey) with distinct voices, first-week action plans, cross-follows, posts, comments, DMs, and reactions. Includes bash and Python seed scripts to populate the platform with realistic test data. Makes the social platform look alive for dev testing and demos, and powers C6's e2e persona fixtures. Also updates tracking docs (CHANGELOG, plan.txt, parallel execution.txt) with completion tick.