### PR TITLE
Split npm publish into web10-npm and web10-cli jobs

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -71,15 +71,14 @@ jobs:
           cache-to: type=gha,mode=max
           platforms: linux/amd64
 
-  npm:
-    name: publish npm
+  npm-publish-web10-npm:
+    name: publish web10-npm
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: startsWith(github.ref, 'refs/tags/v')
     needs: images
     permissions:
       contents: read
-      packages: write
       id-token: write
     defaults:
       run:
@@ -91,11 +90,9 @@ jobs:
         with:
           bun-version: latest
 
-      - name: Setup npm provenance
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: lts/*
-          registry-url: 'https://registry.npmjs.org'
 
       - name: bun install
         run: bun install --frozen-lockfile
@@ -105,15 +102,42 @@ jobs:
 
       - name: publish to npm
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  npm-publish-web10-cli:
+    name: publish web10-cli
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: images
+    permissions:
+      contents: read
+      id-token: write
+    defaults:
+      run:
+        working-directory: marketing/web10-cli
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - name: bun install
+        run: bun install --frozen-lockfile
+
+      - name: publish to npm
+        run: npm publish --provenance --access public
 
   release:
     name: github release
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [images, npm]
+    needs: [images, npm-publish-web10-npm, npm-publish-web10-cli]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Splits the single npm publish job into two independent jobs: one for `web10-npm` (sdk/) and one for `web10-cli` (marketing/web10-cli/). This allows each package to publish with its own working directory and permissions. Switches to OIDC-based provenance (`id-token: write`), removing the need for `NODE_AUTH_TOKEN` and `packages: write`. The release job now depends on both publish jobs.