### PR TITLE
fix: add GitHub icon to navbar star button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+1.0.111 || 23.07.2026
+Marketing navbar: added GitHub icon to the star button so it's visually clear it links to the GitHub repo.
 1.0.110 || 23.07.2026
 Marketing navbar: replaced plain "GitHub" text link with a star button showing the live GitHub star count (fetches from GitHub API). Loading skeleton while fetching, 'k' suffix for 1000+ stars, fallback to "Star" on error. Uses a shared React context so desktop and mobile instances share one API call.
 1.0.109 || 23.07.2026

--- a/marketing/marketing-ui/src/components/GitHubStarButton.tsx
+++ b/marketing/marketing-ui/src/components/GitHubStarButton.tsx
@@ -1,4 +1,4 @@
-import { Star } from 'lucide-react'
+import { Github, Star } from 'lucide-react'
 import { Button } from './ui/button'
 import { useStars } from './GitHubStarsContext'
 import { trackFunnel } from '../lib/analytics'
@@ -15,6 +15,7 @@ function GitHubStarButton({ className, onClose }: { className?: string; onClose?
       className={className}
       onClick={() => { onClose?.(); trackFunnel('github_click'); window.open(REPO_URL, '_blank', 'noopener') }}
     >
+      <Github className="h-3.5 w-3.5" strokeWidth={1.75} />
       <Star className="h-3.5 w-3.5" strokeWidth={1.75} />
       {loading ? (
         <span className="w-5 h-3 rounded-sm bg-muted animate-pulse" />


### PR DESCRIPTION
Adds the GitHub icon before the star icon in the navbar star button so it's visually clear it links to the GitHub repo. Previously only a plain star was shown with no indication it was GitHub-related.