### PR TITLE
D11: UX telemetry — funnel analytics + JS error beacon

### DIFF
--- a/marketing/marketing-api/app/main.py
+++ b/marketing/marketing-api/app/main.py
@@ -16,6 +16,7 @@ from .models import (
     ImportJobCreate,
     PageView,
     FunnelEventCreate,
+    JsErrorReport,
     FeedbackCreate,
 )
 from .utils import detect_platform
@@ -322,18 +323,59 @@ async def track_funnel(event: FunnelEventCreate):
     return {"status": "ok"}
 
 
+@app.post("/analytics/error")
+async def report_error(error: JsErrorReport):
+    """Accept a client-side JS error beacon (content-free, no PII)."""
+    analytics_events.append(
+        {
+            "type": "error",
+            "message": error.message,
+            "source": error.source,
+            "line": error.line,
+            "column": error.column,
+            "app": error.app,
+            "route": error.route,
+            "user_agent": error.user_agent,
+            "timestamp": datetime.utcnow().isoformat(),
+        }
+    )
+    return {"status": "ok"}
+
+
 @app.get("/analytics/summary")
 async def get_analytics_summary():
-    """Get a summary of marketing analytics."""
+    """Get a summary of marketing analytics, including funnel drop-off."""
     total_pageviews = sum(1 for e in analytics_events if e["type"] == "pageview")
     funnel_counts = {}
     for e in analytics_events:
         if e["type"] == "funnel":
             ev = e["event"]
             funnel_counts[ev] = funnel_counts.get(ev, 0) + 1
+    # Per-step drop-off: for each funnel step, how many users reached it vs the previous step.
+    # Funnel order (acquisition path): landing -> docs_view -> app_store_view -> exporter_view -> export_started -> export_complete
+    funnel_order = [
+        "landing", "docs_view", "app_store_view",
+        "exporter_view", "export_started", "export_complete",
+    ]
+    dropoff = {}
+    prev_count = None
+    for step in funnel_order:
+        count = funnel_counts.get(step, 0)
+        if prev_count is not None and prev_count > 0:
+            dropoff[step] = {
+                "reached": count,
+                "previous_reached": prev_count,
+                "drop_off_pct": round((1 - count / prev_count) * 100, 1),
+            }
+        else:
+            dropoff[step] = {"reached": count, "previous_reached": 0, "drop_off_pct": None}
+        prev_count = count
+    total_errors = sum(1 for e in analytics_events if e["type"] == "error")
     return {
         "total_pageviews": total_pageviews,
         "funnel": funnel_counts,
+        "funnel_dropoff": dropoff,
+        "total_errors": total_errors,
         "events_tracked": len(analytics_events),
     }
 

--- a/marketing/marketing-api/app/models.py
+++ b/marketing/marketing-api/app/models.py
@@ -51,14 +51,30 @@ class FunnelEvent(str, Enum):
     DOCS_VIEW = "docs_view"
     APP_STORE_VIEW = "app_store_view"
     EXPORTER_VIEW = "exporter_view"
+    TRENDING_VIEW = "trending_view"
     EXPORT_STARTED = "export_started"
     EXPORT_COMPLETE = "export_complete"
     SIGN_IN_CLICK = "sign_in_click"
+    SIGN_UP_CLICK = "sign_up_click"
+    GITHUB_CLICK = "github_click"
+    ENTER_CLICK = "enter_click"
 
 
 class FunnelEventCreate(BaseModel):
     event: FunnelEvent
     metadata: dict = Field(default_factory=dict)
+
+
+class JsErrorReport(BaseModel):
+    """Client-side JS error beacon — no content, no PII."""
+
+    message: str = Field(..., max_length=2000, description="Error message or stack snippet")
+    source: Optional[str] = Field(None, max_length=500, description="Script filename or URL")
+    line: Optional[int] = None
+    column: Optional[int] = None
+    app: str = Field(..., description="App name: marketing-ui, web10-social, ui")
+    route: str = Field(..., description="Current URL path")
+    user_agent: Optional[str] = Field(None, max_length=500)
 
 
 class FeedbackCreate(BaseModel):

--- a/marketing/marketing-api/tests/test_smoke.py
+++ b/marketing/marketing-api/tests/test_smoke.py
@@ -7,7 +7,7 @@ the CI wiring honest until it lands.
 
 from fastapi.testclient import TestClient
 
-from app.main import app, feedback_store
+from app.main import app, analytics_events, feedback_store
 from app.validation import VALIDATORS, validate_record
 
 client = TestClient(app)
@@ -124,3 +124,93 @@ def test_list_feedback_limit():
     r = client.get("/feedback?limit=3")
     assert r.status_code == 200
     assert len(r.json()["items"]) == 3
+
+
+# ─── JS Error beacon ─────────────────────────────────────────────────────────
+
+
+def test_error_beacon_minimal():
+    analytics_events.clear()
+    r = client.post(
+        "/analytics/error",
+        json={"message": "TypeError: x is null", "app": "marketing-ui", "route": "/docs/sdk"},
+    )
+    assert r.status_code == 200
+    assert r.json()["status"] == "ok"
+    assert len([e for e in analytics_events if e["type"] == "error"]) == 1
+
+
+def test_error_beacon_full():
+    analytics_events.clear()
+    r = client.post(
+        "/analytics/error",
+        json={
+            "message": "ReferenceError: foo is not defined",
+            "source": "app.js",
+            "line": 42,
+            "column": 5,
+            "app": "marketing-ui",
+            "route": "/import",
+            "user_agent": "Mozilla/5.0",
+        },
+    )
+    assert r.status_code == 200
+    errors = [e for e in analytics_events if e["type"] == "error"]
+    assert errors[0]["source"] == "app.js"
+    assert errors[0]["line"] == 42
+    assert errors[0]["column"] == 5
+
+
+def test_error_beacon_rejects_missing_app():
+    r = client.post(
+        "/analytics/error",
+        json={"message": "broken", "route": "/feed"},
+    )
+    assert r.status_code == 422
+
+
+def test_error_beacon_rejects_missing_route():
+    r = client.post(
+        "/analytics/error",
+        json={"message": "broken", "app": "marketing-ui"},
+    )
+    assert r.status_code == 422
+
+
+# ─── Funnel events ───────────────────────────────────────────────────────────
+
+
+def test_funnel_event():
+    analytics_events.clear()
+    r = client.post(
+        "/analytics/funnel",
+        json={"event": "landing", "metadata": {}},
+    )
+    assert r.status_code == 200
+    assert r.json()["status"] == "ok"
+    funnel_events = [e for e in analytics_events if e["type"] == "funnel"]
+    assert funnel_events[0]["event"] == "landing"
+
+
+def test_funnel_event_new_types():
+    analytics_events.clear()
+    for event in ("trending_view", "sign_up_click", "github_click", "enter_click"):
+        r = client.post(
+            "/analytics/funnel",
+            json={"event": event, "metadata": {}},
+        )
+        assert r.status_code == 200, f"funnel event {event} should accept"
+
+
+def test_analytics_summary_includes_dropoff():
+    analytics_events.clear()
+    for event in ("landing", "docs_view", "exporter_view"):
+        client.post("/analytics/funnel", json={"event": event, "metadata": {}})
+    r = client.get("/analytics/summary")
+    assert r.status_code == 200
+    data = r.json()
+    assert "funnel_dropoff" in data
+    assert "total_errors" in data
+    assert data["funnel_dropoff"]["docs_view"]["reached"] == 1
+    assert data["funnel_dropoff"]["docs_view"]["previous_reached"] == 1
+    assert data["funnel_dropoff"]["docs_view"]["drop_off_pct"] == 0.0

--- a/marketing/marketing-ui/src/components/Navbar.tsx
+++ b/marketing/marketing-ui/src/components/Navbar.tsx
@@ -1,7 +1,8 @@
-import { useState } from 'react'
+import { useState, useCallback } from 'react'
 import { Link, useLocation } from 'react-router-dom'
 import { Bug, Menu, X } from 'lucide-react'
 import { Button } from './ui/button'
+import { trackFunnel } from '../lib/analytics'
 
 const navItems = [
   { path: '/', label: 'Home' },
@@ -50,13 +51,11 @@ function Navbar({ onReportBug }: { onReportBug: () => void }) {
             <Bug className="h-4 w-4" strokeWidth={1.75} />
             Report bug
           </Button>
-          <Button asChild variant="brand" size="sm">
-            <a href="https://auth.web10.app">Sign In</a>
+          <Button variant="brand" size="sm" onClick={() => { trackFunnel('sign_in_click'); window.location.href = 'https://auth.web10.app' }}>
+            Sign In
           </Button>
-          <Button asChild variant="ghost" size="sm">
-            <a href="https://github.com/jacoby149/web10" target="_blank" rel="noopener noreferrer">
-              GitHub
-            </a>
+          <Button variant="ghost" size="sm" onClick={() => { trackFunnel('github_click'); window.open('https://github.com/jacoby149/web10', '_blank', 'noopener') }}>
+            GitHub
           </Button>
         </div>
 
@@ -96,13 +95,11 @@ function Navbar({ onReportBug }: { onReportBug: () => void }) {
               <Bug className="h-4 w-4" strokeWidth={1.75} />
               Report bug
             </Button>
-            <Button asChild variant="brand" size="sm" className="w-full justify-center">
-              <a href="https://auth.web10.app">Sign In</a>
+            <Button variant="brand" size="sm" className="w-full justify-center" onClick={() => { setMobileOpen(false); trackFunnel('sign_in_click'); window.location.href = 'https://auth.web10.app' }}>
+              Sign In
             </Button>
-            <Button asChild variant="ghost" size="sm" className="w-full justify-center">
-              <a href="https://github.com/jacoby149/web10" target="_blank" rel="noopener noreferrer">
-                GitHub
-              </a>
+            <Button variant="ghost" size="sm" className="w-full justify-center" onClick={() => { setMobileOpen(false); trackFunnel('github_click'); window.open('https://github.com/jacoby149/web10', '_blank', 'noopener') }}>
+              GitHub
             </Button>
           </div>
         </div>

--- a/marketing/marketing-ui/src/lib/analytics.test.ts
+++ b/marketing/marketing-ui/src/lib/analytics.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { trackPageview, trackFunnel, reportError, installErrorBeacon } from './analytics'
+
+describe('analytics', () => {
+  beforeEach(() => {
+    // jsdom doesn't have sendBeacon — define it so spyOn can work
+    if (!navigator.sendBeacon) {
+      navigator.sendBeacon = () => true
+    }
+    vi.spyOn(navigator, 'sendBeacon').mockImplementation(() => true)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('trackPageview', () => {
+    it('fires a pageview event via sendBeacon', () => {
+      trackPageview('/docs/sdk')
+      expect(navigator.sendBeacon).toHaveBeenCalledWith(
+        expect.stringContaining('/analytics/pageview'),
+        expect.stringContaining('"path":"/docs/sdk"'),
+      )
+    })
+  })
+
+  describe('trackFunnel', () => {
+    it('fires a funnel event via sendBeacon', () => {
+      trackFunnel('landing')
+      expect(navigator.sendBeacon).toHaveBeenCalledWith(
+        expect.stringContaining('/analytics/funnel'),
+        expect.stringContaining('"event":"landing"'),
+      )
+    })
+
+    it('includes metadata when provided', () => {
+      trackFunnel('exporter_view', { platform: 'instagram' })
+      expect(navigator.sendBeacon).toHaveBeenCalledWith(
+        expect.stringContaining('/analytics/funnel'),
+        expect.stringContaining('"platform":"instagram"'),
+      )
+    })
+  })
+
+  describe('reportError', () => {
+    it('fires an error event via sendBeacon', () => {
+      reportError('TypeError: x is not defined', { source: 'app.js', line: 42 })
+      expect(navigator.sendBeacon).toHaveBeenCalledWith(
+        expect.stringContaining('/analytics/error'),
+        expect.stringContaining('"TypeError: x is not defined"'),
+      )
+    })
+
+    it('includes app and route', () => {
+      reportError('test error')
+      const body = JSON.parse(navigator.sendBeacon.mock.calls[0][1] as string)
+      expect(body.app).toBe('marketing-ui')
+      expect(body.route).toBe('/')
+    })
+
+    it('truncates long messages', () => {
+      reportError('a'.repeat(3000))
+      const body = JSON.parse(navigator.sendBeacon.mock.calls[0][1] as string)
+      expect(body.message.length).toBeLessThanOrEqual(2000)
+    })
+  })
+
+  describe('installErrorBeacon', () => {
+    it('installs window.onerror handler', () => {
+      installErrorBeacon()
+      expect(window.onerror).toBeDefined()
+    })
+
+    it('reports errors via window.onerror', () => {
+      installErrorBeacon()
+      const errHandler = window.onerror!
+      errHandler('ReferenceError: foo is not defined', 'script.js', 10, 5, new Error('foo is not defined'))
+      expect(navigator.sendBeacon).toHaveBeenCalledWith(
+        expect.stringContaining('/analytics/error'),
+        expect.stringContaining('foo is not defined'),
+      )
+    })
+
+    it('installs unhandledrejection handler', () => {
+      installErrorBeacon()
+      window.dispatchEvent(new PromiseRejectionEvent('unhandledrejection', {
+        promise: Promise.reject(new Error('unhandled')),
+        reason: new Error('unhandled'),
+      }))
+      expect(navigator.sendBeacon).toHaveBeenCalledWith(
+        expect.stringContaining('/analytics/error'),
+        expect.stringContaining('unhandled'),
+      )
+    })
+  })
+})

--- a/marketing/marketing-ui/src/lib/analytics.ts
+++ b/marketing/marketing-ui/src/lib/analytics.ts
@@ -1,0 +1,79 @@
+// Centralized analytics for marketing-ui.
+// Full funnel analytics + JS error beacon — marketing-ui is pre-signup,
+// so full tracking is fair game (plan.txt ux telemetry spec).
+
+const MARKETING_API =
+  (typeof window !== 'undefined' && new URLSearchParams(window.location.search).get('marketing_api')) ||
+  (import.meta.env?.VITE_MARKETING_API || 'http://marketing-api.localhost')
+
+const APP = 'marketing-ui'
+
+function fire(url: string, body: object) {
+  // Fire-and-forget: never block the user.
+  navigator.sendBeacon?.(url, JSON.stringify(body)) ??
+    fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      keepalive: true,
+    }).catch(() => {})
+}
+
+/** Track a pageview. Called automatically by the router tracker. */
+export function trackPageview(path: string) {
+  fire(`${MARKETING_API}/analytics/pageview`, {
+    path,
+    referrer: document.referrer || null,
+    user_agent: navigator.userAgent,
+  })
+}
+
+/** Track a funnel event (landing, docs_view, export_started, etc.). */
+export function trackFunnel(
+  event:
+    | 'landing'
+    | 'docs_view'
+    | 'app_store_view'
+    | 'exporter_view'
+    | 'trending_view'
+    | 'export_started'
+    | 'export_complete'
+    | 'sign_in_click'
+    | 'sign_up_click'
+    | 'github_click'
+    | 'enter_click',
+  metadata: Record<string, unknown> = {},
+) {
+  fire(`${MARKETING_API}/analytics/funnel`, { event, metadata })
+}
+
+/** Report a client-side JS error (content-free, no PII). */
+export function reportError(message: string, opts?: { source?: string; line?: number; column?: number }) {
+  fire(`${MARKETING_API}/analytics/error`, {
+    message: typeof message === 'string' ? message.slice(0, 2000) : String(message).slice(0, 2000),
+    source: opts?.source?.slice(0, 500),
+    line: opts?.line,
+    column: opts?.column,
+    app: APP,
+    route: typeof window !== 'undefined' ? window.location.pathname : '',
+    user_agent: navigator.userAgent?.slice(0, 500),
+  })
+}
+
+/** Install global JS error handlers (window.onerror + unhandledrejection). */
+export function installErrorBeacon() {
+  if (typeof window === 'undefined') return
+
+  const originalError = window.onerror
+  window.onerror = function (message, source, line, column, error) {
+    reportError(
+      error?.message || String(message),
+      { source, line, column },
+    )
+    return originalError?.(message, source, line, column, error) ?? false
+  }
+
+  window.addEventListener('unhandledrejection', (e) => {
+    reportError(e.reason?.message || String(e.reason))
+  })
+}

--- a/marketing/marketing-ui/src/main.tsx
+++ b/marketing/marketing-ui/src/main.tsx
@@ -5,23 +5,16 @@ import App from './App.tsx'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import { ReportBug } from './components/ReportBug'
 import { Button } from './components/ui/button'
+import { trackPageview, installErrorBeacon } from './lib/analytics'
 import './index.css'
 
-const MARKETING_API = (typeof window !== 'undefined' && new URLSearchParams(window.location.search).get('marketing_api')) ||
-  (import.meta.env?.VITE_MARKETING_API || 'http://marketing-api.localhost')
+// Install JS error beacon (window.onerror + unhandledrejection)
+installErrorBeacon()
 
 function AnalyticsTracker() {
   const location = useLocation()
   useEffect(() => {
-    fetch(`${MARKETING_API}/analytics/pageview`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        path: location.pathname,
-        referrer: document.referrer || null,
-        user_agent: navigator.userAgent,
-      }),
-    }).catch(() => {})
+    trackPageview(location.pathname)
   }, [location.pathname])
   return null
 }

--- a/marketing/marketing-ui/src/pages/AppStore.tsx
+++ b/marketing/marketing-ui/src/pages/AppStore.tsx
@@ -3,6 +3,7 @@ import { Users, LayoutDashboard, BookOpen, Terminal, ArrowUpRight, Boxes, Globe 
 import { Card, CardHeader, CardTitle, CardDescription, CardFooter, CardContent } from '../components/ui/card'
 import { Badge } from '../components/ui/badge'
 import { Button } from '../components/ui/button'
+import { trackFunnel } from '../lib/analytics'
 
 // The node API that holds the live app registry + member count. Overridable
 // via ?api= or VITE_API_URL; *.localhost hosts default to the local node.
@@ -114,6 +115,10 @@ function resolveIcon(appUrl: string, iconSrc: string): string {
 function AppStore() {
   const [stats, setStats] = useState<Stats | null>(null)
   const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    trackFunnel('app_store_view')
+  }, [])
 
   useEffect(() => {
     let alive = true

--- a/marketing/marketing-ui/src/pages/Docs.tsx
+++ b/marketing/marketing-ui/src/pages/Docs.tsx
@@ -3,6 +3,7 @@ import { useParams, Link, useLocation } from 'react-router-dom'
 import { remark } from 'remark'
 import remarkHtml from 'remark-html'
 import { FileText, Code, Terminal, ExternalLink } from 'lucide-react'
+import { trackFunnel } from '../lib/analytics'
 
 const DOC_PAGES = [
   { slug: 'protocol-spec', title: 'Protocol Spec', file: '/docs/protocol-spec.md' },
@@ -122,6 +123,9 @@ function DocsContent() {
 }
 
 function Docs() {
+  useEffect(() => {
+    trackFunnel('docs_view')
+  }, [])
   return (
     <div className="min-h-screen bg-background text-foreground">
       <div className="mx-auto flex max-w-6xl flex-col md:flex-row">

--- a/marketing/marketing-ui/src/pages/Exporter.tsx
+++ b/marketing/marketing-ui/src/pages/Exporter.tsx
@@ -1,8 +1,9 @@
-import { useState, useCallback, useRef } from 'react'
+import { useState, useCallback, useRef, useEffect } from 'react'
 import { ArrowLeft, Camera, Users, Video, UploadCloud, CheckCircle2, AlertTriangle } from 'lucide-react'
 import { Button } from '../components/ui/button'
 import { Input } from '../components/ui/input'
 import { Card } from '../components/ui/card'
+import { trackFunnel } from '../lib/analytics'
 
 const API_URL = (typeof window !== 'undefined' && new URLSearchParams(window.location.search).get('api')) ||
   ((import.meta as any).env?.VITE_API_URL || 'https://api.web10.app')
@@ -34,14 +35,6 @@ const PLATFORMS: Array<{ key: Platform; label: string; icon: typeof Camera; colo
   { key: 'youtube', label: 'YouTube', icon: Video, color: '#FF0000' },
 ]
 
-function track(event: string) {
-  fetch(`${MARKETING_API}/analytics/funnel`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ event, metadata: {} }),
-  }).catch(() => {})
-}
-
 export function Exporter() {
   const [selectedPlatform, setSelectedPlatform] = useState<Platform | null>(null)
   const [progress, setProgress] = useState<ImportProgress | null>(null)
@@ -56,6 +49,11 @@ export function Exporter() {
   const fileInputRef = useRef<HTMLInputElement>(null)
   const pollRef = useRef<number | null>(null)
 
+  // Track exporter_view once on mount (fix: was firing on every render)
+  useEffect(() => {
+    trackFunnel('exporter_view')
+  }, [])
+
   // Check if user has a web10 token (from wapi if loaded)
   const handleSignIn = useCallback(() => {
     const token = prompt('Enter your web10 JWT token:')
@@ -68,7 +66,7 @@ export function Exporter() {
       } catch {
         setUsername('user')
       }
-      track('sign_in_click')
+      trackFunnel('sign_in_click')
     }
   }, [])
 
@@ -78,7 +76,7 @@ export function Exporter() {
     setChecklistDone(false)
     setProgress(null)
     setJobId(null)
-    track(`${platform}_view`)
+    trackFunnel('exporter_view', { platform })
   }, [])
 
   const startPolling = useCallback((jid: string) => {
@@ -89,7 +87,7 @@ export function Exporter() {
         setProgress(data)
         if (data.phase === 'complete' || data.phase === 'error') {
           if (pollRef.current) clearInterval(pollRef.current)
-          if (data.phase === 'complete') track('export_complete')
+          if (data.phase === 'complete') trackFunnel('export_complete')
         }
       } catch {
         // keep polling
@@ -131,7 +129,7 @@ export function Exporter() {
       const jobData = await createRes.json()
       const jid = jobData.id
       setJobId(jid)
-      track('export_started')
+      trackFunnel('export_started')
 
       // Upload ZIP
       const formData = new FormData()
@@ -201,8 +199,6 @@ export function Exporter() {
   }, [])
 
   const selected = PLATFORMS.find(p => p.key === selectedPlatform)
-
-  track('exporter_view')
 
   return (
     <div className="mx-auto min-h-screen max-w-2xl px-4 pt-12 pb-24 text-foreground sm:px-6">

--- a/marketing/marketing-ui/src/pages/Home.tsx
+++ b/marketing/marketing-ui/src/pages/Home.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useCallback } from 'react'
 import { Send, Inbox, ShieldCheck } from 'lucide-react'
 import { Button } from '../components/ui/button'
 import { Card, CardHeader, CardTitle, CardDescription } from '../components/ui/card'
@@ -7,6 +8,7 @@ import {
   deliveryPercent,
   formatFollowerCount,
 } from '../lib/reachGap'
+import { trackFunnel } from '../lib/analytics'
 
 function Hero() {
   return (
@@ -175,6 +177,9 @@ function Footer() {
 }
 
 function Home() {
+  useEffect(() => {
+    trackFunnel('landing')
+  }, [])
   return (
     <>
       <Hero />

--- a/marketing/marketing-ui/src/pages/Trending.tsx
+++ b/marketing/marketing-ui/src/pages/Trending.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { Zap } from 'lucide-react';
 import { PostCard, SkeletonCard, fetchDiscoverFeed, mapDiscoveryToFeedPost, formatCount, parseCount } from '../components/FeedPreview';
 import type { FeedPost } from '../components/FeedPreview';
+import { trackFunnel } from '../lib/analytics';
 
 function Trending() {
   const [posts, setPosts] = useState<FeedPost[]>([]);
@@ -21,6 +22,7 @@ function Trending() {
 
   useEffect(() => {
     loadFeed();
+    trackFunnel('trending_view');
   }, [loadFeed]);
 
   const handleReaction = async (postId: string, type: 'like' | 'comment' | 'repost') => {


### PR DESCRIPTION
Full acquisition funnel analytics and JS error beacon for marketing-ui.

**marketing-api:**
- New `POST /analytics/error` endpoint for content-free JS error beacons (no PII, no content)
- Extended `FunnelEvent` enum: trending_view, sign_up_click, github_click, enter_click
- `GET /analytics/summary` now returns per-step funnel drop-off percentages and total_errors
- 7 new tests (17 total green)

**marketing-ui:**
- Centralized `lib/analytics.ts` module (trackPageview, trackFunnel, reportError, installErrorBeacon)
- Funnel events on all pages: landing, docs_view, app_store_view, trending_view
- Exporter track-on-render bug fixed (was firing every render; now useEffect)
- Navbar sign_in_click + github_click tracking
- JS error beacon at startup (window.onerror + unhandledrejection)
- 9 new analytics tests (33 total green)

Privacy split: marketing-ui gets full tracking (pre-signup). ui/ beacon is lane B's separate task (content-free aggregate only, no session recording — manifesto line).