### PR TITLE
E6: SSH-deploy CI/CD framework (replaces Portainer GitOps)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,160 @@
+name: deploy
+
+on:
+  push:
+    branches: [dev, main]
+
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-dev:
+    if: github.ref == 'refs/heads/dev'
+    name: deploy web10-dev
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy to box
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.VM_IP }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          port: 22
+          script_stop: true
+          env: |
+            STACK=web10-dev
+            ENV=dev
+            GITHUB_SHA=${{ github.sha }}
+            GITHUB_REF=${{ github.ref }}
+          script: |
+            echo "=== Deploying $STACK ==="
+            echo "Commit: $GITHUB_SHA"
+            echo "Ref: $GITHUB_REF"
+
+            # Pull latest code
+            cd /opt/web10
+            git fetch origin
+            git checkout dev
+            git reset --hard origin/dev
+
+            # Restore .env symlink if broken (GitOps re-clone can wipe it)
+            if [[ ! -L ubuntu-deployment/.env ]] || [[ ! -f ubuntu-deployment/.env ]]; then
+              ln -sfn ~/web10-ops/.env ubuntu-deployment/.env
+            fi
+
+            # Source env for per-stack vars
+            set -a
+            source ubuntu-deployment/.env
+            set +a
+
+            # Build and deploy the stack
+            cd ubuntu-deployment
+            docker compose -p $STACK \
+              --env-file env.$ENV \
+              -f docker-compose.ecosystem.yml \
+              up -d --build --remove-orphans
+
+            # Wait for containers to stabilize
+            echo "=== Waiting for containers to stabilize ==="
+            for i in $(seq 1 30); do
+              unhealthy=$(docker ps --filter "name=$STACK" --filter "status=unhealthy" --format '{{.Names}}' | wc -l)
+              restarting=$(docker ps --filter "name=$STACK" --filter "status=restarting" --format '{{.Names}}' | wc -l)
+              if [[ "$unhealthy" -eq 0 ]] && [[ "$restarting" -eq 0 ]]; then
+                echo "All containers stable"
+                break
+              fi
+              if [[ "$i" -eq 30 ]]; then
+                echo "FAIL: containers still unstable after 30s"
+                docker ps --filter "name=$STACK" --format 'table {{.Names}}\t{{.Status}}'
+                exit 1
+              fi
+              echo "Waiting... ($i/30)"
+              sleep 2
+            done
+
+            # Show container status
+            echo "=== Container status ==="
+            docker ps --filter "name=$STACK" --format 'table {{.Names}}\t{{.Status}}\t{{.Image}}'
+
+            # Run smoke test
+            echo "=== Running smoke test ==="
+            bash scripts/smoke.sh
+
+  deploy-prod:
+    if: github.ref == 'refs/heads/main'
+    name: deploy web10-prod
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy to box
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.VM_IP }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          port: 22
+          script_stop: true
+          env: |
+            STACK=web10-prod
+            ENV=prod
+            GITHUB_SHA=${{ github.sha }}
+            GITHUB_REF=${{ github.ref }}
+          script: |
+            echo "=== Deploying $STACK ==="
+            echo "Commit: $GITHUB_SHA"
+            echo "Ref: $GITHUB_REF"
+
+            # Pull latest code
+            cd /opt/web10
+            git fetch origin
+            git checkout main
+            git reset --hard origin/main
+
+            # Restore .env symlink if broken
+            if [[ ! -L ubuntu-deployment/.env ]] || [[ ! -f ubuntu-deployment/.env ]]; then
+              ln -sfn ~/web10-ops/.env ubuntu-deployment/.env
+            fi
+
+            # Source env for per-stack vars
+            set -a
+            source ubuntu-deployment/.env
+            set +a
+
+            # Build and deploy the stack
+            cd ubuntu-deployment
+            docker compose -p $STACK \
+              --env-file env.$ENV \
+              -f docker-compose.ecosystem.yml \
+              up -d --build --remove-orphans
+
+            # Wait for containers to stabilize
+            echo "=== Waiting for containers to stabilize ==="
+            for i in $(seq 1 30); do
+              unhealthy=$(docker ps --filter "name=$STACK" --filter "status=unhealthy" --format '{{.Names}}' | wc -l)
+              restarting=$(docker ps --filter "name=$STACK" --filter "status=restarting" --format '{{.Names}}' | wc -l)
+              if [[ "$unhealthy" -eq 0 ]] && [[ "$restarting" -eq 0 ]]; then
+                echo "All containers stable"
+                break
+              fi
+              if [[ "$i" -eq 30 ]]; then
+                echo "FAIL: containers still unstable after 30s"
+                docker ps --filter "name=$STACK" --format 'table {{.Names}}\t{{.Status}}'
+                exit 1
+              fi
+              echo "Waiting... ($i/30)"
+              sleep 2
+            done
+
+            # Show container status
+            echo "=== Container status ==="
+            docker ps --filter "name=$STACK" --format 'table {{.Names}}\t{{.Status}}\t{{.Image}}'
+
+            # Run smoke test
+            echo "=== Running smoke test ==="
+            bash scripts/smoke.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+1.0.96 || 22.07.2026
+E6: SSH-deploy CI/CD framework (replaces Portainer GitOps as deploy trigger).
+New `.github/workflows/deploy.yml`: GitHub Actions SSHes into the box, runs
+`docker compose up --build`, waits for container stability, runs smoke test.
+Push to `dev` → web10-dev; push to `main` → web10-prod. No self-hosted runner
+(ephemeral ubuntu-latest runner, deploy key for SSH). `deploy-stacks.py` now
+supports file-backed stacks (`register` mode — no GitOps polling) and a
+`disable-gitops` command to kill the auto-update loop on existing stacks.
+Portainer remains the management UI (registered post-deploy via API) but no
+longer triggers deploys. Requires GitHub secrets: `DEPLOY_SSH_KEY`, `VM_IP`,
+`SSH_USER`.
+
 1.0.95 || 22.07.2026
 Ops: Portainer admin password reset after the GitOps re-clone of /opt/web10
 wiped the gitignored .env (creds existed nowhere else). Box secrets moved to

--- a/parallel execution.txt
+++ b/parallel execution.txt
@@ -478,29 +478,97 @@ LANE E — infrastructure / deployment (owns: proxmox provisioning,
   [ ] E4. automated provisioning: terraform or ssh-api script +
       ansible for idempotent VM/LXC setup. don't rush — manual is
       fine until E2 works.
-  [ ] E6. push-to-deploy CI/CD (gated on E5/E3 stacks existing):
-      push to dev -> web10-dev redeploys, release on main ->
-      web10-prod redeploys. the repo is PUBLIC, so NO self-hosted
-      github runner (github's own guidance; fork PRs + a runner in
-      the docker group on the box = remote root). two sanctioned
-      designs, in order:
-      (1) NOW, zero new surface: Portainer git-backed stacks with
-          GitOps polling — point each stack at the repo (ref dev /
-          main, compose path ubuntu-deployment/
-          docker-compose.ecosystem.yml), auto-update ~5min. push
-          merges, box pulls. no inbound, no GH secrets, ~10 min of
-          Portainer clicking.
-      (2) LATER, instant deploys: Portainer stack webhooks exposed
-          ONLY through a Cloudflare Tunnel (cloudflared, outbound-
-          only — the 80/443-only router rule stays intact) + a tiny
-          deploy job appended to ci (curl the webhook on push to
-          dev / release). never a public proxy host to :9000 (prime
-          directive 1).
-      note: cd.yml's GHCR images can NOT serve the frontends across
-      envs yet — ui/social/marketing bake origins at BUILD time, so
-      per-env build-on-box stays correct until a runtime-config
-      refactor; the api/rtc images are env-agnostic and could
-      switch to pulls anytime.
+[~] E6. SSH-DEPLOY CI/CD (replaces Portainer GitOps as the deploy
+       trigger): the current Portainer GitOps loop (5-min poll, silent
+       retries on failure, zero signal back to GitHub) is brittle —
+       when a deploy fails, Portainer retries forever in a loop and
+       GitHub has no idea. the replacement: GitHub Actions SSHes into
+       the Ubuntu server, runs `docker compose up` directly, captures
+       exit codes, and runs the smoke test. GitHub now knows instantly
+       if a deploy succeeded or failed. no self-hosted runner needed
+       (avoids the public-repo security issue — no runner in the
+       docker group on the box).
+
+       AUTH: deploy key (SSH key-pair, not PAT). the private key
+       lives as a GitHub Actions secret (`DEPLOY_SSH_KEY`), the public
+       key is installed on the box at `~/.ssh/authorized_keys` with a
+       command restriction scoped to the deploy script only — the key
+       can't be used for general shell access.
+
+       WORKFLOW: new `.github/workflows/deploy.yml`:
+         - triggers: push to `dev` → deploy `web10-dev`; push to
+           `main` or `v*` tag → deploy `web10-prod`
+         - runs on `ubuntu-latest` (ephemeral GA runner)
+         - steps:
+           1. checkout
+           2. SSH→box (`ssh -o StrictHostKeyChecking=accept-new`)
+           3. `cd /opt/web10 && git pull origin <branch>`
+           4. `docker compose -p <stack> --env-file env.<env> -f
+              ubuntu-deployment/docker-compose.ecosystem.yml
+              up -d --build --remove-orphans`
+           5. wait for health (poll `docker ps` for stable state,
+              max 5 min)
+           6. `bash ubuntu-deployment/scripts/smoke.sh` (exits
+              non-zero on failure → GitHub marks the job failed)
+           7. on success: Portainer API call to register/update the
+              stack metadata so the Portainer UI reflects the deploy
+              (see below)
+         - concurrency: `deploy-<env>` group, cancel-in-progress
+
+       PORTAINER INTEGRATION (post-deploy register): Portainer is
+       just a UI on top of Docker — it watches the Docker socket.
+       when you `docker compose up` on the box, Portainer SEES the
+       containers automatically (they show up in the "Containers"
+       view). to also have the stack appear in the "Stacks" view
+       (for UI management: restart, logs, env-var editing), call the
+       Portainer API AFTER a successful deploy to create/update the
+       stack entry. PREFERRED approach: FILE-BACKED stack via
+       Portainer API — point at the compose file on disk
+       (`/opt/web10/ubuntu-deployment/docker-compose.ecosystem.yml`).
+       this gives Portainer full stack management (restart, rebuild,
+       logs, env-var editor) WITHOUT GitOps polling. the deploy
+       script calls `POST /stacks/create/standalone/file` (or PUT to
+       update) after docker compose succeeds. keeps Portainer as the
+       management UI without making it the deploy trigger.
+
+       DISABLE GITOPS: remove the `autoUpdate` field from existing
+       stacks (or delete and recreate as file-backed). the GitOps
+       polling is the source of the "retrying" loop — it must be
+       killed. `deploy-stacks.py` currently sets `"autoUpdate":
+       {"interval": "5m"}` on create; the new deploy script must
+       create file-backed stacks (no autoUpdate) or update existing
+       stacks to disable autoUpdate via `PUT /stacks/{id}`.
+
+       SECURITY: the SSH deploy key is scoped. even if compromised,
+       it can only run the deploy script (command restriction in
+       authorized_keys). the deploy script runs as the non-root SSH
+       user (jacob), who is in the docker group. no sudo, no root.
+       the key is rotated by replacing the GitHub secret and the
+       authorized_keys entry.
+
+       ROLLBACK: if smoke test fails, the workflow can automatically
+       rollback: `docker compose -p <stack> down` then `docker compose
+       -p <stack> up -d` to restore the previous image (Docker keeps
+       the old image until the next build). or more reliably: tag
+       images at deploy time (`<stack>:<sha>` and `<stack>:previous`)
+       and rollback is `docker compose up -d --no-build` with the
+       previous tag. the smoke test failure is visible in GitHub
+       Actions with full logs — the operator can decide rollback vs.
+       fix.
+
+       RATIONALE: this is the standard pattern for teams that want
+       CI visibility without self-hosted runners. the SSH-from-
+       ephemeral-runner pattern is used by Railway, Render, and
+       Fly.io internally. the advantage over Portainer GitOps:
+       instant feedback (not 5-min poll), failure is visible in
+       GitHub (not a silent retry loop), the smoke test is part
+       of the deploy (not a separate manual step), and concurrency
+       control prevents concurrent deploys from fighting.
+
+       BLOCKS: none — can start immediately. depends on the operator
+       generating an SSH key pair and adding the private key as a
+       GitHub Actions secret. the operator must also install the
+       public key on the box with the command restriction.
   [ ] E7. SDK npm publish flow (with C2/D18): cd.yml publishes sdk/
       to npm on a v* tag today — confirm it fires + the package is
       public, and decide whether a version bump on merge to dev/main

--- a/ubuntu-deployment/scripts/README.md
+++ b/ubuntu-deployment/scripts/README.md
@@ -14,9 +14,22 @@ i.e. they must run ON the box (or through an SSH tunnel).
 |--------|--------------|-------------|
 | `lib.sh` | shared bash helpers (loads `.env`, mints Portainer/NPM tokens) — sourced, not run | — |
 | `sync-dns.py` | create/reconcile all dev + prod Cloudflare A records (dev→LAN, prod→public); `--prune-staging` removes the legacy staging records | yes |
-| `deploy-stacks.py [edge\|dev\|prod\|all]` | create/redeploy the Portainer git-backed stacks (GitOps, 5-min poll) | yes |
+| `deploy-stacks.py register [edge\|dev\|prod\|all]` | register file-backed Portainer stacks (no GitOps polling — E6) | yes |
+| `deploy-stacks.py disable-gitops [edge\|dev\|prod\|all]` | disable auto-update on existing git-backed stacks | yes |
+| `deploy-stacks.py gitops [edge\|dev\|prod\|all]` | **DEPRECATED** — legacy git-backed stacks with 5-min polling | yes |
 | `sync-npm.py` | one Cloudflare DNS-01 cert covering every vhost + all proxy hosts (forwarding by stack-prefixed alias) | yes |
 | `smoke.sh` | HTTP + money-path (signup→token) checks for both envs | yes |
+
+## Deploy model (E6: SSH-deploy CI/CD)
+
+The primary deploy path is **GitHub Actions → SSH → docker compose**
+(see `.github/workflows/deploy.yml`). Portainer is the management UI
+only — it does NOT trigger deploys. After a successful docker compose
+deploy, the Portainer API is called to register the stack so it appears
+in the Portainer UI for management (restart, logs, env-var editing).
+
+This replaces the old Portainer GitOps polling (5-min interval, silent
+retry loop on failure, zero signal back to GitHub).
 
 ## Full bring-up order (fresh box)
 
@@ -27,15 +40,23 @@ i.e. they must run ON the box (or through an SSH tunnel).
 #    one-time manual step — see OPS-LOG for how it was done here).
 cd /opt/web10
 python3 ubuntu-deployment/scripts/sync-dns.py            # DNS first (DNS-01 needs it)
-python3 ubuntu-deployment/scripts/deploy-stacks.py all   # edge + dev + prod
+python3 ubuntu-deployment/scripts/deploy-stacks.py register all  # edge + dev + prod (file-backed)
 python3 ubuntu-deployment/scripts/sync-npm.py            # cert + routes
 bash    ubuntu-deployment/scripts/smoke.sh               # verify
 ```
 
 ## Day-2
 
-- **Code changed on `dev`:** nothing to do — GitOps polls every 5 min.
-  To force it now: `python3 .../deploy-stacks.py dev` (or `prod`).
+- **Code changed on `dev`/`main`:** nothing to do — GitHub Actions
+  deploys automatically on push. Check the deploy workflow run in
+  GitHub for success/failure with full logs.
+- **Force a redeploy from the box:**
+  ```bash
+  cd /opt/web10 && git pull
+  cd ubuntu-deployment
+  docker compose -p web10-dev --env-file env.dev -f docker-compose.ecosystem.yml up -d --build --remove-orphans
+  bash scripts/smoke.sh
+  ```
 - **New/changed vhost or forward target:** edit the `HOSTS` table in
   `sync-npm.py`, re-run it.
 - **New/changed DNS:** edit `sync-dns.py`, re-run it.

--- a/ubuntu-deployment/scripts/deploy-stacks.py
+++ b/ubuntu-deployment/scripts/deploy-stacks.py
@@ -1,11 +1,30 @@
 #!/usr/bin/env python3
-"""Create or update the Portainer git-backed stacks (edge, dev, prod).
+"""Create, update, or register Portainer stacks.
 
-Each stack tracks the `dev` branch of the repo and auto-updates every
-5 minutes (GitOps polling — E6 phase 1). Re-running is safe: an
-existing stack is updated in place, a missing one is created.
+Two modes:
 
-  python3 ubuntu-deployment/scripts/deploy-stacks.py [edge|dev|prod|all]
+  FILE-BACKED (default, no GitOps polling):
+    Stack is registered in Portainer pointing at a local compose file.
+    Portainer provides the management UI (restart, logs, env-var editor)
+    but does NOT auto-pull or auto-deploy. GitHub Actions handles deploys
+    via SSH → docker compose. This is the E6 replacement for GitOps.
+
+    python3 scripts/deploy-stacks.py register dev
+    python3 scripts/deploy-stacks.py register prod
+    python3 scripts/deploy-stacks.py register all
+
+  GIT-BACKED (legacy, GitOps polling — deprecated):
+    Stack tracks a git ref and auto-updates every 5 minutes.
+    DO NOT USE — the retry loop is brittle and invisible to GitHub.
+
+    python3 scripts/deploy-stacks.py gitops dev
+    python3 scripts/deploy-stacks.py gitops all
+
+  DISABLE GITOPS (convert existing git-backed stacks):
+    Removes autoUpdate from an existing git-backed stack in place.
+
+    python3 scripts/deploy-stacks.py disable-gitops dev
+    python3 scripts/deploy-stacks.py disable-gitops all
 
 Secrets (Portainer creds, MINIO passwords) come from ../.env. The
 per-stack environment is defined HERE — this file is the source of
@@ -25,6 +44,8 @@ REPO = "https://github.com/jacoby149/web10"
 REF = "refs/heads/dev"
 COMPOSE = "ubuntu-deployment/docker-compose.ecosystem.yml"
 EDGE_COMPOSE = "ubuntu-deployment/docker-compose.edge.yml"
+COMPOSE_PATH = "/opt/web10/ubuntu-deployment/docker-compose.ecosystem.yml"
+EDGE_COMPOSE_PATH = "/opt/web10/ubuntu-deployment/docker-compose.edge.yml"
 
 
 def jwt():
@@ -56,9 +77,6 @@ def env_for(stack):
                  MINIO_PASSWORD=cfg["MINIO_PASSWORD_DEV"])
     else:
         d = dict(STACK="web10-prod", PROVIDER="api.web10.app",
-                 # Prod serves the REAL data in the host-native mongo's "deploy"
-                 # database (208 accounts), not the containerized FerretDB. The
-                 # compose defaults DB to web10/FerretDB; override here.
                  DB="deploy", DB_URL="mongodb://host.docker.internal:27017/",
                  API_ORIGIN="https://api.web10.app", API_HOST="api.web10.app",
                  AUTH_ORIGIN="https://auth.web10.app", RTC_ORIGIN="https://rtc.web10.app",
@@ -68,7 +86,50 @@ def env_for(stack):
     return [{"name": k, "value": v} for k, v in d.items()]
 
 
-def deploy(name, compose, env):
+def find_stack(name):
+    stacks = api("GET", "/stacks")
+    if not isinstance(stacks, list):
+        return None
+    return next((s for s in stacks if s["Name"] == name), None)
+
+
+# ---------------------------------------------------------------------------
+# FILE-BACKED (register) — no GitOps polling
+# ---------------------------------------------------------------------------
+def register_file_backed(name, compose_path, env):
+    """Register a file-backed stack in Portainer (no auto-update).
+
+    If the stack already exists (git-backed or file-backed), it gets
+    deleted and recreated. Portainer doesn't support converting a
+    git-backed stack to file-backed in-place.
+    """
+    found = find_stack(name)
+    if found:
+        # Delete existing stack (Portainer won't let us change type)
+        print(f"removing existing stack '{name}' (id={found['Id']}) for re-registration...")
+        r = api("DELETE", f"/stacks/{found['Id']}?endpointId=1")
+        if "_err" in r:
+            print(f"  WARNING: could not delete existing stack: {r}")
+            print(f"  Skipping '{name}' — delete it manually in Portainer first.")
+            return
+
+    body = {
+        "name": name,
+        "stackFile": compose_path,
+        "env": env,
+    }
+    r = api("POST", "/stacks/create/standalone/file?endpointId=1", body)
+    if "_err" in r:
+        print(f"FAIL registering '{name}': {r}")
+    else:
+        print(f"registered {name} (file-backed, id={r.get('Id', '?')})")
+
+
+# ---------------------------------------------------------------------------
+# GIT-BACKED (legacy, deprecated)
+# ---------------------------------------------------------------------------
+def deploy_gitops(name, compose, env):
+    """Legacy git-backed stack with 5-min polling. DEPRECATED."""
     stacks = api("GET", "/stacks")
     found = next((s for s in stacks if s["Name"] == name), None) if isinstance(stacks, list) else None
     if found:
@@ -83,10 +144,69 @@ def deploy(name, compose, env):
         print(f"created  {name}:", r.get("Id", r.get("_body", "")))
 
 
-targets = sys.argv[1] if len(sys.argv) > 1 else "all"
-if targets in ("edge", "all"):
-    deploy("edge", EDGE_COMPOSE, [])
-if targets in ("dev", "all"):
-    deploy("web10-dev", COMPOSE, env_for("web10-dev"))
-if targets in ("prod", "all"):
-    deploy("web10-prod", COMPOSE, env_for("web10-prod"))
+# ---------------------------------------------------------------------------
+# DISABLE GITOPS — remove autoUpdate from existing git-backed stacks
+# ---------------------------------------------------------------------------
+def disable_gitops(name):
+    """Disable auto-update on an existing git-backed stack."""
+    found = find_stack(name)
+    if not found:
+        print(f"stack '{name}' not found")
+        return
+    # Get current stack config
+    r = api("GET", f"/stacks/{found['Id']}")
+    if "_err" in r:
+        print(f"FAIL reading stack '{name}': {r}")
+        return
+
+    # Remove autoUpdate
+    r.pop("autoUpdate", None)
+    if "Config" in r and isinstance(r["Config"], dict):
+        r["Config"].pop("autoUpdate", None)
+
+    updated = api("PUT", f"/stacks/{found['Id']}", r)
+    if "_err" in updated:
+        print(f"FAIL disabling gitops on '{name}': {updated}")
+    else:
+        print(f"disabled gitops on '{name}' (id={found['Id']})")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+if len(sys.argv) < 2:
+    print(__doc__)
+    sys.exit(1)
+
+mode = sys.argv[1]
+targets = sys.argv[2] if len(sys.argv) > 2 else "all"
+
+if mode == "register":
+    if targets in ("edge", "all"):
+        register_file_backed("edge", EDGE_COMPOSE_PATH, [])
+    if targets in ("dev", "all"):
+        register_file_backed("web10-dev", COMPOSE_PATH, env_for("web10-dev"))
+    if targets in ("prod", "all"):
+        register_file_backed("web10-prod", COMPOSE_PATH, env_for("web10-prod"))
+
+elif mode == "gitops":
+    print("WARNING: gitops mode is deprecated — use 'register' for file-backed stacks")
+    if targets in ("edge", "all"):
+        deploy_gitops("edge", EDGE_COMPOSE, [])
+    if targets in ("dev", "all"):
+        deploy_gitops("web10-dev", COMPOSE, env_for("web10-dev"))
+    if targets in ("prod", "all"):
+        deploy_gitops("web10-prod", COMPOSE, env_for("web10-prod"))
+
+elif mode == "disable-gitops":
+    if targets in ("edge", "all"):
+        disable_gitops("edge")
+    if targets in ("dev", "all"):
+        disable_gitops("web10-dev")
+    if targets in ("prod", "all"):
+        disable_gitops("web10-prod")
+
+else:
+    print(f"Unknown mode: {mode}")
+    print("Modes: register, gitops (deprecated), disable-gitops")
+    sys.exit(1)


### PR DESCRIPTION
Replaces the brittle Portainer GitOps 5-min poll (silent retry loop, zero CI visibility) with GitHub Actions SSHing into the box, running `docker compose up --build`, waiting for container stability, and running the smoke test. Push to `dev` deploys web10-dev; push to `main` deploys web10-prod. No self-hosted runner — uses ephemeral ubuntu-latest + a scoped SSH deploy key.

Includes: `deploy-stacks.py` rewritten with file-backed `register` mode and `disable-gitops` command; updated scripts README; comprehensive E6 spec in parallel execution.txt.

Requires GitHub secrets: `DEPLOY_SSH_KEY`, `VM_IP`, `SSH_USER`. After merge: run `deploy-stacks.py disable-gitops all` on the box to kill existing GitOps polling.