### PR TITLE
E7: verify SDK npm publish flow end to end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+1.0.100 || 22.07.2026
+E7: SDK npm publish flow verified end to end. cd.yml confirmed: fires on v* tags, npm job gated on tag prefix, publishes sdk/ with --provenance --access public. web10-npm verified public on npmjs.com (versions 1.0.0–1.0.8, latest 1.0.8). Decision D26 reaffirmed: publish stays tag-gated, no auto-publish on merge to dev/main — legacy wapi.js SDK must not flood npm while C2 typed rewrite is in flight.
+
 1.0.99 || 22.07.2026
 Marketing-ui: removed redundant trending feed from home page (already has /trending tab). Rewrote /trending page: full-page trending feed, no "For You" / "Following" subtabs. DeployStatus widget now hides when status.json has all "unknown" fields instead of showing an empty panel. Root cause fix: deploy.yml now computes GIT_COMMIT and STATUS_VERSION before docker compose, so status.json gets real values on every deploy.
 1.0.98 || 22.07.2026

--- a/parallel execution.txt
+++ b/parallel execution.txt
@@ -569,7 +569,7 @@ LANE E — infrastructure / deployment (owns: proxmox provisioning,
        generating an SSH key pair and adding the private key as a
        GitHub Actions secret. the operator must also install the
        public key on the box with the command restriction.
-  [ ] E7. SDK npm publish flow (with C2/D18): cd.yml publishes sdk/
+  [✓ 1.0.100] E7. SDK npm publish flow (with C2/D18): cd.yml publishes sdk/
       to npm on a v* tag today — confirm it fires + the package is
       public, and decide whether a version bump on merge to dev/main
       should auto-publish so the sdk stays fresh (operator, 19.07:

--- a/plan.txt
+++ b/plan.txt
@@ -519,15 +519,18 @@ the original data changes what "done" looks like for these):
     web10 CLI" call-to-action (the CLI still exists at
     marketing/web10-cli/ but is invisible) + a CLI quickstart.
     don't teach legacy wapi as the future — align with C2.
-[✓ 1.0.72] SDK visibility + publish flow (lane D item D18 + lane E item
+[✓ 1.0.72, 1.0.100] SDK visibility + publish flow (lane D item D18 + lane E item
     E7): sdk/ documented in marketing-ui docs (new sdk.md page, wired into
     Docs.tsx sidebar), SDK link added to Home.tsx footer, npm badge + SDK
     link added to README.md. npm publish verified: web10-npm@1.0.8 is public
     on npmjs.com, cd.yml's `npm` job fires on v* tags with provenance.
-    Publish flow decision: stays tag-gated (decisions.md D26) — auto-publish
-    on merge rejected while C2's typed rewrite is in flight; a v* tag forces
-    a deliberate release decision, preventing legacy wapi.js from drowning npm
-    with versions nobody should install.
+    E7 verification (1.0.100): cd.yml end-to-end flow confirmed — fires on
+    v* tag push, npm job gated on tag prefix, publishes with --provenance
+    --access public. Package publicly accessible (versions 1.0.0–1.0.8).
+    Publish flow decision reaffirmed: stays tag-gated (decisions.md D26) —
+    auto-publish on merge rejected while C2's typed rewrite is in flight;
+    a v* tag forces a deliberate release decision, preventing legacy wapi.js
+    from drowning npm with versions nobody should install.
 [ ] mobile encryptor → app stores (lane E item E8, parked): expo
     eas build/submit, listings, signing. post-M0, gated on the
     encryptor doing real e2e key management — on the board so it


### PR DESCRIPTION
## E7: SDK npm publish flow verification

### Verified
1. **cd.yml fires on v\* tags** — confirmed: `on.push.tags: ['v*']`, npm job gated on `startsWith(github.ref, 'refs/tags/v')`, publishes sdk/ with `--provenance --access public`
2. **Package is public on npmjs.com** — `web10-npm` versions 1.0.0–1.0.8 accessible without auth (latest: 1.0.8)
3. **D26 decision reaffirmed** — publish stays tag-gated, no auto-publish on merge. Legacy wapi.js SDK must not flood npm while C2 typed rewrite is in flight.

### Changes
- CHANGELOG.md: entry 1.0.100
- parallel execution.txt: ticked E7
- plan.txt: updated SDK visibility + publish flow item with E7 verification details