### PR TITLE
I6 complete: immutable server-side metadata (A8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,82 @@
+1.0.92 || 22.07.2026
+I6 complete: `_author`, `_source_node`, `_created_at` immutable on update,
+exposed on read, forged values rejected. `to_db()` strips client-supplied
+metadata and injects server values from token + clock. `u_t()` silently drops
+any `$set`/`$unset`/`$inc` targeting immutable fields. `to_gui()` ensures
+metadata fields present on every returned record. `create()` endpoint passes
+token's username/provider to `to_db()`. Cross-node: remote token's provider
+becomes `_source_node`, remote username becomes `_author`. +14 I6 tests
+(309 total green).
+1.0.91 || 22.07.2026
+Fix DMs: single `dms` service with sender/recipient fields (no per-conversation
+service). legacy adapter auto-migrates message-inbox/outbox on first read.
+Fix posts: legacy adapter migrates html/media/time → text/media_refs/created_at
+in-place so text-only posts render in the profile grid.
+Added security invariant I6: server-side record metadata (_author, _source_node,
+_created_at) injected by API on create, immutable on update. audited cross-node
+federation flow: no cross-node token delegation, no data sync, no provenance
+metadata today. 220 tests green, tsc clean.
+1.0.90 || 21.07.2026
+Homepage: moved the social feed preview section above the hero so the feed is front and center — first thing you see after the navbar. The pitch headline follows immediately after.
+
+1.0.89 || 21.07.2026
+Persona orchestration: 5 live-testing personas (solar-flare-69, noodle-empress,
+void-walker, butterfly-mechanic, disco-donkey) with seed scripts (bash + python),
+first-week action plans, cross-follows, posts, comments, DMs, reactions, and
+inbox fan-out. Makes the social platform look alive for dev testing and demos.
+
+1.0.88 || 21.07.2026
+Fix marketing-ui build: SVG `className` assignment changed to `setAttribute('class', ...)` to avoid TS2540 read-only error on dynamically created SVG elements.
+1.0.86 || 20.07.2026
+Marketing-ui homepage: added a social-media-style tabbed feed preview section
+with placeholder content (For You / Following / Trending tabs, post cards with
+avatars, media placeholders, engagement counts). The section sits between the
+hero and the reach-gap proof, giving the landing page a sense of life and
+activity. Avatar UI primitive added to marketing-ui. Placeholder data wired to
+tabs; ready to be replaced with live backend content.
+1.0.87 || 21.07.2026
+D12 follow-up: web10-social vibrancy overhaul. The social flagship was
+muted — flat surfaces, no ambient light, zero interaction energy —
+compared to Kick's vibrant, alive feel. design.md §4 relaxed: glow
+tokens (`--color-glow`, `--color-glow-intense`, `--color-glow-danger`)
+added for the social app (console stays restrained). New animations
+in index.css: shimmer skeleton sweep, heart-burst on like, glow-pulse
+for presence indicators, brand-glow-pulse for ambient energy, float
+for login particles. Custom dark scrollbar. Button gradient brand
+variant with glow-on-hover, `brand_subtle` variant. Badge `brand_glow`
+and `live` (pulsing) variants. Skeleton gradient shimmer replaces
+solid pulse. Layout: sidebar gradient, ambient glow orb, active nav
+glow pill with pulse dot, mobile nav gradient indicator. Feed: card
+hover glow, heart-burst animation on like with danger drop-shadow,
+vibrant brand-tinted tags, origin badges with glow, gradient empty
+state icon, media hover zoom + overlay. Composer: focus glow bar,
+media preview hover scale + ring. Profile: vibrant banner gradient,
+avatar glow ring, gradient avatar fallback, gradient tab indicators,
+media grid hover zoom + overlay. DMs: gradient sent bubbles with
+shadow, presence dots with pulse, conversation list presence indicators.
+Login: animated gradient background, floating ambient orbs. 195 tests
+green, tsc clean, build clean.
+1.0.86 || 20.07.2026
+Add branch naming conventions to AGENTS.md: all new branches must use a
+type prefix (feature/, fix/, refactor/, chore/, test/, docs/) followed by
+a short imperative description, e.g. fix/auth-token-expiry. Existing
+lane-x/ and username/ branches grandfathered.
+1.0.87 || 21.07.2026
+Fix profile name save, photo upload, and restore old contacts/friends.
+Backend: update_records now returns the updated document (find_one_and_update)
+instead of {matchedCount, modifiedCount}, so saveProfile actually persists
+the profile in React state. Media upload: fixed URL path from /media/upload/{user}
+to /{user}/upload, added required filename field, switched to presigned POST
+with confirm step so the media record is created with an _id. Frontend:
+wapi.update now receives the real document back. Profile adapter: readProfile
+falls back to the legacy identity service, maps name→display_name and
+pic→avatar_ref, and writes the adapted record to the new profile service.
+Contacts adapter: readContacts falls back to legacy contact-addresses, maps
+web10→username/provider and date_added→added_at, migrates all records to the
+new contacts service on first read. Follows: added complete data layer
+(readFollows, followUser, unfollowUser, blockUser, deleteFollow, etc.) and
+registered the follows SRO in the adapter. +19 tests (74 data layer tests).
+
 1.0.85 || 20.07.2026
 Remove Netlify integration. Deleted ui/netlify.toml so GitHub pushes no
 longer trigger Netlify builds. Removed web10social.netlify.app from the

--- a/api/app/endpoints/crud.py
+++ b/api/app/endpoints/crud.py
@@ -40,7 +40,11 @@ async def create_records(user: str, service: str, token: Token, b_t: BackgroundT
     if not is_permitted(token, user, service, "create"):
         raise exceptions.CRUD
     check(user)
-    res = db.create(user, service, token.query)
+    # I6: inject server-managed metadata from the authenticated token
+    decoded = decode_token(token.token) if token.token else None
+    author = decoded.username if decoded else None
+    source_node = decoded.provider if decoded else None
+    res = db.create(user, service, token.query, author=author, source_node=source_node)
     b_t.add_task(db.charge, user, "create")
     _emit(user, service, token, "create")
     return res

--- a/api/app/services/documentdb.py
+++ b/api/app/services/documentdb.py
@@ -1,5 +1,6 @@
 import datetime
 import itertools
+import logging
 import re
 import secrets
 
@@ -10,6 +11,11 @@ import app.exceptions as exceptions
 import app.settings as settings
 from app.models.core import dotdict
 from app.services import records as records
+
+log = logging.getLogger(__name__)
+
+# Server-managed metadata fields — the client must never set or forge these.
+IMMUTABLE_METADATA = frozenset(("_author", "_source_node", "_created_at"))
 
 #################################
 ####### CONNECTING TO DB ########
@@ -30,17 +36,29 @@ def to_gui(doc):
     _id = doc["_id"]
     doc = doc["body"]
     doc["_id"] = _id
+    # I6: ensure server-managed metadata is always present on read
+    for field in IMMUTABLE_METADATA:
+        if field not in doc:
+            doc[field] = None
     return doc
 
 
 # transforms user submitted doc for db writing
-def to_db(_doc, service):
+# I6: injects server-managed metadata; strips any client-supplied values
+def to_db(_doc, service, author=None, source_node=None):
     doc = {}
     if "_id" in _doc:
         doc["_id"] = _doc["_id"]
         del _doc["_id"]
     doc["service"] = service
-    doc["body"] = _doc
+    body = {k: v for k, v in _doc.items() if k not in IMMUTABLE_METADATA}
+    # I6: server always wins — inject metadata from token + server clock
+    if author is not None:
+        body["_author"] = author
+    if source_node is not None:
+        body["_source_node"] = source_node
+    body["_created_at"] = datetime.datetime.utcnow()
+    doc["body"] = body
     return doc
 
 
@@ -65,7 +83,7 @@ def q_t(_q, service):
 
 
 # transforms users update for db
-# safe because ops are for values not fields
+# I6: strips any operator targeting immutable metadata fields
 def u_t(_u):
     u = {}
     for op in _u:
@@ -74,7 +92,16 @@ def u_t(_u):
             if "$" in "".join(u[op].keys()):
                 # dont let fancy updates work yet.
                 raise exceptions.DB_NOT_ALLOWED
-            u[op][to_db_field(field)] = _u[op][field]
+            db_field = to_db_field(field)
+            # I6: silently drop updates targeting immutable server-managed fields
+            if field in IMMUTABLE_METADATA:
+                log.warning(
+                    "I6: blocked client update of immutable field '%s' via %s",
+                    field,
+                    op,
+                )
+                continue
+            u[op][db_field] = _u[op][field]
     return u
 
 
@@ -221,7 +248,7 @@ def temp_pass(phone_number, hash):
 ##########################
 
 
-def create(user, service, _data):
+def create(user, service, _data, author=None, source_node=None):
     if star_found([_data]):
         raise exceptions.DSTAR
     # A service's terms record ("services" collection-service) must be unique
@@ -230,9 +257,15 @@ def create(user, service, _data):
     if service == "services" and isinstance(_data, dict) and _data.get("service"):
         if db[f"{user}"].find_one({"service": "services", "body.service": _data["service"]}) is not None:
             raise exceptions.DUPLICATE_SERVICE
-    data = to_db(_data, service)
+    # I6: strip client-supplied immutable metadata before passing to to_db()
+    _data = {k: v for k, v in _data.items() if k not in IMMUTABLE_METADATA}
+    data = to_db(_data, service, author=author, source_node=source_node)
     result = db[f"{user}"].insert_one(data)
     _data["_id"] = str(result.inserted_id)
+    # I6: return the server-injected metadata
+    _data["_author"] = author
+    _data["_source_node"] = source_node
+    _data["_created_at"] = data["body"]["_created_at"]
     return _data
 
 
@@ -581,6 +614,9 @@ def register_app(info):
 
 
 def create_media_record(username: str, record: dict) -> dict:
+    # I6: strip client-supplied immutable metadata
+    record = {k: v for k, v in record.items() if k not in IMMUTABLE_METADATA}
+    record["_created_at"] = datetime.datetime.utcnow()
     doc = {"service": "media", "body": record}
     result = db[username].insert_one(doc)
     record["_id"] = str(result.inserted_id)

--- a/api/tests/test_documentdb.py
+++ b/api/tests/test_documentdb.py
@@ -11,34 +11,83 @@ class TestToGui:
     def test_extract_body_and_id(self):
         doc = {"_id": "abc123", "service": "posts", "body": {"title": "hello", "count": 1}}
         result = documentdb.to_gui(doc)
-        assert result == {"_id": "abc123", "title": "hello", "count": 1}
+        assert result["_id"] == "abc123"
+        assert result["title"] == "hello"
+        assert result["count"] == 1
+        # I6: metadata fields present (None for legacy docs without them)
+        assert result["_author"] is None
+        assert result["_source_node"] is None
+        assert result["_created_at"] is None
 
     def test_empty_body(self):
         doc = {"_id": "x", "service": "s", "body": {}}
         result = documentdb.to_gui(doc)
-        assert result == {"_id": "x"}
+        assert result["_id"] == "x"
+        assert result["_author"] is None
+        assert result["_source_node"] is None
+        assert result["_created_at"] is None
 
     def test_nested_body(self):
         doc = {"_id": "1", "service": "s", "body": {"a": {"b": 2}}}
         result = documentdb.to_gui(doc)
-        assert result == {"_id": "1", "a": {"b": 2}}
+        assert result["_id"] == "1"
+        assert result["a"] == {"b": 2}
+        assert result["_author"] is None
+
+    def test_metadata_passthrough(self):
+        """I6: metadata fields stored in body are passed through to_gui."""
+        doc = {
+            "_id": "abc",
+            "service": "posts",
+            "body": {"title": "hi", "_author": "alice", "_source_node": "node1", "_created_at": "2026-01-01"},
+        }
+        result = documentdb.to_gui(doc)
+        assert result["_author"] == "alice"
+        assert result["_source_node"] == "node1"
+        assert result["_created_at"] == "2026-01-01"
 
 
 class TestToDb:
     def test_basic_wrap(self):
         result = documentdb.to_db({"title": "hi"}, "posts")
-        assert result == {"service": "posts", "body": {"title": "hi"}}
+        assert result["service"] == "posts"
+        assert result["body"]["title"] == "hi"
+        # I6: _created_at always injected
+        assert "_created_at" in result["body"]
 
     def test_preserves_id(self):
         result = documentdb.to_db({"_id": "oid", "name": "x"}, "svc")
         assert result["_id"] == "oid"
-        assert result["body"] == {"name": "x"}
+        assert result["body"]["name"] == "x"
         assert "_id" not in result["body"]
+        assert "_created_at" in result["body"]
 
     def test_no_id(self):
         result = documentdb.to_db({"k": "v"}, "svc")
         assert "_id" not in result
-        assert result == {"service": "svc", "body": {"k": "v"}}
+        assert result["service"] == "svc"
+        assert result["body"]["k"] == "v"
+        assert "_created_at" in result["body"]
+
+    def test_injects_author_and_source_node(self):
+        """I6: to_db injects author and source_node when provided."""
+        result = documentdb.to_db({"title": "hi"}, "posts", author="alice", source_node="node1")
+        assert result["body"]["_author"] == "alice"
+        assert result["body"]["_source_node"] == "node1"
+        assert "_created_at" in result["body"]
+
+    def test_strips_client_metadata(self):
+        """I6: client-supplied immutable metadata is stripped."""
+        result = documentdb.to_db(
+            {"title": "hi", "_author": "hacker", "_source_node": "fake", "_created_at": "2000-01-01"},
+            "posts",
+            author="alice",
+            source_node="node1",
+        )
+        assert result["body"]["_author"] == "alice"
+        assert result["body"]["_source_node"] == "node1"
+        # _created_at should be server time, not "2000-01-01"
+        assert result["body"]["_created_at"] != "2000-01-01"
 
 
 class TestToDbField:
@@ -96,6 +145,39 @@ class TestUTransform:
     def test_single_dollar_field_allowed(self):
         result = documentdb.u_t({"$set": {"$only": 1}})
         assert result == {"$set": {"body.$only": 1}}
+
+    def test_i6_blocks_author_via_set(self):
+        """I6: u_t silently drops $set targeting _author."""
+        u = documentdb.u_t({"$set": {"_author": "hacker", "title": "ok"}})
+        assert "body._author" not in u.get("$set", {})
+        assert u["$set"]["body.title"] == "ok"
+
+    def test_i6_blocks_source_node_via_set(self):
+        """I6: u_t silently drops $set targeting _source_node."""
+        u = documentdb.u_t({"$set": {"_source_node": "fake"}})
+        assert "body._source_node" not in u.get("$set", {})
+
+    def test_i6_blocks_created_at_via_set(self):
+        """I6: u_t silently drops $set targeting _created_at."""
+        u = documentdb.u_t({"$set": {"_created_at": "2000-01-01"}})
+        assert "body._created_at" not in u.get("$set", {})
+
+    def test_i6_blocks_author_via_unset(self):
+        """I6: u_t silently drops $unset targeting _author."""
+        u = documentdb.u_t({"$unset": {"_author": ""}})
+        assert "body._author" not in u.get("$unset", {})
+
+    def test_i6_blocks_author_via_inc(self):
+        """I6: u_t silently drops $inc targeting immutable fields."""
+        u = documentdb.u_t({"$inc": {"_created_at": 1}})
+        assert "body._created_at" not in u.get("$inc", {})
+
+    def test_i6_other_fields_pass_through(self):
+        """I6: non-immutable fields still pass through u_t normally."""
+        u = documentdb.u_t({"$set": {"_author": "hacker", "title": "real", "count": 5}})
+        assert "body._author" not in u.get("$set", {})
+        assert u["$set"]["body.title"] == "real"
+        assert u["$set"]["body.count"] == 5
 
 
 class TestSortTransform:

--- a/api/tests/test_endpoints.py
+++ b/api/tests/test_endpoints.py
@@ -968,3 +968,259 @@ class TestNodeConfig:
         with patch("app.services.config.get_config", return_value={"brand_text": "web10"}):
             resp = client.post("/am_admin", json={"token": _owner_token("jacoby149")})
         assert resp.json() == {"admin": True}
+
+
+# ---------------------------------------------------------------------------
+# 11. I6 — Immutable server-side metadata
+# ---------------------------------------------------------------------------
+
+
+class TestI6MetadataInjection:
+    """I6: _author, _source_node, _created_at are injected by the server on create,
+    immutable on update, and exposed on read. The client cannot forge them."""
+
+    def test_create_injects_author_from_token(self, client):
+        """Server injects _author from the token's username, not from client data."""
+        mock_result = MagicMock()
+        mock_result.inserted_id = "mock_oid"
+        with (
+            patch("app.services.documentdb.get_star", return_value=MOCK_STAR),
+            patch("app.services.documentdb.get_term_record", return_value=MOCK_TERM),
+            patch("app.services.documentdb.get_collection_size", return_value=1),
+            patch("app.services.documentdb.charge"),
+            patch("app.services.documentdb.emit_event"),
+            patch.object(db_module.db, "__getitem__") as mock_col,
+        ):
+            mock_col.return_value.insert_one.return_value = mock_result
+            # Client tries to forge _author
+            resp = client.post(
+                "/alice/posts",
+                json={
+                    "token": _owner_token("alice"),
+                    "query": {"title": "hi", "_author": "someone-else"},
+                },
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        # Server value wins: token username, not client's forged value
+        assert body.get("_author") == "alice"
+        assert body.get("_author") != "someone-else"
+
+    def test_create_injects_source_node_from_token(self, client):
+        """Server injects _source_node from the token's provider."""
+        mock_result = MagicMock()
+        mock_result.inserted_id = "mock_oid"
+        with (
+            patch("app.services.documentdb.get_star", return_value=MOCK_STAR),
+            patch("app.services.documentdb.get_term_record", return_value=MOCK_TERM),
+            patch("app.services.documentdb.get_collection_size", return_value=1),
+            patch("app.services.documentdb.charge"),
+            patch("app.services.documentdb.emit_event"),
+            patch.object(db_module.db, "__getitem__") as mock_col,
+        ):
+            mock_col.return_value.insert_one.return_value = mock_result
+            resp = client.post(
+                "/alice/posts",
+                json={
+                    "token": _owner_token("alice"),
+                    "query": {"title": "hi", "_source_node": "fake-node"},
+                },
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body.get("_source_node") == settings.PROVIDER
+        assert body.get("_source_node") != "fake-node"
+
+    def test_create_injects_created_at(self, client):
+        """Server injects _created_at (server time), ignoring client value."""
+        mock_result = MagicMock()
+        mock_result.inserted_id = "mock_oid"
+        with (
+            patch("app.services.documentdb.get_star", return_value=MOCK_STAR),
+            patch("app.services.documentdb.get_term_record", return_value=MOCK_TERM),
+            patch("app.services.documentdb.get_collection_size", return_value=1),
+            patch("app.services.documentdb.charge"),
+            patch("app.services.documentdb.emit_event"),
+            patch.object(db_module.db, "__getitem__") as mock_col,
+        ):
+            mock_col.return_value.insert_one.return_value = mock_result
+            resp = client.post(
+                "/alice/posts",
+                json={
+                    "token": _owner_token("alice"),
+                    "query": {"title": "hi", "_created_at": "2000-01-01T00:00:00"},
+                },
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "_created_at" in body
+        assert body["_created_at"] != "2000-01-01T00:00:00"
+
+    def test_update_cannot_change_author(self, client):
+        """I6: PUT/PATCH with $set _author is silently dropped."""
+        with (
+            patch("app.services.documentdb.get_star", return_value=MOCK_STAR),
+            patch("app.services.documentdb.get_term_record", return_value=MOCK_TERM),
+            patch("app.services.documentdb.get_collection_size", return_value=1),
+            patch("app.services.documentdb.charge"),
+            patch("app.services.documentdb.emit_event"),
+            patch("app.services.documentdb.star_selected", return_value=False),
+            patch.object(db_module.db, "__getitem__") as mock_col,
+        ):
+            mock_col.return_value.find_one_and_update.return_value = {
+                "_id": "1",
+                "service": "posts",
+                "body": {"title": "new", "_author": "alice", "_source_node": settings.PROVIDER},
+            }
+            resp = client.put(
+                "/alice/posts",
+                json={
+                    "token": _owner_token("alice"),
+                    "query": {"_id": "1"},
+                    "update": {"$set": {"title": "new", "_author": "hacker"}},
+                },
+            )
+        assert resp.status_code == 200
+        # The update returned from the DB still has the original author
+        body = resp.json()
+        assert body.get("_author") == "alice"
+        assert body.get("_author") != "hacker"
+
+    def test_update_cannot_change_source_node(self, client):
+        """I6: update cannot change _source_node."""
+        with (
+            patch("app.services.documentdb.get_star", return_value=MOCK_STAR),
+            patch("app.services.documentdb.get_term_record", return_value=MOCK_TERM),
+            patch("app.services.documentdb.get_collection_size", return_value=1),
+            patch("app.services.documentdb.charge"),
+            patch("app.services.documentdb.emit_event"),
+            patch("app.services.documentdb.star_selected", return_value=False),
+            patch.object(db_module.db, "__getitem__") as mock_col,
+        ):
+            mock_col.return_value.find_one_and_update.return_value = {
+                "_id": "1",
+                "service": "posts",
+                "body": {"title": "new", "_source_node": settings.PROVIDER},
+            }
+            resp = client.put(
+                "/alice/posts",
+                json={
+                    "token": _owner_token("alice"),
+                    "query": {"_id": "1"},
+                    "update": {"$set": {"title": "new", "_source_node": "fake"}},
+                },
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body.get("_source_node") == settings.PROVIDER
+
+    def test_update_cannot_change_created_at(self, client):
+        """I6: update cannot change _created_at."""
+        with (
+            patch("app.services.documentdb.get_star", return_value=MOCK_STAR),
+            patch("app.services.documentdb.get_term_record", return_value=MOCK_TERM),
+            patch("app.services.documentdb.get_collection_size", return_value=1),
+            patch("app.services.documentdb.charge"),
+            patch("app.services.documentdb.emit_event"),
+            patch("app.services.documentdb.star_selected", return_value=False),
+            patch.object(db_module.db, "__getitem__") as mock_col,
+        ):
+            mock_col.return_value.find_one_and_update.return_value = {
+                "_id": "1",
+                "service": "posts",
+                "body": {"title": "new"},
+            }
+            resp = client.put(
+                "/alice/posts",
+                json={
+                    "token": _owner_token("alice"),
+                    "query": {"_id": "1"},
+                    "update": {"$set": {"title": "new", "_created_at": "2000-01-01"}},
+                },
+            )
+        assert resp.status_code == 200
+
+    def test_read_returns_metadata_fields(self, client):
+        """I6: read returns _author, _source_node, _created_at on every record."""
+        with (
+            patch("app.services.documentdb.get_star", return_value=MOCK_STAR),
+            patch("app.services.documentdb.get_term_record", return_value=MOCK_TERM),
+            patch("app.services.documentdb.get_collection_size", return_value=1),
+            patch("app.services.documentdb.charge"),
+            patch("app.services.documentdb.emit_event"),
+            patch(
+                "app.services.documentdb.read",
+                return_value=[
+                    {
+                        "_id": "1",
+                        "title": "hello",
+                        "_author": "alice",
+                        "_source_node": settings.PROVIDER,
+                        "_created_at": "2026-01-01T00:00:00",
+                    }
+                ],
+            ),
+        ):
+            resp = client.patch(
+                "/alice/posts",
+                json={"token": _owner_token("alice"), "query": {}},
+            )
+        assert resp.status_code == 200
+        records = resp.json()
+        assert len(records) == 1
+        rec = records[0]
+        assert "_author" in rec
+        assert "_source_node" in rec
+        assert "_created_at" in rec
+
+    def test_cross_node_source_node(self, client):
+        """I6: a record created via a remote provider token has the correct _source_node
+        (the remote provider, not our PROVIDER)."""
+        mock_result = MagicMock()
+        mock_result.inserted_id = "mock_oid"
+        remote_provider = "remote.web10.app"
+        remote_token = _token(
+            {
+                "username": "remote-user",
+                "site": "auth.remote.web10.app",
+                "target": settings.PROVIDER,
+                "provider": remote_provider,
+                "expires": _future(),
+            }
+        )
+        with (
+            patch("app.services.documentdb.get_star", return_value=MOCK_STAR),
+            patch("app.services.documentdb.get_term_record") as m_term,
+            patch("app.services.documentdb.get_collection_size", return_value=1),
+            patch("app.services.documentdb.charge"),
+            patch("app.services.documentdb.emit_event"),
+            patch("app.services.auth.certify_with_remote_provider", return_value=True),
+            patch.object(db_module.db, "__getitem__") as mock_col,
+        ):
+            m_term.return_value = {
+                "service": "posts",
+                "whitelist": [
+                    {
+                        "username": "remote-user",
+                        "provider": remote_provider,
+                        "create": True,
+                    }
+                ],
+                "blacklist": [],
+                "cross_origins": ["auth.remote.web10.app"],
+            }
+            mock_col.return_value.insert_one.return_value = mock_result
+            resp = client.post(
+                "/alice/posts",
+                json={
+                    "token": remote_token,
+                    "query": {"title": "remote-post"},
+                },
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        # The remote user's username is the author
+        assert body.get("_author") == "remote-user"
+        # The source node is the REMOTE provider, not our PROVIDER
+        assert body.get("_source_node") == remote_provider
+        assert body.get("_source_node") != settings.PROVIDER

--- a/parallel execution.txt
+++ b/parallel execution.txt
@@ -120,6 +120,22 @@ LANE A — api / backend        (owns: api/**, docker-compose, settings)
       the real data and surfaced like the original web10 (feeds the
       D16 app-store stats); and the honest report of any shape drift.
       unblocks B6 (real login to test against) and D16 (real apps).
+    [✓ 1.0.92] A8. P1 server-side record metadata — invariant I6: every record
+       gets `_author` (token's username), `_source_node` (the provider
+       that minted the token), and `_created_at` (server time at the
+       destination node) injected by the API on create, immutable on
+       update. the client cannot set or forge these fields. on cross-node
+       replication, the receiving node stamps its own `_created_at`
+       (arrival time) while preserving the original `_author` and
+       `_source_node`. this stops sender impersonation on DMs, posts,
+       comments, reactions. implementation: in documentdb.py `to_db()`,
+       inject `_author`, `_source_node`, `_created_at` from the
+       authenticated token + server clock. add to `q_t()` / `u_t()` to
+       block client from overwriting via update. expose in `to_gui()` on
+       read. audit the whole cross-node path (certify, token handoff,
+       remote CRUD) to verify it works correctly with multi-node traffic.
+       gate: permission-matrix tests must cover forged `_author`
+       rejection. unblocks: safe DMs, safe feed attribution, audit trail.
 
 LANE B — ui / frontend        (owns: auth2->ui/**, auth/**)
   [✓ 1.0.12-1.0.14] B1. P0 js: auth2 -> vite + bun + typescript
@@ -314,6 +330,12 @@ LANE D — docs / apps / mobile (owns: mobile/**, marketing/, examples/
       path alias (tsc -b had ~90 pre-existing errors) and the
       alternative.png-isn't-the-keys-mark bug (decisions.md D24,
       converged with D13).
+  [✓ 1.0.87] D12 vibrancy overhaul (follow-up): the social flagship was
+      muted — flat surfaces, no ambient light, zero interaction energy.
+      design.md §4 relaxed for social: glow tokens, shimmer skeletons,
+      heart-burst on like, card hover glow, gradient buttons, presence
+      dots, vibrant banner, media hover zoom, animated login. 195 tests
+      green, tsc clean, build clean.
   [✓ 1.0.63] D13. rebuild marketing-ui on the design system. bulma OUT
       entirely (D22), tailwind v4 + design.md §13 tokens, dark
       cinematic landing (lockup hero, tested reach-gap proof section —
@@ -580,9 +602,30 @@ points at an empty db. baseline fixes outrank polish, in this order:
        serves per-env origins; only social still needs D14. operator
        prerequisites: docker group for the ssh user, rotate the CF
        token exposed in the world-readable Caddyfile.
-  ws5: C6 e2e deep sweep + bug hunt (lane C — e2e/** only; local
-       stack, no deploy gate). signup-as-a-test + persona seed
-       fixtures; the honest bug list is the deliverable.
+ws5: C6 e2e deep sweep + bug hunt (lane C — e2e/** only; local
+        stack, no deploy gate). signup-as-a-test + persona seed
+        fixtures; the honest bug list is the deliverable.
+   ws-new: [✓ 1.0.86] D-homepage-feed. Social-media-style tabbed feed
+        preview on the marketing-ui homepage. Placeholder content with
+        For You / Following / Trending tabs, post cards with avatars,
+        media placeholders, engagement counts. Sits between hero and
+        reach-gap section. Ready for live backend content.
+[ ] A5.5. DISCOVERY API — the public layer (Lane A, api/**):
+         discovery index (web10.discovery_posts, write-protected,
+         background task), schema registry (web10.schemas, CRUD with
+         author enforcement, provider.uuid6 IDs), public ledger
+         (web10.public, validated entries), discovery endpoints
+         (/discover/posts, /users, /search, /topics, /post/{user}/{service}/{id}),
+         engagement aggregation (cached counts on index, schema-agnostic).
+         See PHASE 5.5 in plan.txt and docs/discovery.md.
+    [ ] D5.5. SOCIAL APP PUBLIC LAYER — split posts into public_posts /
+         private_posts, default terms on signup, register default schemas,
+         wire reactions to /public/entries, wire feed to /discover/posts.
+         See PHASE 5.5 in plan.txt.
+    [✓ 1.0.89] persona-orchestration/ — 5 live-testing personas with seed scripts,
+         first-week content plans, cross-follows, posts, comments, DMs, and
+         reactions. powers C6's e2e persona fixtures and makes the platform
+         look alive for dev testing + demos.
 
   merge-order notes: B5/D12/D13 don't gate each other; merge each as
   it passes design.md §12. D13 owns the cross-app asset generation

--- a/plan.txt
+++ b/plan.txt
@@ -458,6 +458,17 @@ the three items below are PARALLEL — disjoint directories:
     and the legacy Crm/Mail/Bio vitest excludes (files no longer
     exist). 193 tests green, tsc+build clean. See decisions.md D24 for
     the alternative.png brand-asset correction (shared with D13).
+[✓ 1.0.87] web10-social vibrancy overhaul (lane D, D12 follow-up):
+    the social flagship was muted — flat surfaces, no ambient light,
+    zero interaction energy — compared to Kick's vibrant, alive feel.
+    design.md §4 relaxed for social: glow tokens added, new animations
+    (shimmer, heart-burst, glow-pulse, float), custom scrollbar,
+    gradient brand buttons with glow-on-hover, badge glow/live variants,
+    shimmer skeletons, sidebar gradient + active nav glow pill, card
+    hover glow, heart-burst on like, vibrant tags, gradient sent DM
+    bubbles, presence dots, vibrant profile banner, media hover zoom,
+    animated login background with floating orbs. 195 tests green,
+    tsc clean, build clean.
 [✓ 1.0.63] rebuild marketing-ui on the design system (lane D, item D13):
     bulma OUT entirely (already rejected in D22), tailwind v4 +
     design.md tokens, dark cinematic landing (lockup hero, reach-gap
@@ -787,6 +798,89 @@ swappable per node.
     as a router — same routes and auth, one app on port 6000, no
     separate container. only minio remains in compose for blobs.
 
+
+PHASE 5.5 — the public layer (discovery + schema registry + public ledger)
+--------------------------------------------------------------------------
+D27: posts are plaintext, discoverable by design. E2E encryption is DMs
+only. D28: a schema-registry public ledger gives any app a flexible,
+validated way to publish structured public interactions.
+
+The social app splits posts into separate collections by visibility:
+`public_posts` (anon whitelisted, discovery indexes it) and
+`private_posts` (anon blocked, discovery ignores it). Each collection is
+a separate service with its own terms record, so bulk control is instant
+("make all posts private" = change 1 terms record) and per-app
+permissions work (App A reads public, App B reads both).
+
+API side (Lane A):
+[ ] discovery index: `web10.discovery_posts` system collection,
+    write-protected (background task only). On post create/update in a
+    service where anon is whitelisted, upsert a projection into the
+    index. On post delete or terms change, remove backfill accordingly.
+[ ] schema registry: `web10.schemas` system collection.
+    - POST /schemas/register — any user, returns provider.uuid6 ID
+    - PATCH /schemas/{id} — fetch (anon OK)
+    - PUT /schemas/{id} — update (author only, API enforces ownership)
+    - DELETE /schemas/{id} — delete (author only)
+    - Schemas store JSON Schema for payload validation
+[ ] public ledger: `web10.public` system collection.
+    - POST /public/entries — create (any authenticated user, validates
+      payload against schema)
+    - PATCH /public/entries — query (anon OK, filter by schema_id,
+      target, author)
+    - PUT /public/entries/{id} — update (author only)
+    - DELETE /public/entries/{id} — delete (author only)
+[ ] discovery endpoints (new `discover` router):
+    - PATCH /discover/posts — for you feed (recent/trending sort)
+    - PATCH /discover/users — suggested accounts
+    - PATCH /discover/search — full-text search (Mongo $text index)
+    - PATCH /discover/topics — trending hashtags
+    - PATCH /discover/post/{user}/{service}/{id} — single post lookup
+[ ] engagement aggregation: background task updates cached engagement
+    counts on the discovery index when public ledger entries are created
+    or deleted. Engagement is schema-agnostic (keyed by schema_id).
+[ ] engagement score: formula for trending sort
+    (likes * 1 + comments * 3 + reposts * 5? or just chronological)
+
+Social app side (Lane D):
+[ ] split posts into public_posts / private_posts services
+[ ] create default terms for both services on user signup
+[ ] register default schemas (Reaction, etc.) on first boot
+[ ] cache schemas locally: schema_id → schema definition
+[ ] route createPost by visibility toggle
+[ ] wire reactions to /public/entries endpoint
+[ ] wire feed preview to /discover/posts endpoint (replace placeholder)
+
+Marketing-ui side (Lane D):
+[ ] replace FeedPreview placeholder data with /discover/posts
+[ ] wire tab switching to sort params (recent, trending)
+[ ] wire reaction buttons to /public/entries
+[ ] fetch schema definitions for rendering interaction types
+
+Federation (later):
+[ ] cross-node discovery: /discover/posts aggregates from federated peers
+[ ] schema resolution: fetch remote schemas by provider.uuid6
+[ ] public ledger federation: /public/entries aggregates across nodes
+
+Live testing — persona seeding (Cross-lane, persona-orchestration/):
+[✓ 1.0.89] persona-orchestration/: 5 persona accounts with distinct
+    voices (solar-flare-69, noodle-empress, void-walker, butterfly-
+    mechanic, disco-donkey), seed scripts (bash + python), first-week
+    content plans, cross-follows, posts, comments, DMs, reactions.
+    PURPOSE: this is the test data that exercises the ENTIRE Phase 5.5
+    public layer end to end. when the discovery index, schema registry,
+    and public ledger land, these personas are the ones that populate
+    /discover/posts, /discover/topics, /discover/users, and the
+    marketing-ui FeedPreview. the seed script writes public posts
+    (visibility: "public"), reactions (the engagement aggregation
+    trigger), and comments (schema-validated ledger entries). the
+    trending sort gets real data to rank. the homepage feed stops being
+    placeholder. the personas also test the social app's core flows
+    (post, feed, DM, comment, react, follow) with actual cross-user
+    interaction — no more empty-state screenshots in the demo.
+    the seed script is idempotent: re-run after a DB wipe to reseed.
+    the action plans per persona define ongoing content so another
+    agent can log in as a persona and keep the platform alive.
 
 PHASE 6 — wapi.js revamp (the sdk)
 ----------------------------------
@@ -1530,8 +1624,19 @@ where they get MECHANICALLY enforced so they can't silently rot.
   I3. a request can only ever touch the addressed user's collection.
       cross-collection access is impossible by construction.
   I4. private content is unreadable by the node operator (phase 11).
-  I5. every actor (app, agent, llm) acts under a scoped, expiring,
-      revocable token -- least privilege, always.
+I5. every actor (app, agent, llm) acts under a scoped, expiring,
+       revocable token -- least privilege, always.
+   I6. every record carries server-injected, immutable metadata:
+       `_author` (token's username), `_source_node` (the provider
+       that minted the token — NOT the destination node), and
+       `_created_at` (server time at the node that stored the record).
+       the client cannot set or forge these fields. a cross-node
+       request (foreign provider token certified via remote /certify)
+       still gets stamped with the originating provider in
+       `_source_node` and the local node's time in `_created_at`.
+       this stops sender impersonation on DMs, posts, comments,
+       reactions — any record where the client currently claims
+       to be someone else.
 
 *** CONFIRMED BUG -- federation provider validation (invariant I1) ***
 today providers do NOT validate each other. the chain:


### PR DESCRIPTION
Completes security invariant I6: `_author`, `_source_node`, `_created_at` are now truly immutable.

**Create:** `to_db()` strips any client-supplied metadata and injects server values from the authenticated token (`_author` = username, `_source_node` = provider) + server clock (`_created_at`).

**Update:** `u_t()` silently drops any operator ($set/$unset/$inc) targeting the three immutable fields, with a warning log.

**Read:** `to_gui()` ensures all three metadata fields are present on every returned record (None for legacy docs).

**Cross-node:** a remote token's provider becomes `_source_node` and its username becomes `_author`, preserving provenance.

+14 I6 tests (309 total green), ruff clean.