### PR TITLE
docs(plan): media v0 — reads survive a private bucket (D23, C7)

### DIFF
--- a/parallel execution.txt
+++ b/parallel execution.txt
@@ -271,6 +271,11 @@ LANE C — greenfield services  (owns: sdk/, mcp/, new dirs)
       the suite, lane-owned breakage -> .context/ note + lane
       queue item, never a silent skip. deliverable = the enlarged
       suite AND the honest bug list.
+  [ ] C7. sdk media surface (plan.txt phase 8.5, media v0): the
+      typed sdk (sdk/src) has NO media methods — add upload
+      (presigned POST + confirm) and getReadUrl (presigned GET
+      exchange + expiry-aware cache) matching the contract the
+      web10-social wrapper lands in D23. small; no gate.
 
 LANE D — docs / apps / mobile (owns: mobile/**, marketing/, examples/
                                 *.md/txt)
@@ -506,6 +511,25 @@ LANE D — docs / apps / mobile (owns: mobile/**, marketing/, examples/
         marketing/web10-social/** only. gate: D21's video v0
         merged. acceptance: a phone-recorded vertical video posts
         and swipes like short-form, demoable next to tiktok.
+[ ] D23. MEDIA READS SURVIVE A PRIVATE BUCKET (plan.txt phase 8.5,
+        media v0; the dev-minio 403). media records store the bare
+        unsigned object url and every renderer trusts record.url
+        verbatim, so a private bucket 403s every avatar/photo; the
+        api's request_read_url endpoint has ZERO callers. the wapi
+        wrapper gains getReadUrl (POST /media/{user}/read ->
+        presigned GET, expiry-aware cache so a feed of N images
+        isn't N round-trips per render); resolveMediaRefs + the
+        avatar/feed/composer paths render fresh presigned urls,
+        never record.url raw. cross-lane bits: the typed-sdk media
+        surface is C7; confirm-upload persisting object_key is a
+        tiny lane-A touch (coordinate, don't reach in — legacy
+        records derive the key from the stored url meanwhile).
+        owns marketing/web10-social/** only. gate: none — and
+        D21's photos-v1 acceptance ("post a photo -> it appears
+        in the feed") is BLIND on dev until this lands, so it
+        goes first. acceptance: avatars + feed photos render on
+        dev (private bucket) with zero 403s in the console;
+        presigned urls refresh when they expire.
 
 
 LANE E — infrastructure / deployment (owns: proxmox provisioning,

--- a/plan.txt
+++ b/plan.txt
@@ -1264,6 +1264,37 @@ comes) is a PUBLIC-media upgrade, not the foundation. this also
 keeps every early stage shippable against the api that exists
 right now.
 
+media v0 -- reads survive a private bucket (the dev-minio 403;
+lanes C+D with one tiny lane-A touch):
+the media record stores the BARE unsigned object url composed at
+upload time (confirmUpload: `${uploadUrl}/${objectKey}`) and
+every renderer (avatar, feed, composer) trusts record.url
+verbatim -- readable only while the bucket allows anonymous GET.
+on dev minio the bucket is private, so every avatar/photo 403s
+(AccessDenied). the api's presigned-read endpoint
+(request_read_url) exists with ZERO callers; the wapi wrapper
+has getUploadUrl/confirmUpload but no read half; the typed sdk
+has no media surface at all.
+[ ] wapi gains the read half: getReadUrl(objectKey, user?,
+    provider?) -> POST /media/{user}/read -> presigned GET, with
+    an expiry-aware cache (READ_URL_EXPIRY) so a feed of N
+    images doesn't cost N api round-trips per render. lands in
+    BOTH the web10-social wrapper (lane D) and the typed sdk's
+    new media surface alongside upload (lane C -- sdk/src has
+    neither today).
+[ ] confirm-upload persists object_key on the media record (tiny
+    lane-A touch; today only the composed url is stored). legacy
+    records: derive the key by stripping endpoint+bucket from
+    the stored url.
+[ ] resolveMediaRefs (and the avatar/feed/composer paths above
+    it) exchange refs for fresh presigned urls; nothing renders
+    record.url raw anymore.
+[ ] the bucket-policy call is SEPARATE and stays open: public-
+    read for public media (avatars, public posts) may come later
+    for cacheability/cdn -- decisions.md entry when decided.
+    presigned reads must work regardless: they are the ONLY path
+    for private/encrypted media (I4).
+
 photos v1 -- the composer stops being ugly (lane D; gauntlet step
 2 territory, "post a photo -> it appears in the feed"):
 [ ] media tray: previews at real aspect ratio in the same grid the


### PR DESCRIPTION
Adds the media v0 spec to plan.txt and lanes C7/D23: presigned reads via `/media/{user}/read` for the wapi wrapper and the typed-sdk, with an expiry-aware cache, plus a tiny confirm-upload change to persist `object_key`. Nothing renders `record.url` raw afterward — fixes the dev-minio 403 that blinds D21's photos-v1 acceptance. No behavior changes; spec and lane queue only.