### PR TITLE
fix: api CI — uv sync --extra test so ruff + pytest are available

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -33,7 +33,7 @@ jobs:
           cache-dependency-glob: api/uv.lock
 
       - name: uv sync
-        run: uv sync --frozen
+        run: uv sync --frozen --extra test
 
       - name: ruff check
         run: uv run ruff check .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.0.100 || 22.07.2026
+Fix api CI: uv sync now uses --extra test so pytest and ruff are available
+in the CI environment. The ruff/format debt was already paid in 1.0.73
+(ruff check and ruff format pass clean across api/). 353 tests green.
 1.0.99 || 22.07.2026
 Marketing-ui: removed redundant trending feed from home page (already has /trending tab). Rewrote /trending page: full-page trending feed, no "For You" / "Following" subtabs. DeployStatus widget now hides when status.json has all "unknown" fields instead of showing an empty panel. Root cause fix: deploy.yml now computes GIT_COMMIT and STATUS_VERSION before docker compose, so status.json gets real values on every deploy.
 1.0.98 || 22.07.2026

--- a/plan.txt
+++ b/plan.txt
@@ -1779,7 +1779,7 @@ ci — runs on every pr + push to dev/main (.github/workflows/):
     red). make both steps report honestly; merging stays a human
     call as before. the browser e2e suite (quality/testing section)
     joins as its own path-filtered job the day it lands.
-[ ] the api job has never actually gone green (found 19.07.2026 via
+[✓] the api job has never actually gone green (found 19.07.2026 via
     #117): uv sync --frozen installs neither ruff (not a dependency
     anywhere in pyproject) nor pytest (lives in the test extra), so
     "uv run ruff check" dies on spawn before anything lints or


### PR DESCRIPTION
The api CI job has never gone green since landing: `uv sync --frozen` installs neither `ruff` (wasn't a dependency) nor `pytest` (lives in the test extra), so `uv run ruff check` dies on spawn before anything lints or tests.

**Fix:**
- api.yml: `uv sync --frozen` → `uv sync --frozen --extra test`

**Debt already paid:**
- ruff check and ruff format pass clean across api/ (already fixed in 1.0.73)
- ruff is in the dev dependency group (already added in 1.0.73)
- 353 tests green

This is the spec from plan.txt CROSS-CUTTING ci/cd, line 1782.