### PR TITLE
fix: headline -> "Your audience, actually"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+1.0.108 || 23.07.2026
+Copy: "Own your audience" → "Your audience, actually" in all user-facing surfaces (marketing-ui hero + meta, web10-social login + meta, design.md voice example). "Own your audience" implied ownership of people; the new copy keeps "audience" but frames the claim as about the real relationship — no algorithm in the middle deciding who sees your stuff.
 1.0.107 || 23.07.2026
 CORS: API now allows all browser origins (`allow_origins=["*"]`, credentials off). The security boundary is the scoped token in each request body (certify + is_permitted + per-service ACL), not the browser origin — web10 apps are stateless frontends anyone can build and host anywhere, so an origin allow-list only broke legitimate apps (social, marketing) without adding security. Removed the short-lived `CORS_ALLOW_ORIGINS` setting/env wiring. `CORS_SERVICE_MANAGERS` stays as the real trust list: authenticator hosts (auth.*) that may handle consent and mint tokens for other apps — narrowed to auth-only, which also closes a latent privilege path (a service-manager site bypasses the cross-origin ACL in is_permitted). 353 API tests green.
 1.0.106 || 22.07.2026

--- a/design.md
+++ b/design.md
@@ -73,7 +73,7 @@ self-possession. The brand is confident and quiet; it never begs.
 - **Voice.** Declarative, restrained, no gush. The fan-facing voice
   lives in `manifesto.md`, the creator pitch in `outreach.md` — match
   them. Never claim what isn't built. Headlines state facts:
-  "Own your audience." beats "Unlock the future of social!!"
+  "Own your connections." beats "Unlock the future of social!!"
 - **Never fake it.** No stock photos of smiling people, no invented
   testimonials, no logos of companies that don't use us. Real
   screenshots, real numbers, real mechanics (the reach-gap chart is

--- a/design.md
+++ b/design.md
@@ -73,7 +73,7 @@ self-possession. The brand is confident and quiet; it never begs.
 - **Voice.** Declarative, restrained, no gush. The fan-facing voice
   lives in `manifesto.md`, the creator pitch in `outreach.md` — match
   them. Never claim what isn't built. Headlines state facts:
-  "Own your connections." beats "Unlock the future of social!!"
+  "Your audience, actually." beats "Unlock the future of social!!"
 - **Never fake it.** No stock photos of smiling people, no invented
   testimonials, no logos of companies that don't use us. Real
   screenshots, real numbers, real mechanics (the reach-gap chart is

--- a/marketing/marketing-ui/index.html
+++ b/marketing/marketing-ui/index.html
@@ -8,8 +8,8 @@
     <link rel="apple-touch-icon" href="/brand/apple-touch-icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#09090b" />
-    <meta name="description" content="web10 — own your audience. A creator's node, not a platform: every post reaches every follower, by architecture." />
-    <meta property="og:title" content="web10 — own your audience" />
+    <meta name="description" content="web10 — own your connections. A creator's node, not a platform: every post reaches every follower, by architecture." />
+    <meta property="og:title" content="web10 — own your connections" />
     <meta property="og:description" content="Every post reaches every follower. Not a promise the algorithm can revoke — an architecture that can't." />
     <meta property="og:image" content="/brand/og-image.png" />
     <title>web10</title>

--- a/marketing/marketing-ui/index.html
+++ b/marketing/marketing-ui/index.html
@@ -8,8 +8,8 @@
     <link rel="apple-touch-icon" href="/brand/apple-touch-icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#09090b" />
-    <meta name="description" content="web10 — own your connections. A creator's node, not a platform: every post reaches every follower, by architecture." />
-    <meta property="og:title" content="web10 — own your connections" />
+    <meta name="description" content="web10 — your audience, actually. A creator's node, not a platform: every post reaches every follower, by architecture." />
+    <meta property="og:title" content="web10 — your audience, actually" />
     <meta property="og:description" content="Every post reaches every follower. Not a promise the algorithm can revoke — an architecture that can't." />
     <meta property="og:image" content="/brand/og-image.png" />
     <title>web10</title>

--- a/marketing/marketing-ui/src/pages/Home.tsx
+++ b/marketing/marketing-ui/src/pages/Home.tsx
@@ -28,7 +28,7 @@ function Hero() {
           className="reveal mb-8 h-10 [animation-delay:80ms] sm:h-12"
         />
         <h1 className="reveal font-display text-4xl font-bold leading-[1.1] tracking-[-0.02em] [animation-delay:160ms] sm:text-5xl lg:text-[3.5rem]">
-          Own your connections.
+          Your audience, actually.
         </h1>
         <p className="reveal mt-6 max-w-xl text-lg leading-[1.6] text-muted-foreground [animation-delay:240ms]">
           Every post reaches every follower. Not a promise the algorithm can

--- a/marketing/marketing-ui/src/pages/Home.tsx
+++ b/marketing/marketing-ui/src/pages/Home.tsx
@@ -28,7 +28,7 @@ function Hero() {
           className="reveal mb-8 h-10 [animation-delay:80ms] sm:h-12"
         />
         <h1 className="reveal font-display text-4xl font-bold leading-[1.1] tracking-[-0.02em] [animation-delay:160ms] sm:text-5xl lg:text-[3.5rem]">
-          Own your audience.
+          Own your connections.
         </h1>
         <p className="reveal mt-6 max-w-xl text-lg leading-[1.6] text-muted-foreground [animation-delay:240ms]">
           Every post reaches every follower. Not a promise the algorithm can

--- a/marketing/web10-social/index.html
+++ b/marketing/web10-social/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#09090b" />
-    <meta name="description" content="web10 social — own your connections, no shadow ban. 100% delivery by architecture." />
+    <meta name="description" content="web10 social — your audience, actually. No shadow ban. 100% delivery by architecture." />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <link rel="manifest" href="/manifest.json" />
     <title>web10 social</title>

--- a/marketing/web10-social/index.html
+++ b/marketing/web10-social/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#09090b" />
-    <meta name="description" content="web10 social — own your audience, no shadow ban. 100% delivery by architecture." />
+    <meta name="description" content="web10 social — own your connections, no shadow ban. 100% delivery by architecture." />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <link rel="manifest" href="/manifest.json" />
     <title>web10 social</title>

--- a/marketing/web10-social/src/App.tsx
+++ b/marketing/web10-social/src/App.tsx
@@ -42,7 +42,7 @@ function LoginScreen({ onLogin }: { onLogin: () => void }) {
           <h1 className="font-display text-4xl font-bold tracking-tight text-foreground">
             web<span className="text-brand">10</span>
           </h1>
-          <p className="text-muted-foreground">Own your connections. No shadow ban.</p>
+          <p className="text-muted-foreground">Your audience, actually. No shadow ban.</p>
         </div>
         <Button
           variant="brand"

--- a/marketing/web10-social/src/App.tsx
+++ b/marketing/web10-social/src/App.tsx
@@ -42,7 +42,7 @@ function LoginScreen({ onLogin }: { onLogin: () => void }) {
           <h1 className="font-display text-4xl font-bold tracking-tight text-foreground">
             web<span className="text-brand">10</span>
           </h1>
-          <p className="text-muted-foreground">Own your audience. No shadow ban.</p>
+          <p className="text-muted-foreground">Own your connections. No shadow ban.</p>
         </div>
         <Button
           variant="brand"


### PR DESCRIPTION
Changed the headline copy from "Own your audience" to "Your audience, actually." across all user-facing surfaces:

- marketing-ui hero headline
- marketing-ui meta description + OG title
- web10-social login screen subtitle
- web10-social meta description
- design.md voice example

"Own your audience" implied ownership of people. "Your audience, actually" keeps the word "audience" but frames the claim as about the real relationship — no algorithm in the middle deciding who sees your stuff.