### PR TITLE
reprioritize (D29): killer app proud-and-working first; infra work parked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-1.0.99 || 22.07.2026
+1.0.102 || 22.07.2026
 Reprioritization (D29): the killer app, proud and working, before anything
 else. plan.txt PRIORITY ZERO (baseline chain, merged) superseded by PRIORITY
 ONE: every task judged by "does this make web10-social something the operator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+1.0.99 || 22.07.2026
+Reprioritization (D29): the killer app, proud and working, before anything
+else. plan.txt PRIORITY ZERO (baseline chain, merged) superseded by PRIORITY
+ONE: every task judged by "does this make web10-social something the operator
+demos from his phone with pride?" — with THE GAUNTLET (8 phone-run end-to-end
+steps, each encoded in e2e/ as it passes) as the bar. Conductor board rewritten
+around it; C2 SDK rewrite, C3 MCP, C3.5 create-web10, D11 ux telemetry, E4
+provisioning, E8 store submission explicitly PARKED until the gauntlet passes.
+
 1.0.98 || 22.07.2026
 Knowledge folder complete overhaul: replaced AI-generated content with a working system. Knowledge theories: the-why-layer (connects tech to business), the-how-layer (comprehensive technical explanation), the-what-layer (code/deploy/ownership map). Writing styles: use-case-driven (abstract → specific → technical → logistics). Editing styles: the-touch-up (surgical fixes), the-rewrite (diagnose, pick theory/style/voice, write fresh). Voices: clive-tobacco-smoker (anti-AI voice reference). Visual-styles folder added for Mermaid chart styles. AGENTS.md added with the workflow for AI agents (pick theory → pick style → pick voice → write). Deleted old knowledge-base/ (architecture, protocol, security, 8 Mermaid scenarios) — all replaced.
 1.0.89 || 21.07.2026

--- a/decisions.md
+++ b/decisions.md
@@ -9,6 +9,23 @@ Status legend: [decided] intent set · [in-progress] · [open] still debating.
 
 ---
 
+### D29 — Product pride gates the board: the killer app first, infra parks [decided]
+Operator call (22.07.2026): the deployed product is still a shell — the
+pieces exist but the whole doesn't hold — while the board kept surfacing
+infrastructure-company work (SDK rewrite, MCP, ux telemetry, provisioning).
+Reprioritization: web10-social IS the product until further notice. Every
+task is judged by one question: "does this make the social app something
+the operator opens on his phone, in front of someone, and is proud of?"
+The bar is THE GAUNTLET (plan.txt top): 8 end-to-end steps run from a
+phone against dev, each encoded as a playwright journey as it passes.
+Explicitly PARKED until the gauntlet passes: C2 SDK rewrite, C3 MCP,
+C3.5 create-web10, D11 ux telemetry, E4 provisioning, E8 store submission,
+docs/knowledge prose beyond fixes. This is D20 (platform first, protocol
+second) enforced on the task board, and Priority Zero's successor — its
+baseline chain (A7/B6/D16.1/D17) merged, but baseline was never the real
+bar; pride is. Rejects: breadth-first lane rotation ("pull the top of any
+unblocked lane"), which produced motion without a demoable product.
+
 ### D28 — Schema-registry public ledger for flexible interactions [decided]
 A shared system collection `web10.public` holds structured public interactions
 (reactions, ratings, endorsements, custom events). Any authenticated user can

--- a/parallel execution.txt
+++ b/parallel execution.txt
@@ -634,19 +634,34 @@ M3 "the network"         = encryption integration (A rtc + C2 sdk
                            polish. the last big merge.
 
 
-CURRENT CONDUCTOR BOARD (as of 19.07.2026 — keep this section fresh)
+CURRENT CONDUCTOR BOARD (as of 22.07.2026 — keep this section fresh)
 --------------------------------------------------------------------
-we are in timeline.md WEEK 0/1 — the M0 sprint (video by ~aug 17).
-the beautify wave (B5/D12/D13/D14) and the FULL DEPLOYMENT (E3/E5 —
-both envs live behind NPM with TLS + GitOps polling) are merged.
-PRIORITY ZERO (plan.txt, top): the deployed product must WORK AT A
-BASELINE — auth is broken, docs 404'd (fixed in D16.1), the node
-points at an empty db. baseline fixes outrank polish, in this order:
-  ws-A: A7 connect the real host mongo (unblocks everything)
-  ws-B: B6 authenticator revamp (login must complete; playwright
-        guard) — logo + obvious breakage can start before A7
-  ws-C: C6 e2e deep sweep (now can also run against dev)
-  ws-D: D17 restore the dev docs + D16 real app store (after A7)
+PRIORITY ONE (plan.txt, top — supersedes 19.07's priority zero,
+whose baseline chain A7/B6/D16.1/D17 is merged): THE KILLER APP,
+PROUD AND WORKING, before anything else. the only question a task
+must answer: "does this make web10-social something the operator
+opens on his phone, in front of someone, and is proud of?" (D29)
+  ws-G1: run THE GAUNTLET (plan.txt top, 8 steps) against dev from
+         a phone; write the honest fail list to .context/gauntlet.md;
+         fix in order of demo impact. lane D owns app fixes, lane A
+         owns api fixes, lane B owns the auth/consent seam.
+  ws-G2: keep the personas alive (persona-orchestration/) so feed +
+         trending never demo empty.
+  ws-G3: encode each passing gauntlet step as a playwright journey
+         in e2e/ (lane C — this is C6 continued, NOT C2).
+  then: low-hanging fruit by demo impact — realtime feed refresh,
+        notifications, search-your-own-stuff, D16(3) store curation.
+PARKED until the gauntlet passes (do NOT pick up — they read as an
+infra company, not a social platform): C2 sdk rewrite, C3 mcp,
+C3.5 create-web10, D11 ux telemetry, E4 provisioning, E8 mobile
+store submission, docs/knowledge prose beyond fixes.
+
+previous board (19.07, for history — all merged):
+  ws-A: A7 connect the real host mongo — [✓ 1.0.72]
+  ws-B: B6 authenticator revamp — [✓ 1.0.72] (+ B7 [✓ 1.0.76])
+  ws-C: C6 e2e deep sweep — [✓ 1.0.74]
+  ws-D: D17 dev docs [✓ 1.0.72] + D16 app store (partial, 1.0.84 —
+        curation deferred, now in the low-hanging-fruit tier)
 
   ws1: [✓ 1.0.65] B5 level-up ui/ to design.md (lane B — ui/**) — merged
   ws2: [✓ 1.0.64] D12 level-up web10-social to design.md (lane D —

--- a/plan.txt
+++ b/plan.txt
@@ -1,18 +1,43 @@
 web10 plan
 ==========
 
-PRIORITY ZERO (operator, 19.07.2026): MAKE IT WORK AT A BASELINE.
-it is embarrassing that the deployed product does not work right
-now — the authenticator is broken (login doesn't complete, the logo
-renders broken), the docs 404, the app store is hollow, and the live
-node points at an empty database instead of the 208 real users.
-polish, beautification, new features, and docs prose all rank BELOW
-"a person can sign up, log in, use the apps, and read the docs
-without hitting something broken." when choosing between a shiny
-addition and a baseline fix, take the baseline fix. the current
-baseline chain, in order: A7 (real data) → B6 (auth actually works)
-→ D16.1/D17 (docs reachable) → D16 (store shows real apps). the
-C5/C6 e2e suite is the referee for "works."
+PRIORITY ONE (operator, 22.07.2026): THE KILLER APP, PROUD AND
+WORKING, BEFORE ANYTHING ELSE. supersedes priority zero (19.07) —
+its baseline chain is ticked (A7 real data, B6 auth, D16.1/D17
+docs, D16 mostly), but the honest state is still "a shell of a
+non-working platform": the pieces exist and the whole doesn't
+hold, and the board keeps surfacing work that sounds like an
+infrastructure company (sdk rewrite, ux telemetry, provisioning)
+instead of a social platform. reprioritization: web10-social IS
+the product until further notice. every task is judged by ONE
+question — "does this make the social app something the operator
+opens on his phone, in front of someone, and is proud of?" if the
+answer is no, it waits, explicitly and without guilt (see PARKED
+in parallel execution.txt: C2/C3/C3.5, D11, E4, E8, docs prose).
+these are good ideas whose time is not now (D20 said protocol
+serves platform; this is that decision enforced on the task
+board, logged as D29).
+
+the bar is THE GAUNTLET — run from the operator's phone against
+dev, top to bottom, no apologies. step one of the work is running
+it and writing the honest fail list (.context/gauntlet.md); fixes
+land in order of demo impact:
+  1. sign up + log in on the social app without a broken screen
+  2. post a photo -> it appears in the feed immediately
+  3. follow a persona -> their posts land in your feed
+  4. like + comment -> counts update, feel instant
+  5. dm a persona -> the thread reads like a real messenger
+  6. your profile reads as a creator page you'd screenshot
+  7. trending/discover shows a real, alive feed (personas keep it
+     from ever demoing empty)
+  8. nothing white-screens; every screen is design.md-grade at
+     375px, on a real phone, on dev AND prod
+each step that passes gets encoded as a playwright journey in e2e/
+so it can't regress (C6 continued — the referee for "works").
+when the gauntlet passes end to end, THEN low-hanging fruit in
+order of demo impact (realtime feed refresh, notifications, search
+your own stuff, D16(3) store curation) — judged by the same
+question.
 
 the thesis (why this plan):
 - THIS IS A PRODUCT FOR INFLUENCERS. the proposition is OWNERSHIP ON


### PR DESCRIPTION
## What

The operator's call, verbatim: "sdk rewrite, ux telemetry, these things dont sound like a super social app ... we need to reprioritize the plan so that it is killer app i am proud of first, then low hanging fruit but obviously has to function too."

- **plan.txt**: PRIORITY ZERO (19.07, baseline chain — merged) superseded by **PRIORITY ONE**: web10-social IS the product; every task judged by "does this make the social app something the operator opens on his phone, in front of someone, and is proud of?" The bar is **THE GAUNTLET** — 8 end-to-end steps run from a phone against dev (signup → post → follow → like/comment → DM → profile → trending → nothing broken at 375px), each encoded as a playwright journey as it passes.
- **parallel execution.txt**: conductor board rewritten around the gauntlet (ws-G1 run it + write the honest fail list, ws-G2 personas keep the demo alive, ws-G3 e2e encodes it). Explicit **PARKED** list: C2 SDK rewrite, C3 MCP, C3.5 create-web10, D11 ux telemetry, E4 provisioning, E8 store submission.
- **decisions.md**: D29 logged — this is D20 (platform first, protocol second) enforced on the task board; rejects breadth-first lane rotation.
- **CHANGELOG.md**: 1.0.99.

Docs-only change, no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)