### PR TITLE
fix: open CORS to all origins; keep CORS_SERVICE_MANAGERS as the auth trust list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+1.0.107 || 23.07.2026
+CORS: API now allows all browser origins (`allow_origins=["*"]`, credentials off). The security boundary is the scoped token in each request body (certify + is_permitted + per-service ACL), not the browser origin — web10 apps are stateless frontends anyone can build and host anywhere, so an origin allow-list only broke legitimate apps (social, marketing) without adding security. Removed the short-lived `CORS_ALLOW_ORIGINS` setting/env wiring. `CORS_SERVICE_MANAGERS` stays as the real trust list: authenticator hosts (auth.*) that may handle consent and mint tokens for other apps — narrowed to auth-only, which also closes a latent privilege path (a service-manager site bypasses the cross-origin ACL in is_permitted). 353 API tests green.
 1.0.106 || 22.07.2026
 CD: split npm publish into separate web10-npm (sdk/) and web10-cli (marketing/web10-cli/) jobs. Switched to OIDC provenance (id-token: write), removing NODE_AUTH_TOKEN and packages: write. Release job now depends on both publish jobs.
 1.0.105 || 22.07.2026

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -20,22 +20,16 @@ app = FastAPI(
 )
 
 
-def _cors_origins():
-    """Build allow-listed CORS origins from settings."""
-    origins = set()
-    for host in settings.CORS_ALLOW_ORIGINS:
-        origins.add(f"http://{host}")
-        origins.add(f"https://{host}")
-    # The API itself may serve the UI or OpenAPI docs
-    origins.add(f"http://{settings.PROVIDER}")
-    origins.add(f"https://{settings.PROVIDER}")
-    return list(origins)
-
-
+# CORS is intentionally wide open. The API's security boundary is the
+# scoped, expiring token in each request body (certify + is_permitted +
+# the per-service ACL), NOT the browser origin. web10 apps are stateless
+# frontends anyone can build and host anywhere, so gatekeeping origins
+# would only break legitimate apps without adding security. The token
+# never rides on a browser cookie (the SDK sends it in the request body),
+# so we don't need — and deliberately don't enable — credentialed CORS.
 app.add_middleware(
     CORSMiddleware,
-    allow_credentials=True,
-    allow_origins=_cors_origins(),
+    allow_origins=["*"],
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -8,7 +8,6 @@ from fastapi.responses import JSONResponse
 
 import app.docs as docs
 import app.exceptions as exceptions
-import app.settings as settings
 from app.endpoints import auth, crud, discover, media, payments, public, schemas, system
 
 app = FastAPI(

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -23,7 +23,7 @@ app = FastAPI(
 def _cors_origins():
     """Build allow-listed CORS origins from settings."""
     origins = set()
-    for host in settings.CORS_SERVICE_MANAGERS:
+    for host in settings.CORS_ALLOW_ORIGINS:
         origins.add(f"http://{host}")
         origins.add(f"https://{host}")
     # The API itself may serve the UI or OpenAPI docs

--- a/api/app/settings.py
+++ b/api/app/settings.py
@@ -10,6 +10,20 @@ CORS_SERVICE_MANAGERS = """
     auth.web10.app,
     auth.dev.web10.app
 """
+# Browser origins allowed to call the API via CORS. This is NOT the
+# authenticator list (that is CORS_SERVICE_MANAGERS) — every frontend
+# that fetches from the API in a browser needs to be here.
+CORS_ALLOW_ORIGINS = """
+    auth.localhost,
+    auth.web10.app,
+    auth.dev.web10.app,
+    social.localhost,
+    social.web10.app,
+    social.dev.web10.app,
+    www.localhost,
+    www.web10.app,
+    www.dev.web10.app
+"""
 DB = "testing"
 DB_URL = "mongodb+srv://web10:jSol....."
 # Usernames that may read/write the node config when no admins list has been
@@ -61,6 +75,7 @@ for v in list(globals()):
 
 # Initiate some quality of life variables around the config.
 CORS_SERVICE_MANAGERS = [site.strip() for site in CORS_SERVICE_MANAGERS.split(",")]
+CORS_ALLOW_ORIGINS = [site.strip() for site in CORS_ALLOW_ORIGINS.split(",")]
 COST = {}
 COST["create"] = COST_CREATE
 COST["read"] = COST_READ

--- a/api/app/settings.py
+++ b/api/app/settings.py
@@ -5,24 +5,14 @@ import os
 #################################
 
 PROVIDER = "api.localhost"
+# The authenticator trust list: sites that may handle consent and mint
+# tokens for other apps (see services/auth.py). This is a real trust
+# boundary and must stay narrow — authenticators only, never all frontends.
+# Browser CORS is handled separately in main.py (wide open by design).
 CORS_SERVICE_MANAGERS = """
     auth.localhost,
     auth.web10.app,
     auth.dev.web10.app
-"""
-# Browser origins allowed to call the API via CORS. This is NOT the
-# authenticator list (that is CORS_SERVICE_MANAGERS) — every frontend
-# that fetches from the API in a browser needs to be here.
-CORS_ALLOW_ORIGINS = """
-    auth.localhost,
-    auth.web10.app,
-    auth.dev.web10.app,
-    social.localhost,
-    social.web10.app,
-    social.dev.web10.app,
-    www.localhost,
-    www.web10.app,
-    www.dev.web10.app
 """
 DB = "testing"
 DB_URL = "mongodb+srv://web10:jSol....."
@@ -75,7 +65,6 @@ for v in list(globals()):
 
 # Initiate some quality of life variables around the config.
 CORS_SERVICE_MANAGERS = [site.strip() for site in CORS_SERVICE_MANAGERS.split(",")]
-CORS_ALLOW_ORIGINS = [site.strip() for site in CORS_ALLOW_ORIGINS.split(",")]
 COST = {}
 COST["create"] = COST_CREATE
 COST["read"] = COST_READ

--- a/ubuntu-deployment/docker-compose.ecosystem.yml
+++ b/ubuntu-deployment/docker-compose.ecosystem.yml
@@ -106,7 +106,8 @@ services:
       S3_ENDPOINT: http://${STACK}-minio:9000
       S3_ACCESS_KEY: minioadmin
       S3_SECRET_KEY: ${MINIO_PASSWORD}
-      CORS_SERVICE_MANAGERS: ${CORS_SERVICE_MANAGERS:?comma-separated auth/social/marketing hosts}
+      CORS_ALLOW_ORIGINS: ${CORS_ALLOW_ORIGINS:?comma-separated browser origins for CORS}
+      CORS_SERVICE_MANAGERS: ${CORS_SERVICE_MANAGERS:?authenticator hosts only}
     command: ["uv", "run", "gunicorn", "-b", "0.0.0.0:80", "-w", "4", "-k", "uvicorn.workers.UvicornWorker", "app.main:app"]
     restart: unless-stopped
     networks:

--- a/ubuntu-deployment/docker-compose.ecosystem.yml
+++ b/ubuntu-deployment/docker-compose.ecosystem.yml
@@ -106,7 +106,6 @@ services:
       S3_ENDPOINT: http://${STACK}-minio:9000
       S3_ACCESS_KEY: minioadmin
       S3_SECRET_KEY: ${MINIO_PASSWORD}
-      CORS_ALLOW_ORIGINS: ${CORS_ALLOW_ORIGINS:?comma-separated browser origins for CORS}
       CORS_SERVICE_MANAGERS: ${CORS_SERVICE_MANAGERS:?authenticator hosts only}
     command: ["uv", "run", "gunicorn", "-b", "0.0.0.0:80", "-w", "4", "-k", "uvicorn.workers.UvicornWorker", "app.main:app"]
     restart: unless-stopped

--- a/ubuntu-deployment/env.dev.example
+++ b/ubuntu-deployment/env.dev.example
@@ -24,9 +24,8 @@ RTC_ORIGIN=https://rtc.dev.web10.app
 MINIO_HOST=minio.dev.web10.app
 MARKETING_API_ORIGIN=https://marketing-api.dev.web10.app
 
-# CORS: every browser origin that calls the api
-CORS_ALLOW_ORIGINS=auth.dev.web10.app,social.dev.web10.app,www.dev.web10.app
-# Authenticators only (NOT all frontends — that is CORS_ALLOW_ORIGINS)
+# Authenticator hosts only — sites allowed to handle consent and mint
+# tokens (NOT a browser CORS list; CORS is wide open by design).
 CORS_SERVICE_MANAGERS=auth.dev.web10.app
 
 # secrets — generate fresh, never reuse across envs

--- a/ubuntu-deployment/env.dev.example
+++ b/ubuntu-deployment/env.dev.example
@@ -25,7 +25,9 @@ MINIO_HOST=minio.dev.web10.app
 MARKETING_API_ORIGIN=https://marketing-api.dev.web10.app
 
 # CORS: every browser origin that calls the api
-CORS_SERVICE_MANAGERS=auth.dev.web10.app,social.dev.web10.app,www.dev.web10.app
+CORS_ALLOW_ORIGINS=auth.dev.web10.app,social.dev.web10.app,www.dev.web10.app
+# Authenticators only (NOT all frontends — that is CORS_ALLOW_ORIGINS)
+CORS_SERVICE_MANAGERS=auth.dev.web10.app
 
 # secrets — generate fresh, never reuse across envs
 MINIO_PASSWORD=

--- a/ubuntu-deployment/env.prod.example
+++ b/ubuntu-deployment/env.prod.example
@@ -31,7 +31,9 @@ MINIO_HOST=minio.web10.app
 MARKETING_API_ORIGIN=https://marketing-api.web10.app
 
 # CORS: every browser origin that calls the api
-CORS_SERVICE_MANAGERS=auth.web10.app,social.web10.app,www.web10.app,web10.app
+CORS_ALLOW_ORIGINS=auth.web10.app,social.web10.app,www.web10.app,web10.app
+# Authenticators only (NOT all frontends — that is CORS_ALLOW_ORIGINS)
+CORS_SERVICE_MANAGERS=auth.web10.app
 
 # secrets — generate fresh, never reuse across envs
 MINIO_PASSWORD=

--- a/ubuntu-deployment/env.prod.example
+++ b/ubuntu-deployment/env.prod.example
@@ -30,9 +30,8 @@ RTC_ORIGIN=https://rtc.web10.app
 MINIO_HOST=minio.web10.app
 MARKETING_API_ORIGIN=https://marketing-api.web10.app
 
-# CORS: every browser origin that calls the api
-CORS_ALLOW_ORIGINS=auth.web10.app,social.web10.app,www.web10.app,web10.app
-# Authenticators only (NOT all frontends — that is CORS_ALLOW_ORIGINS)
+# Authenticator hosts only — sites allowed to handle consent and mint
+# tokens (NOT a browser CORS list; CORS is wide open by design).
 CORS_SERVICE_MANAGERS=auth.web10.app
 
 # secrets — generate fresh, never reuse across envs

--- a/ubuntu-deployment/scripts/deploy-stacks.py
+++ b/ubuntu-deployment/scripts/deploy-stacks.py
@@ -73,8 +73,7 @@ def env_for(stack):
                  API_ORIGIN="https://api.dev.web10.app", API_HOST="api.dev.web10.app",
                  AUTH_ORIGIN="https://auth.dev.web10.app", RTC_ORIGIN="https://rtc.dev.web10.app",
                  MINIO_HOST="minio.dev.web10.app", MARKETING_API_ORIGIN="https://marketing-api.dev.web10.app",
-                 CORS_ALLOW_ORIGINS="auth.dev.web10.app,social.dev.web10.app,www.dev.web10.app",
-                  CORS_SERVICE_MANAGERS="auth.dev.web10.app",
+                 CORS_SERVICE_MANAGERS="auth.dev.web10.app",
                  MINIO_PASSWORD=cfg["MINIO_PASSWORD_DEV"])
     else:
         d = dict(STACK="web10-prod", PROVIDER="api.web10.app",
@@ -82,8 +81,7 @@ def env_for(stack):
                  API_ORIGIN="https://api.web10.app", API_HOST="api.web10.app",
                  AUTH_ORIGIN="https://auth.web10.app", RTC_ORIGIN="https://rtc.web10.app",
                  MINIO_HOST="minio.web10.app", MARKETING_API_ORIGIN="https://marketing-api.web10.app",
-                 CORS_ALLOW_ORIGINS="auth.web10.app,social.web10.app,www.web10.app,web10.app",
-                  CORS_SERVICE_MANAGERS="auth.web10.app",
+                 CORS_SERVICE_MANAGERS="auth.web10.app",
                  MINIO_PASSWORD=cfg["MINIO_PASSWORD_PROD"])
     return [{"name": k, "value": v} for k, v in d.items()]
 

--- a/ubuntu-deployment/scripts/deploy-stacks.py
+++ b/ubuntu-deployment/scripts/deploy-stacks.py
@@ -73,7 +73,8 @@ def env_for(stack):
                  API_ORIGIN="https://api.dev.web10.app", API_HOST="api.dev.web10.app",
                  AUTH_ORIGIN="https://auth.dev.web10.app", RTC_ORIGIN="https://rtc.dev.web10.app",
                  MINIO_HOST="minio.dev.web10.app", MARKETING_API_ORIGIN="https://marketing-api.dev.web10.app",
-                 CORS_SERVICE_MANAGERS="auth.dev.web10.app,social.dev.web10.app,www.dev.web10.app",
+                 CORS_ALLOW_ORIGINS="auth.dev.web10.app,social.dev.web10.app,www.dev.web10.app",
+                  CORS_SERVICE_MANAGERS="auth.dev.web10.app",
                  MINIO_PASSWORD=cfg["MINIO_PASSWORD_DEV"])
     else:
         d = dict(STACK="web10-prod", PROVIDER="api.web10.app",
@@ -81,7 +82,8 @@ def env_for(stack):
                  API_ORIGIN="https://api.web10.app", API_HOST="api.web10.app",
                  AUTH_ORIGIN="https://auth.web10.app", RTC_ORIGIN="https://rtc.web10.app",
                  MINIO_HOST="minio.web10.app", MARKETING_API_ORIGIN="https://marketing-api.web10.app",
-                 CORS_SERVICE_MANAGERS="auth.web10.app,social.web10.app,www.web10.app,web10.app",
+                 CORS_ALLOW_ORIGINS="auth.web10.app,social.web10.app,www.web10.app,web10.app",
+                  CORS_SERVICE_MANAGERS="auth.web10.app",
                  MINIO_PASSWORD=cfg["MINIO_PASSWORD_PROD"])
     return [{"name": k, "value": v} for k, v in d.items()]
 


### PR DESCRIPTION
## Problem
`CORS_SERVICE_MANAGERS` was doing double duty: the authenticator trust list **and** the browser CORS allow-list. Conflating them blocked every frontend that wasn't hand-listed (social, marketing, any third-party app) — while also granting authenticator-level trust to any host on the list.

## Fix
CORS is **not** web10's security boundary — the scoped token in each request body is (`certify` → `is_permitted` → per-service ACL). web10 apps are stateless frontends anyone can build and host anywhere, so an origin allow-list only blocks legitimate apps without adding security.

- **`main.py`**: `allow_origins=["*"]`, credentials off. The SDK sends the token in the request **body** (never a browser cookie / `credentials:'include'`), so credentialed CORS isn't needed — the clean wildcard, not the `*`+credentials combo browsers reject.
- **`settings.py`**: removed the short-lived `CORS_ALLOW_ORIGINS`. `CORS_SERVICE_MANAGERS` stays as the **real** trust list — authenticator hosts (`auth.*`) that may handle consent and mint tokens for other apps. Narrowing it to auth-only also closes a latent privilege path: a service-manager site bypasses the cross-origin ACL in `is_permitted`.
- **Deployment**: dropped `CORS_ALLOW_ORIGINS` from `docker-compose.ecosystem.yml`, both `env.*.example`, and `deploy-stacks.py`.

## Verification
353 API tests green.

## History
First commit split the two settings (kept a curated allow-list); the follow-up opens CORS entirely, since gatekeeping browser origins was the actual problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)