### PR TITLE
fix(cd): pass GIT_COMMIT and STATUS_VERSION build args to marketing-ui on prod deploy

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -38,6 +38,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Extract git info for status.json
+        id: git
+        run: |
+          echo "commit=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          echo "version=$(head -1 CHANGELOG.md | sed 's/[| ].*//' | tr -d '[:space:]')" >> "$GITHUB_OUTPUT"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -59,6 +65,7 @@ jobs:
             type=ref,event=tag
 
       - name: Build and push ${{ matrix.service.name }}
+        if: matrix.service.name != 'marketing-ui'
         uses: docker/build-push-action@v6
         with:
           context: ${{ matrix.service.context }}
@@ -70,6 +77,21 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64
+
+      - name: Build and push marketing-ui
+        if: matrix.service.name == 'marketing-ui'
+        uses: docker/build-push-action@v6
+        with:
+          context: marketing/marketing-ui
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64
+          build-args: |
+            VITE_GIT_COMMIT=${{ steps.git.outputs.commit }}
+            STATUS_VERSION=${{ steps.git.outputs.version }}
 
   npm-publish-web10-npm:
     name: publish web10-npm


### PR DESCRIPTION
## Problem

Prod marketing-ui shows the old 'live' badge instead of the version status widget.

**Root cause:** `cd.yml` (the prod CI/CD workflow) builds the marketing-ui Docker image but does **not** pass `VITE_GIT_COMMIT` or `STATUS_VERSION` build args. So `build-status.sh` bakes `status.json` with `"version": "unknown"` and `"commit": "unknown"`. The `DeployStatus` component filters out 'unknown' values and falls back to the literal string 'live'.

Dev works because `deploy.yml` computes and passes these vars before `docker compose up --build`.

## Fix

- Added a step to extract the git commit short hash and version from CHANGELOG.md
- Split the matrix build: non-marketing-ui services use the original step; marketing-ui gets a dedicated step with the `VITE_GIT_COMMIT` and `STATUS_VERSION` build args
- Other services are unaffected (they don't declare these ARGs)

After this, the next prod deploy will bake real version + commit into `status.json` and the DeployStatus widget will show the proper version badge.