### PR TITLE
CD: trusted publisher for web10-npm + web10-cli; deploy status commit message

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -71,15 +71,14 @@ jobs:
           cache-to: type=gha,mode=max
           platforms: linux/amd64
 
-  npm:
-    name: publish npm
+  npm-publish-web10-npm:
+    name: publish web10-npm
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: startsWith(github.ref, 'refs/tags/v')
     needs: images
     permissions:
       contents: read
-      packages: write
       id-token: write
     defaults:
       run:
@@ -91,11 +90,9 @@ jobs:
         with:
           bun-version: latest
 
-      - name: Setup npm provenance
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: lts/*
-          registry-url: 'https://registry.npmjs.org'
 
       - name: bun install
         run: bun install --frozen-lockfile
@@ -105,15 +102,42 @@ jobs:
 
       - name: publish to npm
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  npm-publish-web10-cli:
+    name: publish web10-cli
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: images
+    permissions:
+      contents: read
+      id-token: write
+    defaults:
+      run:
+        working-directory: marketing/web10-cli
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - name: bun install
+        run: bun install --frozen-lockfile
+
+      - name: publish to npm
+        run: npm publish --provenance --access public
 
   release:
     name: github release
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [images, npm]
+    needs: [images, npm-publish-web10-npm, npm-publish-web10-cli]
     steps:
       - uses: actions/checkout@v4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+1.0.106 || 22.07.2026
+CD: split npm publish into separate web10-npm (sdk/) and web10-cli (marketing/web10-cli/) jobs. Switched to OIDC provenance (id-token: write), removing NODE_AUTH_TOKEN and packages: write. Release job now depends on both publish jobs.
 1.0.105 || 22.07.2026
 SDK compat shim: re-exports `wapiInit` and `wapiAuthInit` from the new typed SDK so legacy consumers (ui/, web10-social/) don't break. Both apps now resolve `web10-npm` from the local SDK and build clean. 55 SDK tests green.
 1.0.104 || 22.07.2026


### PR DESCRIPTION
Split npm publish into separate `web10-npm` (sdk/) and `web10-cli` (marketing/web10-cli/) jobs. Switched to OIDC provenance (`id-token: write`), removing the `NPM_TOKEN` secret and `packages: write` permission. Release job now depends on both publish jobs.

Also: deploy status page now shows the commit message (not just the SHA) — visible on hover in the marketing-ui DeployStatus component, and in the static status page HTML.

**Changes:**
- `.github/workflows/cd.yml` — split npm publish, OIDC provenance, job IDs match npm trusted publisher requirement (`npm-publish-<package-name>`)
- `marketing/marketing-ui/build-status.sh` — adds `commitTitle` to status.json + static page
- `marketing/marketing-ui/src/components/DeployStatus.tsx` — shows commit title on hover
- `CHANGELOG.md` — 1.0.106 entry