### PR TITLE
fix(cd): container health check uses docker inspect instead of invalid status=unhealthy filter

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,7 +66,7 @@ jobs:
             # Wait for containers to stabilize
             echo "=== Waiting for containers to stabilize ==="
             for i in $(seq 1 30); do
-              unhealthy=$(docker ps --filter "name=$STACK" --filter "status=unhealthy" --format '{{.Names}}' | wc -l)
+              unhealthy=$(docker ps --filter "name=$STACK" --format '{{.ID}}' | xargs -r docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' | grep -c unhealthy || true)
               restarting=$(docker ps --filter "name=$STACK" --filter "status=restarting" --format '{{.Names}}' | wc -l)
               if [[ "$unhealthy" -eq 0 ]] && [[ "$restarting" -eq 0 ]]; then
                 echo "All containers stable"
@@ -146,7 +146,7 @@ jobs:
             # Wait for containers to stabilize
             echo "=== Waiting for containers to stabilize ==="
             for i in $(seq 1 30); do
-              unhealthy=$(docker ps --filter "name=$STACK" --filter "status=unhealthy" --format '{{.Names}}' | wc -l)
+              unhealthy=$(docker ps --filter "name=$STACK" --format '{{.ID}}' | xargs -r docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' | grep -c unhealthy || true)
               restarting=$(docker ps --filter "name=$STACK" --filter "status=restarting" --format '{{.Names}}' | wc -l)
               if [[ "$unhealthy" -eq 0 ]] && [[ "$restarting" -eq 0 ]]; then
                 echo "All containers stable"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 1.0.111 || 23.07.2026
 Marketing navbar: added GitHub icon to the star button so it's visually clear it links to the GitHub repo.
+Fix deploy health check: `docker ps --filter status=unhealthy` is an invalid filter (Docker states are created/running/paused/restarting/removing/exited/dead — health is a separate field). This caused the stability loop to always exit on the first iteration with "All containers stable" regardless of actual container health. Both deploy jobs now use `docker inspect` to read `State.Health.Status` per container, then grep for unhealthy. Containers without a healthcheck return "none".
+
 1.0.110 || 23.07.2026
 Marketing navbar: replaced plain "GitHub" text link with a star button showing the live GitHub star count (fetches from GitHub API). Loading skeleton while fetching, 'k' suffix for 1000+ stars, fallback to "Star" on error. Uses a shared React context so desktop and mobile instances share one API call.
 1.0.109 || 23.07.2026


### PR DESCRIPTION
The `docker ps --filter status=unhealthy` filter is invalid — Docker's valid states are created/running/paused/restarting/removing/exited/dead. Health is a separate field, not a state.

This caused the stability loop to always exit on the first iteration (the filter error produced empty output, wc -l returned 0, and the condition passed). Deploys reported 'All containers stable' instantly without actually verifying health.

Fix: use `docker inspect` to read `State.Health.Status` for each container, then grep for unhealthy. Containers without a healthcheck return 'none'. Both dev and prod deploy jobs fixed.