### PR TITLE
GitHub star button in navbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+1.0.110 || 23.07.2026
+Marketing navbar: replaced plain "GitHub" text link with a star button showing the live GitHub star count (fetches from GitHub API). Loading skeleton while fetching, 'k' suffix for 1000+ stars, fallback to "Star" on error. Uses a shared React context so desktop and mobile instances share one API call.
 1.0.109 || 23.07.2026
 Fix prod deploy: `deploy-prod` failed with `pathspec 'main' did not match any file(s) known to git`. The server repo at `/opt/web10` is a single-branch clone (tracks only `dev`), so `git fetch origin` never brought down `origin/main` and `git checkout main` had nothing to match — prod could never deploy. Both deploy jobs now fetch the target branch explicitly (`git fetch origin <branch>`, which populates FETCH_HEAD regardless of the clone's refspec) and force the local branch to it (`git checkout -B <branch> FETCH_HEAD`), replacing the `checkout`+`reset --hard origin/<branch>` that assumed a remote-tracking ref existed.
 1.0.107 || 23.07.2026

--- a/marketing/marketing-ui/src/App.tsx
+++ b/marketing/marketing-ui/src/App.tsx
@@ -1,5 +1,6 @@
 import { Routes, Route } from 'react-router-dom'
 import Navbar from './components/Navbar'
+import { StarsProvider } from './components/GitHubStarsContext'
 import DeployStatus from './components/DeployStatus'
 import Home from './pages/Home'
 import Trending from './pages/Trending'
@@ -9,7 +10,7 @@ import Exporter from './pages/Exporter'
 
 function App({ onReportBug }: { onReportBug: () => void }) {
   return (
-    <>
+    <StarsProvider>
       <Navbar onReportBug={onReportBug} />
       <Routes>
         <Route path="/" element={<Home />} />
@@ -20,7 +21,7 @@ function App({ onReportBug }: { onReportBug: () => void }) {
         <Route path="/import" element={<Exporter />} />
       </Routes>
       <DeployStatus />
-    </>
+    </StarsProvider>
   )
 }
 

--- a/marketing/marketing-ui/src/components/GitHubStarButton.tsx
+++ b/marketing/marketing-ui/src/components/GitHubStarButton.tsx
@@ -1,0 +1,30 @@
+import { Star } from 'lucide-react'
+import { Button } from './ui/button'
+import { useStars } from './GitHubStarsContext'
+import { trackFunnel } from '../lib/analytics'
+
+const REPO_URL = 'https://github.com/jacoby149/web10'
+
+function GitHubStarButton({ className, onClose }: { className?: string; onClose?: () => void }) {
+  const { stars, loading } = useStars()
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      className={className}
+      onClick={() => { onClose?.(); trackFunnel('github_click'); window.open(REPO_URL, '_blank', 'noopener') }}
+    >
+      <Star className="h-3.5 w-3.5" strokeWidth={1.75} />
+      {loading ? (
+        <span className="w-5 h-3 rounded-sm bg-muted animate-pulse" />
+      ) : stars != null ? (
+        <span>{stars >= 1000 ? `${(stars / 1000).toFixed(1).replace(/\.0$/, '')}k` : stars}</span>
+      ) : (
+        'Star'
+      )}
+    </Button>
+  )
+}
+
+export default GitHubStarButton

--- a/marketing/marketing-ui/src/components/GitHubStarsContext.tsx
+++ b/marketing/marketing-ui/src/components/GitHubStarsContext.tsx
@@ -1,0 +1,33 @@
+import { createContext, useContext, useState, useEffect } from 'react'
+
+const StarsContext = createContext<{ stars: number | null; loading: boolean }>({
+  stars: null,
+  loading: true,
+})
+
+function StarsProvider({ children }: { children: React.ReactNode }) {
+  const [stars, setStars] = useState<number | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    fetch('https://api.github.com/repos/jacoby149/web10')
+      .then(r => r.json())
+      .then(d => {
+        setStars(d.stargazers_count ?? null)
+        setLoading(false)
+      })
+      .catch(() => setLoading(false))
+  }, [])
+
+  return (
+    <StarsContext.Provider value={{ stars, loading }}>
+      {children}
+    </StarsContext.Provider>
+  )
+}
+
+function useStars() {
+  return useContext(StarsContext)
+}
+
+export { StarsProvider, useStars }

--- a/marketing/marketing-ui/src/components/Navbar.tsx
+++ b/marketing/marketing-ui/src/components/Navbar.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback } from 'react'
 import { Link, useLocation } from 'react-router-dom'
 import { Bug, Menu, X } from 'lucide-react'
 import { Button } from './ui/button'
+import GitHubStarButton from './GitHubStarButton'
 import { trackFunnel } from '../lib/analytics'
 
 const navItems = [
@@ -54,9 +55,7 @@ function Navbar({ onReportBug }: { onReportBug: () => void }) {
           <Button variant="brand" size="sm" onClick={() => { trackFunnel('sign_in_click'); window.location.href = 'https://auth.web10.app' }}>
             Sign In
           </Button>
-          <Button variant="ghost" size="sm" onClick={() => { trackFunnel('github_click'); window.open('https://github.com/jacoby149/web10', '_blank', 'noopener') }}>
-            GitHub
-          </Button>
+          <GitHubStarButton />
         </div>
 
         <button
@@ -98,9 +97,7 @@ function Navbar({ onReportBug }: { onReportBug: () => void }) {
             <Button variant="brand" size="sm" className="w-full justify-center" onClick={() => { setMobileOpen(false); trackFunnel('sign_in_click'); window.location.href = 'https://auth.web10.app' }}>
               Sign In
             </Button>
-            <Button variant="ghost" size="sm" className="w-full justify-center" onClick={() => { setMobileOpen(false); trackFunnel('github_click'); window.open('https://github.com/jacoby149/web10', '_blank', 'noopener') }}>
-              GitHub
-            </Button>
+            <GitHubStarButton className="w-full justify-center" onClose={() => setMobileOpen(false)} />
           </div>
         </div>
       )}


### PR DESCRIPTION
Replaces the plain text GitHub link in the marketing navbar with a star button that shows the live star count from the GitHub API.

**Changes:**
- `GitHubStarButton` component with star icon + live count (fetches from GitHub API)
- `GitHubStarsContext` to share star count between desktop and mobile instances
- Loading skeleton while fetching, fallback to 'Star' on error
- Stars formatted with 'k' suffix for 1000+
- Mobile button closes menu on click
- Kept existing `trackFunnel('github_click')` analytics