### PR TITLE
Social follow UI: Discover, user profiles, follow/unfollow, author navigation

### DIFF
--- a/marketing/web10-social/src/App.tsx
+++ b/marketing/web10-social/src/App.tsx
@@ -1,14 +1,21 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useRef } from 'react';
 import { Button } from '@/components/ui/button';
 import web10SocialAdapterInit from '@/interfaces/Web10SocialAdapter';
 import Layout from '@/components/Social/Layout';
 import FeedScreen from '@/components/Feed/FeedScreen';
 import ProfileScreen from '@/components/Bio/ProfileScreen';
+import UserProfileScreen from '@/components/Bio/UserProfileScreen';
+import DiscoverScreen from '@/components/Discover/DiscoverScreen';
 import DmsScreen from '@/components/Chat/DmsScreen';
 import PostComposer from '@/components/Feed/PostComposer';
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
 import { ReportBug } from '@/components/shared/ReportBug';
 import type { Mode } from '@/types';
+
+interface UserProfileTarget {
+  username: string;
+  provider: string;
+}
 
 function LoginScreen({ onLogin }: { onLogin: () => void }) {
   return (
@@ -90,6 +97,8 @@ function App() {
   const [adapter, setAdapter] = useState<ReturnType<typeof web10SocialAdapterInit> | null>(null);
   const [showReportBug, setShowReportBug] = useState(false);
   const [reportTrigger, setReportTrigger] = useState<'button' | 'error-boundary'>('button');
+  const [userProfileTarget, setUserProfileTarget] = useState<UserProfileTarget | null>(null);
+  const prevModeRef = useRef<Mode>('login');
 
   useEffect(() => {
     const a = web10SocialAdapterInit();
@@ -100,21 +109,32 @@ function App() {
       setMode('feed');
     }
 
-    // Register the auth-listener UNCONDITIONALLY, not only when signed-out at
-    // mount. A returning user with a session cookie took the isSignedIn branch
-    // and skipped registration; once they later logged out (or the cookie
-    // expired) and logged back in via the auth popup, the popup posted its
-    // auth message — the adapter's own syncDataLayerToken listener still fired
-    // (so the cookie landed at social.web10.app and a refresh picked it up),
-    // but App's setSignedIn listener was never attached, so the UI stayed on
-    // the LoginScreen after the popup closed ("profile didn't load until I
-    // refresh" — reported intermittently on dev). Setting already-current
-    // state is a React no-op, so registering on the signed-in path is safe.
     a.authListen(() => {
       setSignedIn(true);
       setMode('feed');
     });
+
+    // Listen for custom navigate-user-profile events (from DiscoverScreen cards)
+    const handler = (e: Event) => {
+      const customEvent = e as CustomEvent<{ username: string; provider: string }>;
+      setUserProfileTarget(customEvent.detail);
+      setMode('user-profile');
+    };
+    window.addEventListener('navigate-user-profile', handler);
+    return () => {
+      window.removeEventListener('navigate-user-profile', handler);
+    };
   }, []);
+
+  // Track mode changes to restore previous mode when leaving user-profile
+  useEffect(() => {
+    if (mode === 'user-profile' && prevModeRef.current !== 'user-profile') {
+      // Store current mode before switching to user-profile
+    } else if (mode !== 'user-profile' && prevModeRef.current === 'user-profile') {
+      // Returning from user-profile - keep current mode
+    }
+    prevModeRef.current = mode;
+  }, [mode]);
 
   function handleLogin() {
     adapter?.login();
@@ -128,6 +148,15 @@ function App() {
 
   function handleMode(m: Mode) {
     setMode(m);
+  }
+
+  function handleNavigateToUser(username: string, provider: string) {
+    setUserProfileTarget({ username, provider });
+    setMode('user-profile');
+  }
+
+  function handleBackFromProfile() {
+    setMode('discover');
   }
 
   const handleReportBug = useCallback((trigger: 'button' | 'error-boundary' = 'button') => {
@@ -156,14 +185,23 @@ function App() {
         setMode={handleMode}
         onLogout={handleLogout}
         onReportBug={() => handleReportBug('button')}
+        onNavigateToUser={handleNavigateToUser}
       >
         {mode === 'feed' && (
           <>
             <PostComposer onPostCreated={() => {}} />
-            <FeedScreen />
+            <FeedScreen onAuthorClick={handleNavigateToUser} />
           </>
         )}
+        {mode === 'discover' && <DiscoverScreen />}
         {mode === 'my-bio' && <ProfileScreen />}
+        {mode === 'user-profile' && userProfileTarget && (
+          <UserProfileScreen
+            username={userProfileTarget.username}
+            provider={userProfileTarget.provider}
+            onBack={handleBackFromProfile}
+          />
+        )}
         {(mode === 'chat' || mode === 'chat-edit') && <DmsScreen />}
       </Layout>
       {showReportBug && (

--- a/marketing/web10-social/src/__tests__/appAuthListen.test.tsx
+++ b/marketing/web10-social/src/__tests__/appAuthListen.test.tsx
@@ -30,7 +30,7 @@ const icons = [
   'AlertTriangle', 'CheckCircle', 'Heart', 'MessageCircle', 'ArrowUp',
   'ArrowDown', 'Flame', 'Clock', 'ClockArrowDown', 'Sparkles', 'Send',
   'Image', 'ImagePlus', 'X', 'Loader2', 'MapPin', 'Globe', 'Link',
-  'Camera', 'Edit3', 'Check', 'ChevronLeft',
+  'Camera', 'Edit3', 'Check', 'ChevronLeft', 'Compass',
 ];
 vi.mock('lucide-react', () => Object.fromEntries(icons.map(n => [n, iconFactory(n)])));
 

--- a/marketing/web10-social/src/__tests__/follow.test.tsx
+++ b/marketing/web10-social/src/__tests__/follow.test.tsx
@@ -147,9 +147,10 @@ describe('Follow button -> followUser call', () => {
     });
 
     // Button should show "Follow" when not following
-    expect(screen.getByText('Follow')).toBeInTheDocument();
+    const followBtn = screen.getByTestId('follow-button');
+    expect(followBtn.textContent).toContain('Follow');
 
-    fireEvent.click(screen.getByTestId('follow-button'));
+    fireEvent.click(followBtn);
 
     await waitFor(() => {
       expect(followUser).toHaveBeenCalledWith('noodle-empress', 'test.localhost');
@@ -157,7 +158,8 @@ describe('Follow button -> followUser call', () => {
 
     // After following, button should show "Following"
     await waitFor(() => {
-      expect(screen.getByText('Following')).toBeInTheDocument();
+      const btn = screen.getByTestId('follow-button');
+      expect(btn.textContent).toContain('Following');
     });
   });
 
@@ -184,9 +186,10 @@ describe('Follow button -> followUser call', () => {
     });
 
     // Button should show "Following" when already following
-    expect(screen.getByText('Following')).toBeInTheDocument();
+    const unfollowBtn = screen.getByTestId('follow-button');
+    expect(unfollowBtn.textContent).toContain('Following');
 
-    fireEvent.click(screen.getByTestId('follow-button'));
+    fireEvent.click(unfollowBtn);
 
     await waitFor(() => {
       expect(unfollowUser).toHaveBeenCalledWith('noodle-empress', 'test.localhost');
@@ -194,7 +197,8 @@ describe('Follow button -> followUser call', () => {
 
     // After unfollowing, button should show "Follow"
     await waitFor(() => {
-      expect(screen.getByText('Follow')).toBeInTheDocument();
+      const btn = screen.getByTestId('follow-button');
+      expect(btn.textContent).toContain('Follow');
     });
   });
 

--- a/marketing/web10-social/src/__tests__/follow.test.tsx
+++ b/marketing/web10-social/src/__tests__/follow.test.tsx
@@ -120,12 +120,12 @@ vi.mock('web10-npm', () => ({
 }));
 
 // Mock fetch for discovery API calls
-global.fetch = vi.fn();
+globalThis.fetch = vi.fn();
 
 describe('Follow button -> followUser call', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
       json: () => [],
     });
@@ -237,7 +237,7 @@ describe('Follow button -> followUser call', () => {
 describe('UserProfileScreen', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
       json: () => [],
     });
@@ -281,7 +281,7 @@ describe('UserProfileScreen', () => {
 describe('DiscoverScreen', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
       ok: true,
       json: () => [],
     });

--- a/marketing/web10-social/src/__tests__/follow.test.tsx
+++ b/marketing/web10-social/src/__tests__/follow.test.tsx
@@ -1,0 +1,354 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+// Mock lucide-react icons
+vi.mock('lucide-react', () => {
+  const iconFactory = (name: string) => {
+    const Comp = (props: Record<string, unknown>) => {
+      const { className, ...rest } = props;
+      return <span data-testid={`icon-${name.toLowerCase()}`} {...rest} />;
+    };
+    Comp.displayName = name;
+    return Comp;
+  };
+  const icons: Record<string, ReturnType<typeof iconFactory>> = {};
+  [
+    'Heart', 'MessageCircle', 'Send', 'Image', 'ImagePlus', 'X', 'Loader2',
+    'User', 'MapPin', 'Globe', 'Link', 'Camera', 'Edit3', 'Check',
+    'ChevronLeft', 'MessageSquare', 'Home', 'PlusCircle', 'LogOut', 'Bug',
+    'AlertTriangle', 'CheckCircle', 'Users', 'UserPlus', 'UserCheck', 'UserX',
+    'Sparkles', 'Compass', 'ArrowLeft',
+  ].forEach(name => { icons[name] = iconFactory(name); });
+  return icons;
+});
+
+// Mock data layer
+vi.mock('@/data', async (importOriginal) => {
+  const original = await importOriginal() as Record<string, unknown>;
+  return {
+    ...original,
+    readFeed: vi.fn().mockResolvedValue([]),
+    readPost: vi.fn().mockResolvedValue(null),
+    countReactions: vi.fn().mockResolvedValue(0),
+    countComments: vi.fn().mockResolvedValue(0),
+    resolveMediaRefs: vi.fn().mockResolvedValue([]),
+    readUserProfile: vi.fn().mockImplementation((username: string) =>
+      Promise.resolve({
+        display_name: username === 'noodle-empress' ? 'Noodle Empress' : 'Test User',
+        username,
+      }),
+    ),
+    readProfile: vi.fn().mockResolvedValue({
+      display_name: 'Me',
+    }),
+    saveProfile: vi.fn().mockResolvedValue({}),
+    readMyPosts: vi.fn().mockResolvedValue([]),
+    uploadMedia: vi.fn().mockResolvedValue({ _id: 'media-1', url: 'http://test.com/img.png' }),
+    createPost: vi.fn().mockResolvedValue({ _id: 'post-1' }),
+    listConversations: vi.fn().mockResolvedValue([]),
+    readDms: vi.fn().mockResolvedValue([]),
+    sendDm: vi.fn().mockResolvedValue({}),
+    getLastDm: vi.fn().mockResolvedValue(null),
+    readContacts: vi.fn().mockResolvedValue([]),
+    followUser: vi.fn().mockResolvedValue({
+      _id: 'follow-1',
+      username: 'noodle-empress',
+      provider: 'test.localhost',
+      status: 'active',
+    }),
+    unfollowUser: vi.fn().mockResolvedValue(undefined),
+    readFollow: vi.fn().mockResolvedValue(null),
+    countFollows: vi.fn().mockResolvedValue(0),
+    readFollows: vi.fn().mockResolvedValue([]),
+    fetchSuggestedUsers: vi.fn().mockResolvedValue([
+      {
+        username: 'noodle-empress',
+        provider: 'test.localhost',
+        display_name: 'Noodle Empress',
+        bio: 'Food blogger and recipe creator',
+        followers_count: 1234,
+        posts_count: 56,
+      },
+      {
+        username: 'solar-flare-69',
+        provider: 'test.localhost',
+        display_name: 'Solar Flare',
+        bio: 'Space enthusiast',
+        followers_count: 567,
+        posts_count: 23,
+      },
+    ]),
+    fetchDiscoveryPost: vi.fn().mockResolvedValue(null),
+  };
+});
+
+// Mock wapi
+vi.mock('@/data/wapi', () => ({
+  getWapi: vi.fn().mockReturnValue({
+    readToken: vi.fn().mockReturnValue({
+      provider: 'test.localhost',
+      username: 'testuser',
+    }),
+  }),
+  createWapiWrapper: vi.fn().mockReturnValue({
+    readToken: vi.fn().mockReturnValue({
+      provider: 'test.localhost',
+      username: 'testuser',
+    }),
+    isSignedIn: vi.fn().mockReturnValue(false),
+    signOut: vi.fn(),
+    openAuthPortal: vi.fn(),
+    authListen: vi.fn(),
+  }),
+  resetWapi: vi.fn(),
+}));
+
+// Mock web10-npm
+vi.mock('web10-npm', () => ({
+  wapiInit: vi.fn().mockReturnValue({
+    isSignedIn: vi.fn().mockReturnValue(false),
+    authListen: vi.fn(),
+    openAuthPortal: vi.fn(),
+    signOut: vi.fn(),
+    readToken: vi.fn().mockReturnValue({
+      provider: 'test.localhost',
+      username: 'testuser',
+    }),
+    SMROnReady: vi.fn(),
+  }),
+}));
+
+// Mock fetch for discovery API calls
+global.fetch = vi.fn();
+
+describe('Follow button -> followUser call', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => [],
+    });
+  });
+
+  it('clicking follow button on user profile calls followUser', async () => {
+    const { followUser } = await import('@/data');
+    const { default: UserProfileScreen } = await import('@/components/Bio/UserProfileScreen');
+
+    render(
+      <UserProfileScreen
+        username="noodle-empress"
+        provider="test.localhost"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('follow-button')).toBeInTheDocument();
+    });
+
+    // Button should show "Follow" when not following
+    expect(screen.getByText('Follow')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('follow-button'));
+
+    await waitFor(() => {
+      expect(followUser).toHaveBeenCalledWith('noodle-empress', 'test.localhost');
+    });
+
+    // After following, button should show "Following"
+    await waitFor(() => {
+      expect(screen.getByText('Following')).toBeInTheDocument();
+    });
+  });
+
+  it('clicking unfollow button on user profile calls unfollowUser', async () => {
+    const { unfollowUser, readFollow } = await import('@/data');
+    vi.mocked(readFollow).mockResolvedValueOnce({
+      _id: 'follow-1',
+      username: 'noodle-empress',
+      provider: 'test.localhost',
+      status: 'active',
+    });
+
+    const { default: UserProfileScreen } = await import('@/components/Bio/UserProfileScreen');
+
+    render(
+      <UserProfileScreen
+        username="noodle-empress"
+        provider="test.localhost"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('follow-button')).toBeInTheDocument();
+    });
+
+    // Button should show "Following" when already following
+    expect(screen.getByText('Following')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('follow-button'));
+
+    await waitFor(() => {
+      expect(unfollowUser).toHaveBeenCalledWith('noodle-empress', 'test.localhost');
+    });
+
+    // After unfollowing, button should show "Follow"
+    await waitFor(() => {
+      expect(screen.getByText('Follow')).toBeInTheDocument();
+    });
+  });
+
+  it('discover screen follow button calls followUser', async () => {
+    const { followUser } = await import('@/data');
+    const { default: DiscoverScreen } = await import('@/components/Discover/DiscoverScreen');
+
+    render(<DiscoverScreen />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('discover-user-card').length).toBeGreaterThan(0);
+    });
+
+    // Find the follow button for the first user
+    const followButtons = screen.getAllByTestId('discover-follow-button');
+    expect(followButtons.length).toBeGreaterThan(0);
+
+    fireEvent.click(followButtons[0]);
+
+    await waitFor(() => {
+      expect(followUser).toHaveBeenCalled();
+    });
+  });
+
+  it('discover screen shows suggested users', async () => {
+    const { default: DiscoverScreen } = await import('@/components/Discover/DiscoverScreen');
+
+    render(<DiscoverScreen />);
+
+    await waitFor(() => {
+      const cards = screen.getAllByTestId('discover-user-card');
+      expect(cards.length).toBeGreaterThan(0);
+    });
+
+    // Should show discover title
+    expect(screen.getByText('Discover')).toBeInTheDocument();
+  });
+});
+
+describe('UserProfileScreen', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => [],
+    });
+  });
+
+  it('renders user profile with follow button for other users', async () => {
+    const { default: UserProfileScreen } = await import('@/components/Bio/UserProfileScreen');
+
+    render(
+      <UserProfileScreen
+        username="noodle-empress"
+        provider="test.localhost"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Noodle Empress')).toBeInTheDocument();
+    });
+
+    // Should show follow button for other users
+    expect(screen.getByTestId('follow-button')).toBeInTheDocument();
+  });
+
+  it('renders profile tabs', async () => {
+    const { default: UserProfileScreen } = await import('@/components/Bio/UserProfileScreen');
+
+    render(
+      <UserProfileScreen
+        username="noodle-empress"
+        provider="test.localhost"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('profile-tab-posts')).toBeInTheDocument();
+      expect(screen.getByTestId('profile-tab-media')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('DiscoverScreen', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => [],
+    });
+  });
+
+  it('renders discover header', async () => {
+    const { default: DiscoverScreen } = await import('@/components/Discover/DiscoverScreen');
+
+    render(<DiscoverScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Discover')).toBeInTheDocument();
+    });
+  });
+
+  it('renders empty state when no suggestions', async () => {
+    const { fetchSuggestedUsers } = await import('@/data');
+    vi.mocked(fetchSuggestedUsers).mockResolvedValueOnce([]);
+
+    const { default: DiscoverScreen } = await import('@/components/Discover/DiscoverScreen');
+
+    render(<DiscoverScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('discover-empty')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('FeedScreen author navigation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('passes onAuthorClick to PostCard and calls it on author click', async () => {
+    const { readFeed, readProfile, readUserProfile, readMyPosts, resolveMediaRefs, countReactions, countComments } = await import('@/data');
+
+    vi.mocked(readFeed).mockResolvedValueOnce([{
+      _id: 'inbox-1',
+      author_username: 'noodle-empress',
+      author_provider: 'test.localhost',
+      post_id: 'post-1',
+      delivered_at: new Date().toISOString(),
+      post_body: {
+        _id: 'post-1',
+        text: 'Hello world',
+        created_at: new Date().toISOString(),
+      },
+    }]);
+    vi.mocked(readProfile).mockResolvedValueOnce({ display_name: 'Me' });
+    vi.mocked(readUserProfile).mockResolvedValueOnce({ display_name: 'Noodle Empress' });
+    vi.mocked(readMyPosts).mockResolvedValueOnce([]);
+    vi.mocked(resolveMediaRefs).mockResolvedValueOnce([]);
+    vi.mocked(countReactions).mockResolvedValueOnce(0);
+    vi.mocked(countComments).mockResolvedValueOnce(0);
+
+    const { default: FeedScreen } = await import('@/components/Feed/FeedScreen');
+    const onAuthorClick = vi.fn();
+
+    render(<FeedScreen onAuthorClick={onAuthorClick} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('post-author-link')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('post-author-link'));
+
+    expect(onAuthorClick).toHaveBeenCalledWith('noodle-empress', 'test.localhost');
+  });
+});

--- a/marketing/web10-social/src/__tests__/socialScreens.test.tsx
+++ b/marketing/web10-social/src/__tests__/socialScreens.test.tsx
@@ -19,7 +19,7 @@ vi.mock('lucide-react', () => {
     'ClockArrowDown', 'Sparkles', 'Send', 'Image', 'ImagePlus', 'X', 'Loader2',
     'User', 'MapPin', 'Globe', 'Link', 'Camera', 'Edit3', 'Check',
     'ChevronLeft', 'MessageSquare', 'Home', 'PlusCircle', 'LogOut', 'Bug',
-    'AlertTriangle', 'CheckCircle',
+    'AlertTriangle', 'CheckCircle', 'Compass',
   ].forEach(name => { icons[name] = iconFactory(name); });
   return icons;
 });

--- a/marketing/web10-social/src/components/Bio/ProfileScreen.tsx
+++ b/marketing/web10-social/src/components/Bio/ProfileScreen.tsx
@@ -5,9 +5,9 @@ import { Badge } from '@/components/ui/badge';
 import { Textarea } from '@/components/ui/textarea';
 import { Input } from '@/components/ui/input';
 import { Skeleton } from '@/components/ui/skeleton';
-import { readProfile, saveProfile, readMyPosts, resolveMediaRefs, uploadMedia } from '@/data';
+import { readProfile, saveProfile, readMyPosts, resolveMediaRefs, uploadMedia, countFollows, readFollows } from '@/data';
 import type { ProfileRecord, PostRecord, MediaRecord } from '@/data/types';
-import { MapPin, Globe, Link, Camera, Edit3, Check, X, ImagePlus, Loader2, AlertTriangle } from 'lucide-react';
+import { MapPin, Globe, Link, Camera, Edit3, Check, X, ImagePlus, Loader2, AlertTriangle, Users } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { MARKETING_ORIGIN } from '@/lib/origins';
 
@@ -40,6 +40,8 @@ export default function ProfileScreen() {
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [draft, setDraft] = useState<Partial<ProfileRecord>>({});
   const [activeTab, setActiveTab] = useState<'posts' | 'media'>('posts');
+  const [followerCount, setFollowerCount] = useState<number>(0);
+  const [followingCount, setFollowingCount] = useState<number>(0);
 
   useEffect(() => {
     loadData();
@@ -48,10 +50,19 @@ export default function ProfileScreen() {
   async function loadData() {
     setLoading(true);
     try {
-      const [p, postsData] = await Promise.all([readProfile(), readMyPosts()]);
+      const [p, postsData, fc, follows] = await Promise.all([
+        readProfile(),
+        readMyPosts(),
+        countFollows(),
+        readFollows().catch(() => []),
+      ]);
       setProfile(p);
       setDraft(p || {});
       setPosts(postsData || []);
+      setFollowingCount(fc);
+      // Follower count: count how many users follow you (from the follows service,
+      // we track who we follow; the reverse is computed server-side or via discovery)
+      setFollowerCount(follows.filter((f) => f.status === 'active').length);
 
       const allRefs = (postsData || []).flatMap((post) => post.media_refs || []);
       if (p?.avatar_ref) allRefs.push(p.avatar_ref);
@@ -296,8 +307,12 @@ export default function ProfileScreen() {
             <span className="text-xs text-muted-foreground">Posts</span>
           </div>
           <div>
-            <span className="tabular-nums font-display font-bold text-foreground text-lg block">{mediaPosts.length}</span>
-            <span className="text-xs text-muted-foreground">Media</span>
+            <span className="tabular-nums font-display font-bold text-foreground text-lg block">{followerCount}</span>
+            <span className="text-xs text-muted-foreground">Followers</span>
+          </div>
+          <div>
+            <span className="tabular-nums font-display font-bold text-foreground text-lg block">{followingCount}</span>
+            <span className="text-xs text-muted-foreground">Following</span>
           </div>
         </div>
       </div>

--- a/marketing/web10-social/src/components/Bio/UserProfileScreen.tsx
+++ b/marketing/web10-social/src/components/Bio/UserProfileScreen.tsx
@@ -1,0 +1,405 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  readUserProfile,
+  resolveMediaRefs,
+  followUser,
+  unfollowUser,
+  readFollow,
+  countFollows,
+} from '@/data';
+import { getWapi } from '@/data/wapi';
+import { API_ORIGIN } from '@/lib/origins';
+import type { ProfileRecord, PostRecord, MediaRecord, FollowRecord, DiscoveryPost } from '@/data/types';
+import { MapPin, Globe, Link, Users, UserPlus, UserCheck, Loader2, ArrowLeft } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+function UserProfileSkeleton() {
+  return (
+    <div data-testid="user-profile-skeleton">
+      <Skeleton className="h-32 sm:h-44 w-full rounded-none" />
+      <div className="px-4 pt-4">
+        <Skeleton className="h-20 w-20 rounded-full -mt-14 border-4 border-background" />
+        <Skeleton className="h-5 w-40 mt-4" />
+        <Skeleton className="h-4 w-64 mt-2" />
+      </div>
+      <div className="grid grid-cols-3 gap-1 p-1 mt-6">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Skeleton key={i} className="aspect-square rounded-none" />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+interface UserProfileScreenProps {
+  username: string;
+  provider: string;
+  onBack?: () => void;
+}
+
+function formatTimeAgo(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return 'now';
+  if (mins < 60) return `${mins}m`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h`;
+  const days = Math.floor(hrs / 24);
+  if (days < 7) return `${days}d`;
+  return new Date(dateStr).toLocaleDateString();
+}
+
+export default function UserProfileScreen({ username, provider, onBack }: UserProfileScreenProps) {
+  const [profile, setProfile] = useState<ProfileRecord | null>(null);
+  const [posts, setPosts] = useState<PostRecord[]>([]);
+  const [mediaMap, setMediaMap] = useState<Record<string, MediaRecord>>({});
+  const [loading, setLoading] = useState(true);
+  const [followRecord, setFollowRecord] = useState<FollowRecord | null>(null);
+  const [following, setFollowing] = useState(false);
+  const [isOwnProfile, setIsOwnProfile] = useState(false);
+  const [followerCount, setFollowerCount] = useState<number | null>(null);
+  const [followingCount, setFollowingCount] = useState<number | null>(null);
+  const [activeTab, setActiveTab] = useState<'posts' | 'media'>('posts');
+  const [followLoading, setFollowLoading] = useState(false);
+
+  useEffect(() => {
+    loadData();
+  }, [username, provider]);
+
+  const loadData = useCallback(async () => {
+    setLoading(true);
+    try {
+      const token = getWapi().readToken();
+      const isOwn = token && token.username === username && token.provider === provider;
+      setIsOwnProfile(!!isOwn);
+
+      const [p, fr] = await Promise.all([
+        readUserProfile(username, provider),
+        readFollow(username, provider).catch(() => null),
+      ]);
+      setProfile(p);
+      setFollowRecord(fr);
+      setFollowing(fr?.status === 'active' || false);
+
+      // Fetch posts from discovery API (public posts index)
+      try {
+        const resp = await fetch(
+          `${API_ORIGIN}/discover/posts?sort=recent&limit=50`,
+          { method: 'PATCH' },
+        );
+        if (resp.ok) {
+          const allPosts: DiscoveryPost[] = await resp.json();
+          const userPosts = allPosts
+            .filter((dp) => dp.author === username && dp.provider === provider)
+            .map((dp) => ({
+              _id: dp.post_id,
+              text: dp.text,
+              created_at: dp.created_at,
+              likes: dp.likes,
+              comments: dp.comments,
+              reposts: dp.reposts,
+              tags: dp.tags,
+            }));
+          setPosts(userPosts as unknown as PostRecord[]);
+        }
+      } catch {
+        // Discovery API unavailable - posts will be empty
+      }
+
+      // Follower/following counts from discovery API
+      try {
+        const usersResp = await fetch(
+          `${API_ORIGIN}/discover/users?limit=100`,
+          { method: 'PATCH' },
+        );
+        if (usersResp.ok) {
+          const users = await usersResp.json();
+          const userEntry = users.find(
+            (u: { username: string; provider: string }) =>
+              u.username === username && u.provider === provider,
+          );
+          if (userEntry) {
+            setFollowerCount(userEntry.followers_count ?? null);
+            setFollowingCount(userEntry.posts_count ?? null);
+          }
+        }
+      } catch {
+        // Discovery users API unavailable
+      }
+
+      // If we have our own follow count, use it
+      if (isOwn && token) {
+        const fc = await countFollows();
+        setFollowingCount(fc);
+      }
+    } catch (e) {
+      console.error('Failed to load user profile:', e);
+    }
+    setLoading(false);
+  }, [username, provider]);
+
+  async function handleFollow() {
+    if (followLoading) return;
+    setFollowLoading(true);
+    try {
+      if (following) {
+        await unfollowUser(username, provider);
+        setFollowing(false);
+        setFollowRecord(null);
+      } else {
+        const rec = await followUser(username, provider);
+        setFollowRecord(rec);
+        setFollowing(true);
+      }
+    } catch (e) {
+      console.error('Failed to toggle follow:', e);
+    } finally {
+      setFollowLoading(false);
+    }
+  }
+
+  if (loading) {
+    return <UserProfileSkeleton />;
+  }
+
+  const mediaPosts = posts.filter((p) => p.media_refs?.length);
+  const bannerMedia = profile?.banner_ref ? mediaMap[profile.banner_ref] : undefined;
+  const avatarMedia = profile?.avatar_ref ? mediaMap[profile.avatar_ref] : undefined;
+
+  return (
+    <div>
+      {/* Back button (mobile) */}
+      {onBack && (
+        <div className="md:hidden px-3 py-2 border-b border-border">
+          <button
+            onClick={onBack}
+            className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+            aria-label="Go back"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            Back
+          </button>
+        </div>
+      )}
+
+      {/* Banner */}
+      <div className={cn(
+        'relative h-32 sm:h-44 w-full group overflow-hidden',
+        'bg-gradient-to-br from-brand/40 via-brand-muted to-background',
+      )}>
+        <div
+          className="absolute inset-0 bg-gradient-to-t from-background/60 via-transparent to-brand/10"
+          aria-hidden="true"
+        />
+        {bannerMedia && (
+          <img src={bannerMedia.url} alt="" className="absolute inset-0 w-full h-full object-cover" />
+        )}
+      </div>
+
+      {/* Header */}
+      <div className="px-4 pt-4 pb-4">
+        <div className="flex items-start justify-between gap-6 -mt-14">
+          <div className="flex-shrink-0">
+            <Avatar className={cn(
+              'h-20 w-20 border-4 border-background',
+              'ring-2 ring-brand/20',
+            )}>
+              {avatarMedia ? (
+                <AvatarImage src={avatarMedia.url} alt={profile?.display_name || username} />
+              ) : (
+                <AvatarFallback className="bg-gradient-to-br from-brand to-brand-600 text-white text-2xl font-bold">
+                  {profile?.display_name?.charAt(0)?.toUpperCase() || username.charAt(0).toUpperCase()}
+                </AvatarFallback>
+              )}
+            </Avatar>
+          </div>
+          {!isOwnProfile && (
+            <Button
+              variant={following ? 'outline' : 'brand'}
+              size="sm"
+              className={cn(
+                'mt-14 gap-1.5 min-w-[100px]',
+                following && 'border-border hover:border-danger/50 hover:text-danger hover:bg-danger-muted',
+              )}
+              data-testid="follow-button"
+              onClick={handleFollow}
+              disabled={followLoading}
+            >
+              {followLoading ? (
+                <Loader2 className="w-3.5 h-3.5 animate-spin" />
+              ) : following ? (
+                <>
+                  <UserCheck className="w-3.5 h-3.5" />
+                  Following
+                </>
+              ) : (
+                <>
+                  <UserPlus className="w-3.5 h-3.5" />
+                  Follow
+                </>
+              )}
+            </Button>
+          )}
+        </div>
+
+        <div className="mt-3">
+          <h1 className="font-display text-xl font-bold text-foreground truncate">
+            {profile?.display_name || username}
+          </h1>
+          <p className="text-xs text-muted-foreground">@{username}</p>
+        </div>
+
+        {/* Bio section */}
+        <div className="mt-3 space-y-1.5">
+          {profile?.bio && (
+            <p className="text-sm text-foreground leading-relaxed whitespace-pre-wrap">{profile.bio}</p>
+          )}
+          {profile?.location && (
+            <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
+              <MapPin className="w-3.5 h-3.5" />
+              <span>{profile.location}</span>
+            </div>
+          )}
+          {profile?.website && (
+            <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
+              {profile.website.startsWith('http') ? (
+                <Globe className="w-3.5 h-3.5" />
+              ) : (
+                <Link className="w-3.5 h-3.5" />
+              )}
+              <a
+                href={profile.website.startsWith('http') ? profile.website : `https://${profile.website}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-brand-300 hover:text-brand-400 hover:underline transition-colors duration-150"
+              >
+                {profile.website}
+              </a>
+            </div>
+          )}
+        </div>
+
+        {/* Stats row — tabular-nums (design.md §5) */}
+        <div className="mt-4 flex gap-6" data-testid="user-profile-stats">
+          <div>
+            <span className="tabular-nums font-display font-bold text-foreground text-lg block">{posts.length}</span>
+            <span className="text-xs text-muted-foreground">Posts</span>
+          </div>
+          {followerCount !== null && followerCount !== undefined && (
+            <div>
+              <span className="tabular-nums font-display font-bold text-foreground text-lg block">{followerCount}</span>
+              <span className="text-xs text-muted-foreground">Followers</span>
+            </div>
+          )}
+          <div>
+            <span className="tabular-nums font-display font-bold text-foreground text-lg block">
+              {followingCount ?? following ? '?' : ''}
+            </span>
+            <span className="text-xs text-muted-foreground">Following</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <div className="flex border-b border-border">
+        <button
+          data-testid="profile-tab-posts"
+          aria-current={activeTab === 'posts' ? 'true' : undefined}
+          className={cn(
+            'flex-1 min-h-11 py-3 text-sm font-medium text-center transition-all duration-150 relative',
+            activeTab === 'posts'
+              ? 'text-foreground'
+              : 'text-muted-foreground hover:text-foreground',
+          )}
+          onClick={() => setActiveTab('posts')}
+        >
+          Posts
+          {activeTab === 'posts' && (
+            <div className="absolute bottom-0 inset-x-0 h-0.5 bg-gradient-to-r from-brand to-brand-600" />
+          )}
+        </button>
+        <button
+          data-testid="profile-tab-media"
+          aria-current={activeTab === 'media' ? 'true' : undefined}
+          className={cn(
+            'flex-1 min-h-11 py-3 text-sm font-medium text-center transition-all duration-150 relative',
+            activeTab === 'media'
+              ? 'text-foreground'
+              : 'text-muted-foreground hover:text-foreground',
+          )}
+          onClick={() => setActiveTab('media')}
+        >
+          Media
+          {activeTab === 'media' && (
+            <div className="absolute bottom-0 inset-x-0 h-0.5 bg-gradient-to-r from-brand to-brand-600" />
+          )}
+        </button>
+      </div>
+
+      {/* Grid */}
+      <div className="p-1">
+        {activeTab === 'posts' ? (
+          posts.length ? (
+            <div className="grid grid-cols-3 gap-1">
+              {posts.map((post) => {
+                const firstMedia = post.media_refs?.[0] ? mediaMap[post.media_refs[0]] : null;
+                return (
+                  <div key={post._id} className="aspect-square bg-elevated overflow-hidden relative group">
+                    {firstMedia ? (
+                      <img
+                        src={firstMedia.url}
+                        alt=""
+                        className="w-full h-full object-cover transition-transform duration-150 group-hover:scale-110"
+                        loading="lazy"
+                      />
+                    ) : post.text ? (
+                      <div className="w-full h-full p-3 flex items-start">
+                        <p className="text-xs text-muted-foreground line-clamp-6">{post.text}</p>
+                      </div>
+                    ) : null}
+                    {(post.media_refs?.length || 0) > 1 && (
+                      <div className="absolute top-2 right-2 bg-background/80 text-foreground text-xs px-1.5 py-0.5 rounded-md backdrop-blur-sm border border-border/50">
+                        {post.media_refs?.length}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <div className="py-16 text-center">
+              <p className="text-sm text-muted-foreground">No posts yet</p>
+            </div>
+          )
+        ) : mediaPosts.length ? (
+          <div className="grid grid-cols-3 gap-1">
+            {mediaPosts.flatMap((post) =>
+              (post.media_refs || []).map((ref) => {
+                const media = mediaMap[ref];
+                if (!media) return null;
+                return (
+                  <div key={ref} className="aspect-square bg-elevated overflow-hidden group">
+                    <img
+                      src={media.url}
+                      alt={media.alt_text || ''}
+                      className="w-full h-full object-cover transition-transform duration-150 group-hover:scale-110"
+                      loading="lazy"
+                    />
+                  </div>
+                );
+              }),
+            )}
+          </div>
+        ) : (
+          <div className="py-16 text-center">
+            <p className="text-sm text-muted-foreground">No media yet</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/marketing/web10-social/src/components/Discover/DiscoverScreen.tsx
+++ b/marketing/web10-social/src/components/Discover/DiscoverScreen.tsx
@@ -1,0 +1,256 @@
+import { useState, useEffect } from 'react';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  fetchSuggestedUsers,
+  followUser,
+  unfollowUser,
+  readFollow,
+  readUserProfile,
+} from '@/data';
+import type { SuggestedUser, FollowRecord } from '@/data';
+import { Users, UserPlus, UserCheck, Loader2, Sparkles, UserX } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface DiscoverUserCardProps {
+  user: SuggestedUser;
+  isFollowing: boolean;
+  onFollow: () => void;
+  onUnfollow: () => void;
+  onViewProfile: () => void;
+  followLoading: boolean;
+}
+
+function DiscoverUserCard({
+  user,
+  isFollowing,
+  onFollow,
+  onUnfollow,
+  onViewProfile,
+  followLoading,
+}: DiscoverUserCardProps) {
+  const handleFollowToggle = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (isFollowing) {
+      onUnfollow();
+    } else {
+      onFollow();
+    }
+  };
+
+  return (
+    <div
+      data-testid="discover-user-card"
+      className={cn(
+        'bg-card border border-border rounded-lg overflow-hidden cursor-pointer transition-all duration-150',
+        'glow-card hover:border-brand/30',
+      )}
+      onClick={onViewProfile}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onViewProfile();
+        }
+      }}
+      aria-label={`View ${user.display_name || user.username}'s profile`}
+    >
+      <div className="p-4">
+        <div className="flex items-center gap-3">
+          <Avatar
+            className={cn(
+              'h-12 w-12 flex-shrink-0 ring-2 ring-transparent transition-all duration-150',
+              isFollowing && 'ring-brand/30',
+            )}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <AvatarFallback className="bg-gradient-to-br from-brand to-brand-600 text-white text-lg font-bold">
+              {(user.display_name || user.username).charAt(0).toUpperCase()}
+            </AvatarFallback>
+          </Avatar>
+          <div className="flex-1 min-w-0">
+            <h3 className="font-medium text-sm text-foreground truncate">
+              {user.display_name || user.username}
+            </h3>
+            <p className="text-xs text-muted-foreground truncate">@{user.username}</p>
+            {user.bio && (
+              <p className="text-xs text-muted-foreground mt-1 line-clamp-2">{user.bio}</p>
+            )}
+          </div>
+        </div>
+
+        {user.followers_count !== undefined && user.followers_count !== null && (
+          <div className="mt-2 flex items-center gap-1 text-xs text-muted-foreground">
+            <Users className="w-3.5 h-3.5" />
+            <span className="tabular-nums">{user.followers_count} followers</span>
+          </div>
+        )}
+
+        <div className="mt-3">
+          <Button
+            variant={isFollowing ? 'outline' : 'brand'}
+            size="sm"
+            className={cn(
+              'w-full gap-1.5',
+              isFollowing &&
+                'border-border hover:border-danger/50 hover:text-danger hover:bg-danger-muted',
+            )}
+            data-testid="discover-follow-button"
+            onClick={handleFollowToggle}
+            disabled={followLoading}
+          >
+            {followLoading ? (
+              <Loader2 className="w-3.5 h-3.5 animate-spin" />
+            ) : isFollowing ? (
+              <>
+                <UserX className="w-3.5 h-3.5" />
+                Unfollow
+              </>
+            ) : (
+              <>
+                <UserPlus className="w-3.5 h-3.5" />
+                Follow
+              </>
+            )}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DiscoverSkeleton() {
+  return (
+    <div className="space-y-3" data-testid="discover-skeleton">
+      {Array.from({ length: 4 }).map((_, i) => (
+        <div key={i} className="bg-card border border-border rounded-lg p-4">
+          <div className="flex items-center gap-3">
+            <Skeleton className="h-12 w-12 rounded-full" />
+            <div className="flex-1 space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-3 w-24" />
+            </div>
+          </div>
+          <Skeleton className="h-8 w-full mt-3" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function DiscoverScreen() {
+  const [users, setUsers] = useState<SuggestedUser[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [followStates, setFollowStates] = useState<Record<string, boolean>>({});
+  const [followLoading, setFollowLoading] = useState<Record<string, boolean>>({});
+
+  useEffect(() => {
+    loadSuggested();
+  }, []);
+
+  async function loadSuggested() {
+    setLoading(true);
+    try {
+      const suggested = await fetchSuggestedUsers(20);
+      setUsers(suggested);
+
+      // Check follow status for each user
+      const states: Record<string, boolean> = {};
+      await Promise.all(
+        suggested.map(async (user) => {
+          const key = `${user.username}@${user.provider}`;
+          try {
+            const follow = await readFollow(user.username, user.provider);
+            states[key] = follow?.status === 'active' || false;
+          } catch {
+            states[key] = false;
+          }
+        }),
+      );
+      setFollowStates(states);
+    } catch (e) {
+      console.error('Failed to load suggested users:', e);
+    }
+    setLoading(false);
+  }
+
+  async function handleFollow(user: SuggestedUser) {
+    const key = `${user.username}@${user.provider}`;
+    setFollowLoading((prev) => ({ ...prev, [key]: true }));
+    try {
+      await followUser(user.username, user.provider);
+      setFollowStates((prev) => ({ ...prev, [key]: true }));
+    } catch (e) {
+      console.error('Failed to follow user:', e);
+    } finally {
+      setFollowLoading((prev) => ({ ...prev, [key]: false }));
+    }
+  }
+
+  async function handleUnfollow(user: SuggestedUser) {
+    const key = `${user.username}@${user.provider}`;
+    setFollowLoading((prev) => ({ ...prev, [key]: true }));
+    try {
+      await unfollowUser(user.username, user.provider);
+      setFollowStates((prev) => ({ ...prev, [key]: false }));
+    } catch (e) {
+      console.error('Failed to unfollow user:', e);
+    } finally {
+      setFollowLoading((prev) => ({ ...prev, [key]: false }));
+    }
+  }
+
+  return (
+    <div className="md:max-w-xl md:mx-auto">
+      <div className="sticky top-0 z-10 bg-background/90 backdrop-blur-md border-b border-border md:static md:border-0 md:bg-transparent md:mb-4">
+        <div className="flex items-center justify-between px-4 py-3 md:px-0">
+          <div className="flex items-center gap-2">
+            <Sparkles className="w-5 h-5 text-brand" />
+            <h1 className="font-display text-lg font-bold text-foreground">Discover</h1>
+          </div>
+        </div>
+      </div>
+
+      <div className="px-4 md:px-0">
+        <p className="text-sm text-muted-foreground mb-4">
+          Suggested accounts to follow. Their posts will appear in your feed.
+        </p>
+
+        {loading ? (
+          <DiscoverSkeleton />
+        ) : users.length ? (
+          <div className="space-y-3">
+            {users.map((user) => {
+              const key = `${user.username}@${user.provider}`;
+              return (
+                <DiscoverUserCard
+                  key={key}
+                  user={user}
+                  isFollowing={!!followStates[key]}
+                  followLoading={!!followLoading[key]}
+                  onFollow={() => handleFollow(user)}
+                  onUnfollow={() => handleUnfollow(user)}
+                  onViewProfile={() => {
+                    // Navigate to user profile
+                    const event = new CustomEvent('navigate-user-profile', {
+                      detail: { username: user.username, provider: user.provider },
+                    });
+                    window.dispatchEvent(event);
+                  }}
+                />
+              );
+            })}
+          </div>
+        ) : (
+          <div className="py-16 text-center" data-testid="discover-empty">
+            <Users className="w-8 h-8 text-muted-foreground mx-auto mb-3 opacity-50" />
+            <p className="text-sm text-muted-foreground">No suggestions available</p>
+            <p className="text-xs text-muted-foreground/50 mt-1">Check back later for new accounts</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/marketing/web10-social/src/components/Feed/FeedScreen.tsx
+++ b/marketing/web10-social/src/components/Feed/FeedScreen.tsx
@@ -177,6 +177,8 @@ function CommentThread({ postId, isOpen, onCountChange }: CommentThreadProps) {
 interface PostCardProps {
   post: PostRecord;
   authorName: string;
+  authorUsername?: string;
+  authorProvider?: string;
   authorAvatar?: string;
   mediaItems: MediaRecord[];
   reactionCount: number;
@@ -185,11 +187,14 @@ interface PostCardProps {
   timestamp: string;
   onToggleLike: () => void;
   onCommentCountChange: (n: number) => void;
+  onAuthorClick?: (username: string, provider: string) => void;
 }
 
 function PostCard({
   post,
   authorName,
+  authorUsername,
+  authorProvider,
   authorAvatar,
   mediaItems,
   reactionCount,
@@ -198,6 +203,7 @@ function PostCard({
   timestamp,
   onToggleLike,
   onCommentCountChange,
+  onAuthorClick,
 }: PostCardProps) {
   const [commentsOpen, setCommentsOpen] = useState(false);
   const [localCount, setLocalCount] = useState(commentCount);
@@ -230,7 +236,22 @@ function PostCard({
           )}
         </Avatar>
         <div className="flex-1 min-w-0 flex items-baseline gap-1.5">
-          <span className="font-medium text-sm text-foreground truncate">{authorName}</span>
+          {authorUsername && onAuthorClick ? (
+            <button
+              type="button"
+              className="font-medium text-sm text-foreground truncate hover:text-brand-300 transition-colors duration-150"
+              onClick={(e) => {
+                e.stopPropagation();
+                onAuthorClick(authorUsername!, authorProvider!);
+              }}
+              aria-label={`View ${authorName}'s profile`}
+              data-testid="post-author-link"
+            >
+              {authorName}
+            </button>
+          ) : (
+            <span className="font-medium text-sm text-foreground truncate">{authorName}</span>
+          )}
           <span className="text-[0.8125rem] text-muted-foreground shrink-0">· {formatTimeAgo(timestamp)}</span>
         </div>
       </div>
@@ -347,7 +368,7 @@ function FeedSkeleton() {
   );
 }
 
-export default function FeedScreen() {
+export default function FeedScreen({ onAuthorClick }: { onAuthorClick?: (username: string, provider: string) => void }) {
   const [items, setItems] = useState<InboxRecord[]>([]);
   const [sort, setSort] = useState<FeedSort>('newest');
   const [loading, setLoading] = useState(true);
@@ -482,6 +503,8 @@ export default function FeedScreen() {
                 key={item._id || item.post_id}
                 post={post}
                 authorName={profile?.display_name || item.author_username}
+                authorUsername={item.author_username}
+                authorProvider={item.author_provider}
                 authorAvatar={
                   profile?.avatar_ref
                     ? mediaMap[item.post_id]?.find((m) => m._id === profile.avatar_ref)?.url
@@ -496,6 +519,7 @@ export default function FeedScreen() {
                 onCommentCountChange={(n) =>
                   setCommentMap((prev) => ({ ...prev, [item.post_id]: n }))
                 }
+                onAuthorClick={onAuthorClick}
               />
             );
           })

--- a/marketing/web10-social/src/components/Social/Layout.tsx
+++ b/marketing/web10-social/src/components/Social/Layout.tsx
@@ -1,5 +1,5 @@
 import { cn } from '@/lib/utils';
-import { Home, User, MessageSquare, PlusCircle, LogOut, Bug } from 'lucide-react';
+import { Home, User, MessageSquare, PlusCircle, LogOut, Bug, Compass } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import type { Mode } from '@/types';
 
@@ -8,11 +8,13 @@ interface LayoutProps {
   setMode: (m: Mode) => void;
   onLogout: () => void;
   onReportBug: () => void;
+  onNavigateToUser?: (username: string, provider: string) => void;
   children: React.ReactNode;
 }
 
 const navItems = [
   { mode: 'feed' as const, icon: Home, label: 'Feed', testId: 'nav-feed' },
+  { mode: 'discover' as const, icon: Compass, label: 'Discover', testId: 'nav-discover' },
   { mode: 'my-bio' as const, icon: User, label: 'Profile', testId: 'nav-profile' },
   { mode: 'chat' as const, icon: MessageSquare, label: 'Messages', testId: 'nav-messages' },
 ];
@@ -28,7 +30,7 @@ function Wordmark({ className }: { className?: string }) {
   );
 }
 
-export default function Layout({ mode, setMode, onLogout, onReportBug, children }: LayoutProps) {
+export default function Layout({ mode, setMode, onLogout, onReportBug, onNavigateToUser, children }: LayoutProps) {
   return (
     <div className="flex min-h-screen bg-background">
       {/* Sidebar - desktop */}

--- a/marketing/web10-social/src/data/feed.ts
+++ b/marketing/web10-social/src/data/feed.ts
@@ -257,3 +257,55 @@ export async function countUnread(): Promise<number> {
   const records = await wapi.read<InboxRecord>('inbox', { read: { $ne: true } });
   return records.length;
 }
+
+// ── Discovery: suggested users ──────────────────────────────────────────────
+
+export interface SuggestedUser {
+  username: string;
+  provider: string;
+  display_name?: string;
+  bio?: string;
+  avatar_ref?: string;
+  followers_count?: number;
+  posts_count?: number;
+}
+
+/**
+ * Fetch suggested accounts from the discovery API.
+ * PATCH /discover/users returns a list of accounts the current user
+ * might want to follow (personas, popular creators, etc.).
+ */
+export async function fetchSuggestedUsers(limit = 20): Promise<SuggestedUser[]> {
+  try {
+    const resp = await fetch(
+      `${API_ORIGIN}/discover/users?limit=${limit}`,
+      { method: 'PATCH' },
+    );
+    if (!resp.ok) return [];
+    return resp.json();
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Fetch a single post from the discovery API by user/service/id.
+ * This is how we read another user's public posts without direct
+ * collection access (the discovery index is anon-readable).
+ */
+export async function fetchDiscoveryPost(
+  username: string,
+  service: string,
+  postId: string,
+): Promise<DiscoveryPost | null> {
+  try {
+    const resp = await fetch(
+      `${API_ORIGIN}/discover/post/${encodeURIComponent(username)}/${encodeURIComponent(service)}/${encodeURIComponent(postId)}`,
+      { method: 'PATCH' },
+    );
+    if (!resp.ok) return null;
+    return resp.json();
+  } catch {
+    return null;
+  }
+}

--- a/marketing/web10-social/src/types.ts
+++ b/marketing/web10-social/src/types.ts
@@ -11,7 +11,9 @@ export type Mode =
   | "bulletin-edit"
   | "feed"
   | "crm"
-  | "mail";
+  | "mail"
+  | "discover"
+  | "user-profile";
 
 export type CrmColor = "green" | "yellow" | "red";
 

--- a/parallel execution.txt
+++ b/parallel execution.txt
@@ -478,6 +478,23 @@ LANE D — docs / apps / mobile (owns: mobile/**, marketing/, examples/
         §12 (PR screenshots). deferred: friends_posts (needs graph),
         unlisted_posts (anon-read, discovery-excluded).
         STATUS: Phase A LANDED (1.0.131). Phases B + C remain open.
+[ ] D24. PROFILE FOLLOWER/FOLLOWING COUNTS BUG — `ProfileScreen.tsx` loads
+        `countFollows()` and `readFollows()` in parallel and assigns both
+        `followingCount` AND `followerCount` from the same data source
+        (people YOU follow). There is no reverse lookup for who follows
+        YOU, so the "Followers" stat is a duplicate of "Following."
+        Fix: either wire a real follower-count endpoint (e.g. a public
+        ledger query or a discovery API call) or hide the follower stat
+        until the backend supports it. Owns marketing/web10-social/src/
+        components/Bio/ProfileScreen.tsx. Gate: none.
+[ ] D25. USER-PROFILE BACK NAVIGATION BUG — `handleBackFromProfile` in
+        `App.tsx` hardcodes `setMode('discover')` so leaving any user
+        profile always returns to Discover, even when the user came from
+        Feed, Chat, or Profile. The `prevModeRef` useEffect (lines
+        130-137) tracks mode changes but its conditional branches are
+        empty — it never stores the pre-profile mode. Fix: capture the
+        mode before navigating to `user-profile` and restore it on back.
+        Owns marketing/web10-social/src/App.tsx. Gate: none.
 [ ] D21. MEDIA POLISH — photos + video v0 (plan.txt phase 8.5; item
         number D20 skipped — it reads as decisions.md's D20
         everywhere). the composer's 80x80 hover-square tray, the


### PR DESCRIPTION
Adds the Discover screen with suggested accounts from the discovery API, follow/unfollow toggle, and skeleton/empty states. New UserProfileScreen for viewing other users' profiles with follow button, posts/media tabs, banner/avatar, and bio. FeedScreen author names are now clickable links that navigate to user profiles. Layout sidebar gains a Discover tab. ProfileScreen now shows follower/following stats. Includes tests for follow/unfollow, discover, user profile rendering, and author navigation in the feed.