### PR TITLE
fix: marketing-ui AppStore SVG className build error

### DIFF
--- a/marketing/marketing-ui/src/pages/AppStore.tsx
+++ b/marketing/marketing-ui/src/pages/AppStore.tsx
@@ -265,7 +265,7 @@ function AppStore() {
                           const parent = e.currentTarget.parentElement
                           if (parent) {
                             const fallback = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
-fallback.className = 'h-5 w-5 text-muted-foreground'
+fallback.setAttribute('class', 'h-5 w-5 text-muted-foreground')
                             fallback.setAttribute('strokeWidth', '1.5')
                             fallback.setAttribute('fill', 'none')
                             fallback.setAttribute('stroke', 'currentColor')


### PR DESCRIPTION
The 1.0.88 fix for SVG className assignment (setAttribute instead of direct assignment) never merged to dev. Every push-to-deploy has been failing with TS2540 on AppStore.tsx:268.