### PR TITLE
fix: lucide-react exports GitHub not Github

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+1.0.112 || 23.07.2026
+Fix marketing-ui build: `lucide-react` exports `GitHub` (capital H), not `Github`. The GitHubStarButton component used the wrong case, causing the TypeScript build to fail in CI/CD.
+
 1.0.111 || 23.07.2026
 Marketing navbar: added GitHub icon to the star button so it's visually clear it links to the GitHub repo.
 Fix deploy health check: `docker ps --filter status=unhealthy` is an invalid filter (Docker states are created/running/paused/restarting/removing/exited/dead — health is a separate field). This caused the stability loop to always exit on the first iteration with "All containers stable" regardless of actual container health. Both deploy jobs now use `docker inspect` to read `State.Health.Status` per container, then grep for unhealthy. Containers without a healthcheck return "none".

--- a/marketing/marketing-ui/src/components/GitHubStarButton.tsx
+++ b/marketing/marketing-ui/src/components/GitHubStarButton.tsx
@@ -1,4 +1,4 @@
-import { Github, Star } from 'lucide-react'
+import { GitHub, Star } from 'lucide-react'
 import { Button } from './ui/button'
 import { useStars } from './GitHubStarsContext'
 import { trackFunnel } from '../lib/analytics'

--- a/marketing/marketing-ui/src/components/GitHubStarButton.tsx
+++ b/marketing/marketing-ui/src/components/GitHubStarButton.tsx
@@ -15,7 +15,7 @@ function GitHubStarButton({ className, onClose }: { className?: string; onClose?
       className={className}
       onClick={() => { onClose?.(); trackFunnel('github_click'); window.open(REPO_URL, '_blank', 'noopener') }}
     >
-      <Github className="h-3.5 w-3.5" strokeWidth={1.75} />
+      <GitHub className="h-3.5 w-3.5" strokeWidth={1.75} />
       <Star className="h-3.5 w-3.5" strokeWidth={1.75} />
       {loading ? (
         <span className="w-5 h-3 rounded-sm bg-muted animate-pulse" />


### PR DESCRIPTION
Fix marketing-ui build failure: `lucide-react` exports `GitHub` (capital H), not `Github`. The GitHubStarButton component used the wrong case in both the import and JSX, causing the TypeScript build to fail in CI/CD.

```
src/components/GitHubStarButton.tsx(1,10): error TS2305: Module '"lucide-react"' has no exported member 'Github'.
```

This has been blocking all dev deploys since 1.0.111.