### PR TITLE
marketing-ui: fixed corner deployment-status widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+1.0.96 || 22.07.2026
+Marketing-ui: fixed corner deployment-status widget. A small pill in the
+bottom-right (green dot + live version, mono) reads the baked /status.json
+(E9) and expands to version / commit / deployed-at with a link to the full
+/status/ page. Renders nothing when the status feed is absent (local dev,
+tests) — no dead control. Token-only styling, keyboard operable (Esc,
+focus-visible ring), covered by 4 vitest cases.
+
 1.0.95 || 22.07.2026
 Ops: Portainer admin password reset after the GitOps re-clone of /opt/web10
 wiped the gitignored .env (creds existed nowhere else). Box secrets moved to

--- a/marketing/marketing-ui/src/App.tsx
+++ b/marketing/marketing-ui/src/App.tsx
@@ -1,5 +1,6 @@
 import { Routes, Route } from 'react-router-dom'
 import Navbar from './components/Navbar'
+import DeployStatus from './components/DeployStatus'
 import Home from './pages/Home'
 import Trending from './pages/Trending'
 import Docs from './pages/Docs'
@@ -18,6 +19,7 @@ function App({ onReportBug }: { onReportBug: () => void }) {
         <Route path="/app-store" element={<AppStore />} />
         <Route path="/import" element={<Exporter />} />
       </Routes>
+      <DeployStatus />
     </>
   )
 }

--- a/marketing/marketing-ui/src/components/DeployStatus.test.tsx
+++ b/marketing/marketing-ui/src/components/DeployStatus.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+const jsonResponse = (body: unknown) => ({
+  ok: true,
+  headers: new Headers({ 'content-type': 'application/json' }),
+  json: () => Promise.resolve(body),
+});
+
+describe('DeployStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  it('renders nothing when the status feed is absent', async () => {
+    vi.mocked(fetch).mockRejectedValue(new Error('404'));
+    const { default: DeployStatus } = await import('@/components/DeployStatus');
+    render(<DeployStatus />);
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith('/status.json', expect.anything()));
+    expect(screen.queryByTestId('deploy-status')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when the SPA fallback answers with HTML', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      headers: new Headers({ 'content-type': 'text/html' }),
+      json: () => Promise.reject(new Error('not json')),
+    } as unknown as Response);
+    const { default: DeployStatus } = await import('@/components/DeployStatus');
+    render(<DeployStatus />);
+    await waitFor(() => expect(fetch).toHaveBeenCalled());
+    expect(screen.queryByTestId('deploy-status')).not.toBeInTheDocument();
+  });
+
+  it('shows the version pill and expands to deployment details', async () => {
+    vi.mocked(fetch).mockResolvedValue(jsonResponse({
+      version: '1.0.95',
+      commit: 'c0f4929',
+      commitTitle: 'ops: reset Portainer creds',
+      deployedAt: '2026-07-22T10:00:00Z',
+    }) as unknown as Response);
+    const { default: DeployStatus } = await import('@/components/DeployStatus');
+    render(<DeployStatus />);
+
+    const toggle = await screen.findByTestId('deploy-status-toggle');
+    expect(toggle).toHaveTextContent('v1.0.95');
+    expect(screen.queryByTestId('deploy-status-panel')).not.toBeInTheDocument();
+
+    fireEvent.click(toggle);
+    const panel = screen.getByTestId('deploy-status-panel');
+    expect(panel).toHaveTextContent('1.0.95');
+    expect(panel).toHaveTextContent('c0f4929');
+    expect(screen.getByRole('link', { name: /full status/i })).toHaveAttribute('href', '/status/');
+
+    fireEvent.click(toggle);
+    expect(screen.queryByTestId('deploy-status-panel')).not.toBeInTheDocument();
+  });
+
+  it('falls back to the commit when the version is unknown', async () => {
+    vi.mocked(fetch).mockResolvedValue(jsonResponse({
+      version: 'unknown',
+      commit: 'c0f4929',
+    }) as unknown as Response);
+    const { default: DeployStatus } = await import('@/components/DeployStatus');
+    render(<DeployStatus />);
+    const toggle = await screen.findByTestId('deploy-status-toggle');
+    expect(toggle).toHaveTextContent('c0f4929');
+  });
+});

--- a/marketing/marketing-ui/src/components/DeployStatus.tsx
+++ b/marketing/marketing-ui/src/components/DeployStatus.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useRef, useState } from 'react'
+import { ExternalLink } from 'lucide-react'
+
+interface DeployInfo {
+  version?: string
+  commit?: string
+  commitTitle?: string
+  deployedAt?: string
+}
+
+const known = (v?: string) => (v && v !== 'unknown' ? v : null)
+
+// Fixed corner widget showing what build is live. Reads the status.json
+// baked by build-status.sh at image build time; renders nothing when the
+// feed is absent (local dev, tests) so there is never a dead control.
+function DeployStatus() {
+  const [info, setInfo] = useState<DeployInfo | null>(null)
+  const [open, setOpen] = useState(false)
+  const rootRef = useRef<HTMLDivElement>(null)
+  const buttonRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    const controller = new AbortController()
+    fetch('/status.json', { signal: controller.signal })
+      .then(res => {
+        if (!res.ok || !res.headers.get('content-type')?.includes('json')) return null
+        return res.json()
+      })
+      .then(data => { if (data) setInfo(data) })
+      .catch(() => {})
+    return () => controller.abort()
+  }, [])
+
+  useEffect(() => {
+    if (!open) return
+    const onPointerDown = (e: PointerEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpen(false)
+    }
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setOpen(false)
+        buttonRef.current?.focus()
+      }
+    }
+    document.addEventListener('pointerdown', onPointerDown)
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown)
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [open])
+
+  if (!info) return null
+
+  const version = known(info.version)
+  const commit = known(info.commit)
+  const label = version ? `v${version}` : commit ?? 'live'
+  const deployed = known(info.deployedAt)
+
+  return (
+    <div ref={rootRef} className="fixed bottom-4 right-4 z-40" data-testid="deploy-status">
+      {open && (
+        <div
+          id="deploy-status-panel"
+          className="absolute bottom-full right-0 mb-2 w-64 rounded-lg border border-border bg-surface p-4 shadow-[0_8px_30px_rgb(0_0_0/0.35)]"
+          data-testid="deploy-status-panel"
+        >
+          <p className="text-xs font-medium uppercase tracking-[0.04em] text-muted-foreground">
+            Deployment
+          </p>
+          <dl className="mt-3 flex flex-col gap-2 text-sm">
+            {version && (
+              <div className="flex items-baseline justify-between gap-4">
+                <dt className="text-muted-foreground">Version</dt>
+                <dd className="font-mono text-[0.8125rem] text-foreground">{version}</dd>
+              </div>
+            )}
+            {commit && (
+              <div className="flex items-baseline justify-between gap-4">
+                <dt className="text-muted-foreground">Commit</dt>
+                <dd className="truncate font-mono text-[0.8125rem] text-foreground" title={known(info.commitTitle) ?? undefined}>
+                  {commit}
+                </dd>
+              </div>
+            )}
+            {deployed && (
+              <div className="flex items-baseline justify-between gap-4">
+                <dt className="text-muted-foreground">Deployed</dt>
+                <dd className="text-right text-[0.8125rem] text-foreground">
+                  {new Date(deployed).toLocaleString(undefined, {
+                    day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit',
+                  })}
+                </dd>
+              </div>
+            )}
+          </dl>
+          <a
+            href="/status/"
+            className="mt-3 inline-flex items-center gap-1 text-[0.8125rem] font-medium text-brand-300 transition-colors duration-150 ease-out hover:text-brand-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-surface"
+          >
+            Full status
+            <ExternalLink className="h-3.5 w-3.5" strokeWidth={1.75} />
+          </a>
+        </div>
+      )}
+      <button
+        ref={buttonRef}
+        type="button"
+        aria-label="Deployment status"
+        aria-expanded={open}
+        aria-controls="deploy-status-panel"
+        onClick={() => setOpen(v => !v)}
+        className="relative flex items-center gap-2 rounded-full border border-border bg-surface/95 px-3 py-1.5 backdrop-blur-sm transition-colors duration-150 ease-out before:absolute before:-inset-2 hover:bg-elevated focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+        data-testid="deploy-status-toggle"
+      >
+        <span className="h-2 w-2 rounded-full bg-success" aria-hidden="true" />
+        <span className="font-mono text-xs text-muted-foreground">{label}</span>
+      </button>
+    </div>
+  )
+}
+
+export default DeployStatus


### PR DESCRIPTION
## What

A small deployment-status indicator fixed in the bottom-right corner of the marketing site, on every page.

- **Collapsed**: a quiet pill — `surface` background, `border` ring, green `success` dot, live version in mono micro type (e.g. `v1.0.95`).
- **Expanded** (click / Enter): a card with Version, Commit (short SHA, commit title on hover), Deployed time, and a **Full status →** link to the existing baked `/status/` page (E9, 1.0.71).
- Data source is the `status.json` that `build-status.sh` already bakes into the image at deploy time — no new backend, no polling; what the pill shows is by construction what is deployed.
- **Renders nothing when the feed is absent** (local dev, tests, or a non-JSON SPA-fallback response) — never a dead control.

## design.md compliance

- Tokens only (`surface`, `border`, `elevated`, `success`, `brand-300/400`, `ring`, mono/micro type steps) — zero hardcoded colors.
- Restrained per §4 (marketing surface): static dot, no pulse, no glow.
- Keyboard operable: focus-visible ring, `aria-expanded`/`aria-controls`/`aria-label`, Esc closes and returns focus, outside-click closes.
- ≥44px effective touch target via expanded hit area (`before:-inset-2`).
- `data-testid` hooks: `deploy-status`, `deploy-status-toggle`, `deploy-status-panel`.

## Verified

- `bun run test:run` — 23/23 pass (4 new DeployStatus cases: hidden on missing feed, hidden on HTML fallback, pill→panel expand/collapse with correct values and `/status/` link, commit fallback when version unknown).
- `bun run build` clean (tsc + vite).
- Screenshotted at 1440 and 375 against the dev server with a real-shaped `status.json` fixture (fixture not committed): pill sits clear of content bottom-right; panel opens above it. Screenshots in-thread.

CHANGELOG 1.0.96. Not a lane item — direct operator request; builds on the merged E9 status page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)