### PR TITLE
fix: clean up 'your audience' copy

### DIFF
--- a/design.md
+++ b/design.md
@@ -73,7 +73,7 @@ self-possession. The brand is confident and quiet; it never begs.
 - **Voice.** Declarative, restrained, no gush. The fan-facing voice
   lives in `manifesto.md`, the creator pitch in `outreach.md` — match
   them. Never claim what isn't built. Headlines state facts:
-  "Your audience, actually." beats "Unlock the future of social!!"
+  Your audience. beats "Unlock the future of social!!"
 - **Never fake it.** No stock photos of smiling people, no invented
   testimonials, no logos of companies that don't use us. Real
   screenshots, real numbers, real mechanics (the reach-gap chart is

--- a/marketing/marketing-ui/index.html
+++ b/marketing/marketing-ui/index.html
@@ -8,8 +8,8 @@
     <link rel="apple-touch-icon" href="/brand/apple-touch-icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#09090b" />
-    <meta name="description" content="web10 — your audience, actually. A creator's node, not a platform: every post reaches every follower, by architecture." />
-    <meta property="og:title" content="web10 — your audience, actually" />
+    <meta name="description" content="web10 — your audience. A creator's node, not a platform: every post reaches every follower, by architecture." />
+    <meta property="og:title" content="web10 — your audience" />
     <meta property="og:description" content="Every post reaches every follower. Not a promise the algorithm can revoke — an architecture that can't." />
     <meta property="og:image" content="/brand/og-image.png" />
     <title>web10</title>

--- a/marketing/marketing-ui/src/pages/Home.tsx
+++ b/marketing/marketing-ui/src/pages/Home.tsx
@@ -28,7 +28,7 @@ function Hero() {
           className="reveal mb-8 h-10 [animation-delay:80ms] sm:h-12"
         />
         <h1 className="reveal font-display text-4xl font-bold leading-[1.1] tracking-[-0.02em] [animation-delay:160ms] sm:text-5xl lg:text-[3.5rem]">
-          Your audience, actually.
+          Your audience.
         </h1>
         <p className="reveal mt-6 max-w-xl text-lg leading-[1.6] text-muted-foreground [animation-delay:240ms]">
           Every post reaches every follower. Not a promise the algorithm can

--- a/marketing/web10-social/index.html
+++ b/marketing/web10-social/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#09090b" />
-    <meta name="description" content="web10 social — your audience, actually. No shadow ban. 100% delivery by architecture." />
+    <meta name="description" content="web10 social — your audience. No shadow ban. 100% delivery by architecture." />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <link rel="manifest" href="/manifest.json" />
     <title>web10 social</title>

--- a/marketing/web10-social/src/App.tsx
+++ b/marketing/web10-social/src/App.tsx
@@ -42,7 +42,7 @@ function LoginScreen({ onLogin }: { onLogin: () => void }) {
           <h1 className="font-display text-4xl font-bold tracking-tight text-foreground">
             web<span className="text-brand">10</span>
           </h1>
-          <p className="text-muted-foreground">Your audience, actually. No shadow ban.</p>
+          <p className="text-muted-foreground">Your audience. No shadow ban.</p>
         </div>
         <Button
           variant="brand"


### PR DESCRIPTION
Removed trailing comma from tagline across marketing pages.

- : meta description + og:title
- : meta description