### PR TITLE
fix(marketing-ui): remove live Trending feed from landing page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+1.0.125 || 23.07.2026
+Remove the live "Trending" feed from the marketing landing page. `Home` rendered `<FeedPreview />` as the very first section (above the Hero, added in #168), so the front marketing page opened with a network feed that showed perpetual skeleton cards whenever the discovery API returned nothing — burying the hero and the pitch under a half-loaded app surface. Dropped `<FeedPreview />` and its import from `Home.tsx` (plus the now-unused `useCallback` import); the landing page opens on the Hero again. The dedicated `/trending` page is untouched — it imports the feed pieces (`PostCard`, `SkeletonCard`, `fetchDiscoverFeed`, …) directly, not the `FeedPreview` wrapper, so it keeps working. vite build clean.
+
 1.0.122 || 23.07.2026
 Fix trending page comment button and marketing-ui like button. The trending page's comment button now toggles a comment thread (fetches from `/public/entries`) instead of just incrementing the comment count. The marketing-ui FeedPreview on the home page renders interaction icons as read-only spans — no clickable like/comment/repost buttons — since the marketing site is a public preview with no auth. `PostCard` gained a `readOnly` prop; `FeedPreview` passes `readOnly={true}`. Trending page comment handler removed from `handleReaction` (only like/repost still increment counts).
 

--- a/marketing/marketing-ui/src/pages/Home.tsx
+++ b/marketing/marketing-ui/src/pages/Home.tsx
@@ -1,8 +1,7 @@
-import { useEffect, useCallback } from 'react'
+import { useEffect } from 'react'
 import { Send, Inbox, ShieldCheck } from 'lucide-react'
 import { Button } from '../components/ui/button'
 import { Card, CardHeader, CardTitle, CardDescription } from '../components/ui/card'
-import { FeedPreview } from '../components/FeedPreview'
 import {
   REACH_GAP_EXAMPLE,
   WEB10_DELIVERY_PERCENT,
@@ -184,7 +183,6 @@ function Home() {
   }, [])
   return (
     <>
-      <FeedPreview />
       <Hero />
       <ReachGap />
       <HowItWorks />


### PR DESCRIPTION
The marketing landing page (`Home`) rendered `<FeedPreview />` as its very first section — above the Hero, added in #168 — so the front page opened with a live network feed that showed perpetual skeleton cards whenever the discovery API returned nothing, burying the hero and the pitch under a half-loaded app surface. This drops `<FeedPreview />` and its import from `Home.tsx` (plus the now-unused `useCallback` import), so the page opens on the Hero again. The dedicated `/trending` page is untouched — it imports the feed pieces (`PostCard`, `SkeletonCard`, `fetchDiscoverFeed`, …) directly, not the `FeedPreview` wrapper, so it keeps working. `vite build` is clean and CHANGELOG entry `1.0.125` is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)