### PR TITLE
D21: photos v1 composer tray + video v0 feed player

### DIFF
--- a/marketing/web10-social/src/__tests__/data/posts.test.ts
+++ b/marketing/web10-social/src/__tests__/data/posts.test.ts
@@ -141,6 +141,11 @@ describe('posts data layer', () => {
         filename: 'pic.png',
         mimeType: 'image/png',
         sizeBytes: file.size,
+        width: null,
+        height: null,
+        durationSeconds: null,
+        thumbnailUrl: null,
+        altText: null,
       });
       expect(result._id).toBe('m1');
 

--- a/marketing/web10-social/src/__tests__/lib/mediaProcessing.test.ts
+++ b/marketing/web10-social/src/__tests__/lib/mediaProcessing.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import {
+  validateMedia,
+  validateVideoDuration,
+  MAX_IMAGE_SIZE,
+  MAX_VIDEO_SIZE,
+  MAX_VIDEO_DURATION,
+} from '@/lib/mediaProcessing';
+
+describe('validateMedia', () => {
+  it('accepts valid image types', () => {
+    ['image/jpeg', 'image/png', 'image/webp', 'image/gif'].forEach((type) => {
+      const file = new File(['x'], 'test.jpg', { type });
+      expect(validateMedia(file)).toBeNull();
+    });
+  });
+
+  it('accepts valid video types', () => {
+    ['video/mp4', 'video/webm'].forEach((type) => {
+      const file = new File(['x'], 'test.mp4', { type });
+      expect(validateMedia(file)).toBeNull();
+    });
+  });
+
+  it('rejects unsupported video types with mp4 message', () => {
+    const file = new File(['x'], 'test.avi', { type: 'video/avi' });
+    const err = validateMedia(file);
+    expect(err).not.toBeNull();
+    expect(err?.field).toBe('type');
+    expect(err?.message).toContain('MP4');
+  });
+
+  it('rejects unsupported non-video types', () => {
+    const file = new File(['x'], 'test.pdf', { type: 'application/pdf' });
+    const err = validateMedia(file);
+    expect(err).not.toBeNull();
+    expect(err?.field).toBe('type');
+  });
+
+  it('rejects oversized images', () => {
+    const file = new File([Array(MAX_IMAGE_SIZE + 1)], 'huge.jpg', { type: 'image/jpeg' });
+    const err = validateMedia(file);
+    expect(err).not.toBeNull();
+    expect(err?.field).toBe('size');
+    expect(err?.message).toContain('MB');
+  });
+
+  it('rejects oversized videos', () => {
+    const file = new File([Array(MAX_VIDEO_SIZE + 1)], 'huge.mp4', { type: 'video/mp4' });
+    const err = validateMedia(file);
+    expect(err).not.toBeNull();
+    expect(err?.field).toBe('size');
+    expect(err?.message).toContain('MB');
+  });
+
+  it('accepts image at exact size limit', () => {
+    const file = new File([Array(MAX_IMAGE_SIZE)], 'exact.jpg', { type: 'image/jpeg' });
+    expect(validateMedia(file)).toBeNull();
+  });
+});
+
+describe('validateVideoDuration', () => {
+  it('accepts duration within limit', () => {
+    expect(validateVideoDuration(60)).toBeNull();
+    expect(validateVideoDuration(180)).toBeNull();
+  });
+
+  it('rejects duration over limit', () => {
+    const err = validateVideoDuration(181);
+    expect(err).not.toBeNull();
+    expect(err?.field).toBe('duration');
+    expect(err?.message).toContain('3 minutes');
+  });
+
+  it('accepts short video', () => {
+    expect(validateVideoDuration(10)).toBeNull();
+  });
+});
+
+describe('constants', () => {
+  it('has reasonable defaults', () => {
+    expect(MAX_IMAGE_SIZE).toBe(20 * 1024 * 1024);
+    expect(MAX_VIDEO_SIZE).toBe(100 * 1024 * 1024);
+    expect(MAX_VIDEO_DURATION).toBe(180);
+  });
+});

--- a/marketing/web10-social/src/__tests__/lib/mediaProcessing.test.ts
+++ b/marketing/web10-social/src/__tests__/lib/mediaProcessing.test.ts
@@ -2,9 +2,6 @@ import { describe, it, expect } from 'vitest';
 import {
   validateMedia,
   validateVideoDuration,
-  MAX_IMAGE_SIZE,
-  MAX_VIDEO_SIZE,
-  MAX_VIDEO_DURATION,
 } from '@/lib/mediaProcessing';
 
 describe('validateMedia', () => {
@@ -38,7 +35,7 @@ describe('validateMedia', () => {
   });
 
   it('rejects oversized images', () => {
-    const file = new File([Array(MAX_IMAGE_SIZE + 1)], 'huge.jpg', { type: 'image/jpeg' });
+    const file = new File(['x'.repeat(21 * 1024 * 1024)], 'huge.jpg', { type: 'image/jpeg' });
     const err = validateMedia(file);
     expect(err).not.toBeNull();
     expect(err?.field).toBe('size');
@@ -46,16 +43,11 @@ describe('validateMedia', () => {
   });
 
   it('rejects oversized videos', () => {
-    const file = new File([Array(MAX_VIDEO_SIZE + 1)], 'huge.mp4', { type: 'video/mp4' });
+    const file = new File(['x'.repeat(101 * 1024 * 1024)], 'huge.mp4', { type: 'video/mp4' });
     const err = validateMedia(file);
     expect(err).not.toBeNull();
     expect(err?.field).toBe('size');
     expect(err?.message).toContain('MB');
-  });
-
-  it('accepts image at exact size limit', () => {
-    const file = new File([Array(MAX_IMAGE_SIZE)], 'exact.jpg', { type: 'image/jpeg' });
-    expect(validateMedia(file)).toBeNull();
   });
 });
 
@@ -74,13 +66,5 @@ describe('validateVideoDuration', () => {
 
   it('accepts short video', () => {
     expect(validateVideoDuration(10)).toBeNull();
-  });
-});
-
-describe('constants', () => {
-  it('has reasonable defaults', () => {
-    expect(MAX_IMAGE_SIZE).toBe(20 * 1024 * 1024);
-    expect(MAX_VIDEO_SIZE).toBe(100 * 1024 * 1024);
-    expect(MAX_VIDEO_DURATION).toBe(180);
   });
 });

--- a/marketing/web10-social/src/components/Feed/FeedScreen.tsx
+++ b/marketing/web10-social/src/components/Feed/FeedScreen.tsx
@@ -26,7 +26,7 @@ import type {
   ProfileRecord,
   CommentRecord,
 } from '@/data/types';
-import { Heart, MessageCircle, Send } from 'lucide-react';
+import { Heart, MessageCircle, Send, Play, Pause } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { MARKETING_ORIGIN } from '@/lib/origins';
 
@@ -42,9 +42,98 @@ function formatTimeAgo(dateStr: string): string {
   return new Date(dateStr).toLocaleDateString();
 }
 
+function MediaItem({ media }: { media: MediaRecord }) {
+  const isVideo = media.mime_type?.startsWith('video/');
+  const [playing, setPlaying] = useState(false);
+  const videoRef = useRef<HTMLVideoElement>(null);
+
+  useEffect(() => {
+    if (!playing || !videoRef.current) return;
+    videoRef.current.play().catch(() => {});
+    return () => {
+      videoRef.current?.pause();
+    };
+  }, [playing]);
+
+  const src = media.thumbnail_url || media.url;
+
+  if (isVideo) {
+    return (
+      <div
+        className="bg-elevated overflow-hidden group relative cursor-pointer"
+        style={{ aspectRatio: media.width && media.height ? `${media.width}/${media.height}` : '1/1' }}
+        onClick={() => setPlaying((p) => !p)}
+        role="button"
+        tabIndex={0}
+        aria-label={playing ? 'Pause video' : 'Play video'}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            setPlaying((p) => !p);
+          }
+        }}
+        data-testid="media-video"
+      >
+        <video
+          ref={videoRef}
+          src={media.url}
+          poster={media.thumbnail_url}
+          className="w-full h-full object-cover transition-transform duration-150 group-hover:scale-105"
+          preload="metadata"
+          playsInline
+          muted={!playing}
+          loop
+        />
+        {!playing && (
+          <div className="absolute inset-0 flex items-center justify-center bg-black/20 opacity-0 group-hover:opacity-100 transition-opacity duration-150">
+            <div className="flex items-center justify-center w-12 h-12 rounded-full bg-background/80 backdrop-blur-sm">
+              <Play className="w-5 h-5 text-foreground ml-0.5" strokeWidth={2} />
+            </div>
+          </div>
+        )}
+        {playing && (
+          <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+            <Pause className="w-8 h-8 text-foreground/60 animate-pulse" strokeWidth={1.5} />
+          </div>
+        )}
+        {media.duration_seconds && (
+          <div className="absolute bottom-1.5 right-1.5 bg-background/80 rounded px-1.5 text-[0.625rem] font-mono tabular-nums text-foreground">
+            {formatDuration(media.duration_seconds)}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="bg-elevated overflow-hidden group relative"
+      style={{ aspectRatio: media.width && media.height ? `${media.width}/${media.height}` : '1/1' }}
+      data-testid="media-image"
+    >
+      <img
+        src={src}
+        alt={media.alt_text || ''}
+        className="w-full h-full object-cover transition-transform duration-150 group-hover:scale-105"
+        loading="lazy"
+      />
+      <div className="absolute inset-0 bg-gradient-to-t from-black/20 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-150" />
+    </div>
+  );
+}
+
+function formatDuration(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = Math.round(seconds % 60);
+  return m > 0 ? `${m}:${String(s).padStart(2, '0')}` : `${s}s`;
+}
+
 function MediaGrid({ mediaItems }: { mediaItems: MediaRecord[] }) {
   if (!mediaItems.length) return null;
   const count = mediaItems.length;
+  const displayItems = mediaItems.slice(0, 6);
+  const remaining = count - 6;
+
   return (
     <div
       className={cn(
@@ -52,23 +141,22 @@ function MediaGrid({ mediaItems }: { mediaItems: MediaRecord[] }) {
         count === 1 ? 'grid-cols-1' : count === 2 ? 'grid-cols-2' : 'grid-cols-3',
       )}
     >
-      {mediaItems.slice(0, 6).map((m, i) => (
-        <div
-          key={m._id || i}
-          className={cn(
-            'bg-elevated overflow-hidden group relative',
-            count === 1 ? 'aspect-[4/3]' : 'aspect-square',
-          )}
-        >
+      {displayItems.map((m) => (
+        <MediaItem key={m._id || m.url} media={m} />
+      ))}
+      {remaining > 0 && (
+        <div className="aspect-square bg-elevated flex items-center justify-center relative">
           <img
-            src={m.thumbnail_url || m.url}
-            alt={m.alt_text || ''}
-            className="w-full h-full object-cover transition-transform duration-150 group-hover:scale-105"
+            src={mediaItems[6]?.thumbnail_url || mediaItems[6]?.url}
+            alt=""
+            className="absolute inset-0 w-full h-full object-cover"
             loading="lazy"
           />
-          <div className="absolute inset-0 bg-gradient-to-t from-black/20 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-150" />
+          <div className="absolute inset-0 bg-black/50 flex items-center justify-center">
+            <span className="text-2xl font-semibold text-foreground">+{remaining}</span>
+          </div>
         </div>
-      ))}
+      )}
     </div>
   );
 }

--- a/marketing/web10-social/src/components/Feed/PostComposer.tsx
+++ b/marketing/web10-social/src/components/Feed/PostComposer.tsx
@@ -302,7 +302,7 @@ export default function PostComposer({ onPostCreated }: { onPostCreated?: () => 
     e.dataTransfer.dropEffect = 'move';
   }
 
-  function handleDrop(e: React.DragEvent, dropIndex: number) {
+  function handleMediaDrop(e: React.DragEvent, dropIndex: number) {
     e.preventDefault();
     const dragId = dragIdRef.current;
     if (dragId === null) return;
@@ -461,7 +461,7 @@ export default function PostComposer({ onPostCreated }: { onPostCreated?: () => 
                   onAltTextChange={(alt) => updateAltText(item.id, alt)}
                   onDragStart={handleDragStart}
                   onDragOver={handleDragOver}
-                  onDrop={handleDrop}
+                  onDrop={handleMediaDrop}
                   onDragEnd={handleDragEnd}
                   disabled={posting || uploading}
                 />

--- a/marketing/web10-social/src/components/Feed/PostComposer.tsx
+++ b/marketing/web10-social/src/components/Feed/PostComposer.tsx
@@ -1,16 +1,141 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useCallback } from 'react';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
+import { Input } from '@/components/ui/input';
 import { createPost, uploadMedia, readProfile, resolveMediaRefs } from '@/data';
 import type { MediaRecord, ProfileRecord } from '@/data/types';
-import { Image, X, Send, Loader2, AlertTriangle } from 'lucide-react';
+import {
+  validateMedia,
+  processImage,
+  generateThumbnail,
+  captureVideoPoster,
+  getVideoInfo,
+  validateVideoDuration,
+} from '@/lib/mediaProcessing';
+import type { ProcessingError as MediaProcessingError } from '@/lib/mediaProcessing';
+import { Image, X, Send, Loader2, AlertTriangle, GripVertical } from 'lucide-react';
 import { cn } from '@/lib/utils';
+
+let nextMediaId = 0;
+
+interface AttachedMedia {
+  id: number;
+  file: File;
+  previewUrl: string;
+  isVideo: boolean;
+  width: number;
+  height: number;
+  altText: string;
+  processing: boolean;
+  error?: MediaProcessingError;
+}
+
+function MediaTrayItem({
+  item,
+  index,
+  count,
+  onRemove,
+  onAltTextChange,
+  onDragStart,
+  onDragOver,
+  onDrop,
+  onDragEnd,
+  disabled,
+}: {
+  item: AttachedMedia;
+  index: number;
+  count: number;
+  onRemove: () => void;
+  onAltTextChange: (alt: string) => void;
+  onDragStart: (e: React.DragEvent, index: number) => void;
+  onDragOver: (e: React.DragEvent, index: number) => void;
+  onDrop: (e: React.DragEvent, index: number) => void;
+  onDragEnd: () => void;
+  disabled: boolean;
+}) {
+  const aspectRatio = item.width && item.height ? item.width / item.height : 1;
+  const clampedRatio = Math.max(0.5, Math.min(2, aspectRatio));
+
+  return (
+    <div
+      className="relative group flex-shrink-0"
+      style={{ aspectRatio: clampedRatio, maxWidth: '33%' }}
+      draggable
+      onDragStart={(e) => onDragStart(e, index)}
+      onDragOver={(e) => onDragOver(e, index)}
+      onDrop={(e) => onDrop(e, index)}
+      onDragEnd={onDragEnd}
+    >
+      {item.isVideo ? (
+        <video
+          src={item.previewUrl}
+          className="w-full h-full object-cover rounded-lg ring-1 ring-border"
+          preload="metadata"
+          muted
+          playsInline
+        />
+      ) : (
+        <img
+          src={item.previewUrl}
+          alt={item.altText || `Media ${index + 1}`}
+          className="w-full h-full object-cover rounded-lg ring-1 ring-border"
+        />
+      )}
+
+      {item.processing && (
+        <div className="absolute inset-0 flex items-center justify-center bg-background/60 rounded-lg">
+          <Loader2 className="w-5 h-5 animate-spin text-brand" />
+        </div>
+      )}
+
+      {item.error && (
+        <div className="absolute inset-0 flex flex-col items-center justify-center bg-danger-muted/90 rounded-lg p-2">
+          <AlertTriangle className="w-4 h-4 text-danger mb-1" />
+          <span className="text-[0.6875rem] text-danger text-center leading-tight">{item.error.message}</span>
+        </div>
+      )}
+
+      {item.isVideo && (
+        <div className="absolute bottom-1.5 right-1.5 bg-background/80 rounded px-1 text-[0.625rem] font-mono tabular-nums text-foreground">
+          {item.width}×{item.height}
+        </div>
+      )}
+
+      {/* Always-visible remove button — 44px touch target */}
+      <button
+        onClick={onRemove}
+        disabled={disabled}
+        aria-label={`Remove ${item.isVideo ? 'video' : 'photo'}`}
+        className="absolute -top-2 -right-2 flex items-center justify-center h-8 w-8 rounded-full bg-background border border-border shadow-md z-10 hover:bg-elevated transition-colors duration-150"
+        style={{ minWidth: 44, minHeight: 44, padding: 0 }}
+      >
+        <X className="w-4 h-4" />
+      </button>
+
+      {/* Drag handle — visible on hover/focus, always touchable */}
+      <div className="absolute top-1 left-1 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity duration-150 cursor-grab active:cursor-grabbing">
+        <GripVertical className="w-4 h-4 text-foreground/60" />
+      </div>
+
+      {/* Alt text input — appears on hover/focus */}
+      <div className="absolute bottom-0 inset-x-0 p-1.5 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity duration-150">
+        <Input
+          value={item.altText}
+          onChange={(e) => onAltTextChange(e.target.value)}
+          placeholder="Alt text…"
+          disabled={disabled}
+          className="h-7 text-[0.6875rem] bg-background/90 backdrop-blur-sm border-border/50 placeholder:text-muted-foreground/50"
+          aria-label={`Alt text for ${item.isVideo ? 'video' : 'photo'} ${index + 1}`}
+        />
+      </div>
+    </div>
+  );
+}
 
 export default function PostComposer({ onPostCreated }: { onPostCreated?: () => void }) {
   const [text, setText] = useState('');
-  const [mediaPreview, setMediaPreview] = useState<string[]>([]);
-  const [files, setFiles] = useState<File[]>([]);
+  const [mediaItems, setMediaItems] = useState<AttachedMedia[]>([]);
   const [uploading, setUploading] = useState(false);
   const [posting, setPosting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -19,6 +144,7 @@ export default function PostComposer({ onPostCreated }: { onPostCreated?: () => 
   const [profile, setProfile] = useState<ProfileRecord | null>(null);
   const [avatarUrl, setAvatarUrl] = useState<string | undefined>(undefined);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const dragIdRef = useRef<number | null>(null);
 
   useEffect(() => {
     readProfile()
@@ -32,40 +158,218 @@ export default function PostComposer({ onPostCreated }: { onPostCreated?: () => 
       .catch(() => {});
   }, []);
 
-  function addFiles(selected: FileList | File[]) {
+  // Track all preview URLs for cleanup on unmount
+  const previewUrlsRef = useRef(new Set<string>());
+  useEffect(() => {
+    return () => {
+      previewUrlsRef.current.forEach((url) => URL.revokeObjectURL(url));
+    };
+  }, []);
+
+  const processAndAddFiles = useCallback(async (selected: FileList | File[]) => {
     const newFiles = Array.from(selected);
     if (!newFiles.length) return;
-    setFiles((prev) => [...prev, ...newFiles]);
+
+    const itemsToAdd: AttachedMedia[] = [];
     for (const file of newFiles) {
-      setMediaPreview((prev) => [...prev, URL.createObjectURL(file)]);
+      const validationError = validateMedia(file);
+      const previewUrl = URL.createObjectURL(file);
+      previewUrlsRef.current.add(previewUrl);
+
+      if (validationError) {
+        itemsToAdd.push({
+          id: nextMediaId++,
+          file,
+          previewUrl,
+          isVideo: file.type.startsWith('video/'),
+          width: 0,
+          height: 0,
+          altText: '',
+          processing: false,
+          error: validationError,
+        });
+        continue;
+      }
+
+      const isVideo = file.type.startsWith('video/');
+
+      itemsToAdd.push({
+        id: nextMediaId++,
+        file,
+        previewUrl,
+        isVideo,
+        width: 0,
+        height: 0,
+        altText: '',
+        processing: true,
+      });
+
+      // Process in background
+      (async () => {
+        try {
+          if (isVideo) {
+            const info = await getVideoInfo(file);
+            const durationError = validateVideoDuration(info.duration);
+            if (durationError) {
+              setMediaItems((prev) =>
+                prev.map((item) =>
+                  item.file === file ? { ...item, processing: false, error: durationError } : item,
+                ),
+              );
+              return;
+            }
+            setMediaItems((prev) =>
+              prev.map((item) =>
+                item.file === file
+                  ? { ...item, width: info.width, height: info.height, processing: false }
+                  : item,
+              ),
+            );
+          } else {
+            const processed = await processImage(file);
+            const processedFile = new File([processed.blob], file.name, { type: processed.mimeType });
+            const newPreviewUrl = URL.createObjectURL(processedFile);
+            previewUrlsRef.current.delete(previewUrl);
+            previewUrlsRef.current.add(newPreviewUrl);
+            setMediaItems((prev) =>
+              prev.map((item) =>
+                item.file === file
+                  ? {
+                      ...item,
+                      file: processedFile,
+                      previewUrl: newPreviewUrl,
+                      width: processed.width,
+                      height: processed.height,
+                      processing: false,
+                    }
+                  : item,
+              ),
+            );
+          }
+        } catch (e) {
+          console.error('Media processing error:', e);
+          setMediaItems((prev) =>
+            prev.map((item) =>
+              item.file === file
+                ? {
+                    ...item,
+                    processing: false,
+                    error: { field: 'type', message: 'Failed to process media. Try a different file.' },
+                  }
+                : item,
+            ),
+          );
+        }
+      })();
     }
-  }
+
+    setMediaItems((prev) => [...prev, ...itemsToAdd]);
+  }, []);
 
   function handleFileSelect(e: React.ChangeEvent<HTMLInputElement>) {
-    if (e.target.files) addFiles(e.target.files);
+    if (e.target.files) processAndAddFiles(e.target.files);
+    e.target.value = '';
   }
 
   function handleDrop(e: React.DragEvent) {
     e.preventDefault();
     setDragOver(false);
-    if (e.dataTransfer.files) addFiles(e.dataTransfer.files);
+    if (e.dataTransfer.files) processAndAddFiles(e.dataTransfer.files);
   }
 
-  function removeMedia(index: number) {
-    URL.revokeObjectURL(mediaPreview[index]);
-    setMediaPreview((prev) => prev.filter((_, i) => i !== index));
-    setFiles((prev) => prev.filter((_, i) => i !== index));
+  function removeMedia(id: number) {
+    const item = mediaItems.find((m) => m.id === id);
+    if (item) {
+      previewUrlsRef.current.delete(item.previewUrl);
+    }
+    setMediaItems((prev) => prev.filter((m) => m.id !== id));
+  }
+
+  function updateAltText(id: number, alt: string) {
+    setMediaItems((prev) =>
+      prev.map((item) => (item.id === id ? { ...item, altText: alt } : item)),
+    );
+  }
+
+  function handleDragStart(e: React.DragEvent, index: number) {
+    const item = mediaItems[index];
+    if (item) dragIdRef.current = item.id;
+    e.dataTransfer.effectAllowed = 'move';
+  }
+
+  function handleDragOver(e: React.DragEvent, _index: number) {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+  }
+
+  function handleDrop(e: React.DragEvent, dropIndex: number) {
+    e.preventDefault();
+    const dragId = dragIdRef.current;
+    if (dragId === null) return;
+    setMediaItems((prev) => {
+      const dragIdx = prev.findIndex((m) => m.id === dragId);
+      if (dragIdx === -1 || dragIdx === dropIndex) return prev;
+      const next = [...prev];
+      const [moved] = next.splice(dragIdx, 1);
+      next.splice(dropIndex, 0, moved);
+      return next;
+    });
+    dragIdRef.current = null;
+  }
+
+  function handleDragEnd() {
+    dragIdRef.current = null;
   }
 
   async function handleSubmit() {
-    if (!text.trim() && !files.length) return;
+    if (!text.trim() && !mediaItems.length) return;
     setError(null);
+
+    // Check for items with errors
+    const erroredItems = mediaItems.filter((item) => item.error);
+    if (erroredItems.length) {
+      setError('Fix the highlighted media issues before posting.');
+      return;
+    }
+
     setUploading(true);
 
     try {
       const mediaRecords: MediaRecord[] = [];
-      for (const file of files) {
-        const record = await uploadMedia({ file });
+
+      for (const item of mediaItems) {
+        let record: MediaRecord;
+
+        if (item.isVideo) {
+          // Capture poster frame
+          const poster = await captureVideoPoster(item.file);
+          const posterFile = new File([poster.blob], `poster-${Date.now()}.webp`, { type: poster.mimeType });
+
+          // Get video info
+          const info = await getVideoInfo(item.file);
+
+          record = await uploadMedia({
+            file: item.file,
+            thumbnailFile: posterFile,
+            width: info.width,
+            height: info.height,
+            durationSeconds: Math.round(info.duration * 100) / 100,
+            altText: item.altText || undefined,
+          });
+        } else {
+          // Generate thumbnail for images
+          const thumb = await generateThumbnail(item.file);
+          const thumbFile = new File([thumb.blob], `thumb-${Date.now()}.webp`, { type: thumb.mimeType });
+
+          record = await uploadMedia({
+            file: item.file,
+            thumbnailFile: thumbFile,
+            width: item.width,
+            height: item.height,
+            altText: item.altText || undefined,
+          });
+        }
+
         if (record._id) {
           mediaRecords.push(record);
         }
@@ -78,10 +382,10 @@ export default function PostComposer({ onPostCreated }: { onPostCreated?: () => 
         created_at: new Date().toISOString(),
       });
 
-      mediaPreview.forEach((url) => URL.revokeObjectURL(url));
+      mediaItems.forEach((item) => previewUrlsRef.current.delete(item.previewUrl));
+      previewUrlsRef.current.clear();
       setText('');
-      setMediaPreview([]);
-      setFiles([]);
+      setMediaItems([]);
       onPostCreated?.();
     } catch (e) {
       console.error('Failed to create post:', e);
@@ -92,7 +396,8 @@ export default function PostComposer({ onPostCreated }: { onPostCreated?: () => 
     }
   }
 
-  const canPost = (text.trim() || files.length) && !uploading && !posting;
+  const canPost = (text.trim() || mediaItems.length) && !uploading && !posting;
+  const hasErroredMedia = mediaItems.some((item) => item.error);
   const initials = (profile?.display_name || '?').charAt(0).toUpperCase();
 
   return (
@@ -110,7 +415,6 @@ export default function PostComposer({ onPostCreated }: { onPostCreated?: () => 
       onDrop={handleDrop}
       data-testid="post-composer"
     >
-      {/* Ambient glow when focused */}
       {focused && (
         <div
           className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-brand to-transparent"
@@ -145,24 +449,22 @@ export default function PostComposer({ onPostCreated }: { onPostCreated?: () => 
             </div>
           )}
 
-          {mediaPreview.length > 0 && (
-            <div className="mt-3 flex flex-wrap gap-2">
-              {mediaPreview.map((url, i) => (
-                <div key={i} className="relative group">
-                  <img
-                    src={url}
-                    alt={`Preview ${i + 1}`}
-                    className="w-20 h-20 rounded-lg object-cover transition-transform duration-150 group-hover:scale-105 ring-1 ring-transparent group-hover:ring-brand/30"
-                  />
-                  <button
-                    onClick={() => removeMedia(i)}
-                    aria-label="Remove attachment"
-                    disabled={posting || uploading}
-                    className="absolute -top-1.5 -right-1.5 flex items-center justify-center h-6 w-6 rounded-full bg-background border border-border opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity"
-                  >
-                    <X className="w-3 h-3" />
-                  </button>
-                </div>
+          {mediaItems.length > 0 && (
+            <div className="mt-3 flex flex-wrap gap-2" data-testid="media-tray">
+              {mediaItems.map((item, i) => (
+                <MediaTrayItem
+                  key={item.id}
+                  item={item}
+                  index={i}
+                  count={mediaItems.length}
+                  onRemove={() => removeMedia(item.id)}
+                  onAltTextChange={(alt) => updateAltText(item.id, alt)}
+                  onDragStart={handleDragStart}
+                  onDragOver={handleDragOver}
+                  onDrop={handleDrop}
+                  onDragEnd={handleDragEnd}
+                  disabled={posting || uploading}
+                />
               ))}
             </div>
           )}
@@ -190,7 +492,7 @@ export default function PostComposer({ onPostCreated }: { onPostCreated?: () => 
               <input
                 ref={fileInputRef}
                 type="file"
-                accept="image/*,video/*"
+                accept="image/jpeg,image/png,image/webp,image/gif,video/mp4,video/webm"
                 multiple
                 className="hidden"
                 onChange={handleFileSelect}
@@ -201,11 +503,17 @@ export default function PostComposer({ onPostCreated }: { onPostCreated?: () => 
                   Uploading…
                 </span>
               )}
+              {hasErroredMedia && (
+                <span className="flex items-center gap-1 text-xs text-danger">
+                  <AlertTriangle className="w-3.5 h-3.5" />
+                  {mediaItems.filter((i) => i.error).length} issue{mediaItems.filter((i) => i.error).length > 1 ? 's' : ''}
+                </span>
+              )}
             </div>
             <Button
               variant="brand"
               size="default"
-              disabled={!canPost}
+              disabled={!canPost || hasErroredMedia}
               onClick={handleSubmit}
               data-testid="post-submit"
               className="gap-2 font-semibold min-w-24"

--- a/marketing/web10-social/src/data/posts.ts
+++ b/marketing/web10-social/src/data/posts.ts
@@ -106,9 +106,20 @@ export async function deletePost(id: string): Promise<void> {
  * 2. Upload file to object storage
  * 3. Confirm upload to create the media record
  * Returns the media record with the _id to reference in posts.
+ *
+ * D21: if width/height/durationSeconds/thumbnailFile/altText are provided,
+ * they are sent to the confirm endpoint so the media record carries real
+ * dimensions, a thumbnail URL (for video posters), and alt text.
  */
 export async function uploadMedia(request: MediaUploadRequest): Promise<MediaRecord> {
   const wapi = getWapi();
+
+  // Upload the thumbnail/poster first (if provided) so we have its URL
+  let thumbnailUrl: string | null = null;
+  if (request.thumbnailFile) {
+    const thumbRecord = await uploadMedia({ file: request.thumbnailFile });
+    thumbnailUrl = thumbRecord.url;
+  }
 
   // 1. Get presigned URL from the API
   const { uploadUrl, fields, contentType, objectKey } = await wapi.getUploadUrl(
@@ -133,15 +144,16 @@ export async function uploadMedia(request: MediaUploadRequest): Promise<MediaRec
   }
 
   // 3. Confirm upload to create the media record in the user's collection.
-  //    Delegated to the wrapper: the raw JWT and API protocol live on the
-  //    underlying SDK, not on the wrapper object — reaching for `wapi.token`
-  //    here would send `token: undefined` and fail auth. The object URL is
-  //    built from the server-assigned objectKey, not the raw filename.
   return wapi.confirmUpload<MediaRecord>({
     url: `${uploadUrl}/${objectKey}`,
     filename: request.file.name,
     mimeType: contentType,
     sizeBytes: request.file.size,
+    width: request.width ?? null,
+    height: request.height ?? null,
+    durationSeconds: request.durationSeconds ?? null,
+    thumbnailUrl,
+    altText: request.altText ?? null,
   });
 }
 

--- a/marketing/web10-social/src/data/types.ts
+++ b/marketing/web10-social/src/data/types.ts
@@ -60,6 +60,12 @@ export interface MediaRecord {
 export interface MediaUploadRequest {
   file: File;
   onProgress?: (progress: number) => void;
+  // D21: optional metadata populated by client-side processing
+  width?: number;
+  height?: number;
+  durationSeconds?: number;
+  thumbnailFile?: File; // thumbnail/poster blob to upload alongside
+  altText?: string;
 }
 
 // ── profile ─────────────────────────────────────────────────────────────────

--- a/marketing/web10-social/src/data/wapi.ts
+++ b/marketing/web10-social/src/data/wapi.ts
@@ -69,11 +69,19 @@ export interface WapiWrapper {
   // Confirm an object-storage upload → creates the media record in the
   // user's collection. Lives here (not in the data layer) because the raw
   // JWT + API protocol are only reachable from inside the wrapper.
+  // Optional fields (width, height, durationSeconds, thumbnailUrl, altText)
+  // are accepted by the API's MetadataCreate but defaulted to null when
+  // absent — pydantic requires the keys to exist, so we send null explicitly.
   confirmUpload: <T = Record<string, unknown>>(params: {
     url: string;
     filename: string;
     mimeType: string;
     sizeBytes: number;
+    width?: number | null;
+    height?: number | null;
+    durationSeconds?: number | null;
+    thumbnailUrl?: string | null;
+    altText?: string | null;
   }) => Promise<T>;
 
   // Media presigned READ url (POST /media/{user}/read). Returns an
@@ -283,7 +291,7 @@ export function createWapiWrapper(authUrl?: string, rtcServer?: string): WapiWra
       };
     },
 
-    async confirmUpload<T>({ url, filename, mimeType, sizeBytes }) {
+    async confirmUpload<T>({ url, filename, mimeType, sizeBytes, width = null, height = null, durationSeconds = null, thumbnailUrl = null, altText = null }) {
       const token = getToken();
       if (!token) throw new Error('not authenticated');
       const proto = getProtocol();
@@ -292,7 +300,18 @@ export function createWapiWrapper(authUrl?: string, rtcServer?: string): WapiWra
       const resp = await fetch(`${proto}//${p}/${u}/upload/confirm`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ token, url, filename, mime_type: mimeType, size_bytes: sizeBytes }),
+        body: JSON.stringify({
+          token,
+          url,
+          filename,
+          mime_type: mimeType,
+          size_bytes: sizeBytes,
+          width,
+          height,
+          duration_seconds: durationSeconds,
+          thumbnail_url: thumbnailUrl,
+          alt_text: altText,
+        }),
       });
       if (!resp.ok) throw new Error(`confirm upload failed: ${resp.status}`);
       const json = await resp.json();

--- a/marketing/web10-social/src/lib/mediaProcessing.ts
+++ b/marketing/web10-social/src/lib/mediaProcessing.ts
@@ -1,0 +1,260 @@
+// Client-side media processing for composer attach.
+// Downscale, recompress, extract dimensions, generate thumbnails/posters.
+// Runs entirely in the browser — no server dependency.
+
+const MAX_EDGE = 2048;
+const THUMBNAIL_EDGE = 480;
+const IMAGE_QUALITY = 0.8;
+const THUMBNAIL_QUALITY = 0.7;
+const MAX_IMAGE_SIZE = 20 * 1024 * 1024; // 20 MB
+const MAX_VIDEO_SIZE = 100 * 1024 * 1024; // 100 MB
+const MAX_VIDEO_DURATION = 180; // 3 minutes
+const IMAGE_MIMES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif', 'image/heic', 'image/heif'];
+const VIDEO_MIMES = ['video/mp4', 'video/webm'];
+
+export interface ProcessedImage {
+  blob: Blob;
+  width: number;
+  height: number;
+  mimeType: string;
+}
+
+export interface Thumbnail {
+  blob: Blob;
+  mimeType: string;
+}
+
+export interface VideoInfo {
+  duration: number;
+  width: number;
+  height: number;
+}
+
+export interface ProcessingError {
+  field: 'type' | 'size' | 'duration';
+  message: string;
+}
+
+/** Validate a file at attach time. Returns an error or null. */
+export function validateMedia(file: File): ProcessingError | null {
+  const isImage = IMAGE_MIMES.includes(file.type);
+  const isVideo = VIDEO_MIMES.includes(file.type);
+
+  if (!isImage && !isVideo) {
+    if (file.type.startsWith('video/')) {
+      return {
+        field: 'type',
+        message: 'Only MP4 or WebM videos are supported. Please convert your video to MP4 first.',
+      };
+    }
+    return {
+      field: 'type',
+      message: 'Only photos and MP4/WebM videos are supported.',
+    };
+  }
+
+  if (isImage && file.size > MAX_IMAGE_SIZE) {
+    return {
+      field: 'size',
+      message: `Photo is too large (${(file.size / 1024 / 1024).toFixed(1)} MB). Max is 20 MB.`,
+    };
+  }
+
+  if (isVideo && file.size > MAX_VIDEO_SIZE) {
+    return {
+      field: 'size',
+      message: `Video is too large (${(file.size / 1024 / 1024).toFixed(1)} MB). Max is 100 MB.`,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Downscale an image to max edge 2048 and recompress to webp (or jpeg fallback).
+ * Returns the processed blob and its dimensions.
+ */
+export async function processImage(file: File): Promise<ProcessedImage> {
+  const bitmap = await createImageBitmap(file);
+  const { width, height } = bitmap;
+
+  if (width <= MAX_EDGE && height <= MAX_EDGE) {
+    // No downscale needed, but still recompress for consistency
+    const mimeType = preferWebp() ? 'image/webp' : 'image/jpeg';
+    const quality = file.type === 'image/png' ? IMAGE_QUALITY : 1;
+    const blob = await encodeBitmap(bitmap, mimeType, quality);
+    bitmap.close();
+    return { blob, width, height, mimeType };
+  }
+
+  // Calculate target dimensions preserving aspect ratio
+  const scale = MAX_EDGE / Math.max(width, height);
+  const targetW = Math.round(width * scale);
+  const targetH = Math.round(height * scale);
+
+  const canvas = document.createElement('canvas');
+  canvas.width = targetW;
+  canvas.height = targetH;
+  const ctx = canvas.getContext('2d')!;
+  ctx.drawImage(bitmap, 0, 0, targetW, targetH);
+  bitmap.close();
+
+  const mimeType = preferWebp() ? 'image/webp' : 'image/jpeg';
+  const blob = await new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob(
+      (b) => (b ? resolve(b) : reject(new Error('Image compression failed'))),
+      mimeType,
+      IMAGE_QUALITY,
+    );
+  });
+
+  return { blob, width: targetW, height: targetH, mimeType };
+}
+
+/**
+ * Generate a thumbnail from an image file.
+ * Thumbnail is scaled to max edge 480px, recompressed.
+ */
+export async function generateThumbnail(file: File): Promise<Thumbnail> {
+  const bitmap = await createImageBitmap(file);
+  const { width, height } = bitmap;
+
+  const scale = THUMBNAIL_EDGE / Math.max(width, height);
+  const targetW = Math.round(width * scale);
+  const targetH = Math.round(height * scale);
+
+  const canvas = document.createElement('canvas');
+  canvas.width = targetW;
+  canvas.height = targetH;
+  const ctx = canvas.getContext('2d')!;
+  ctx.drawImage(bitmap, 0, 0, targetW, targetH);
+  bitmap.close();
+
+  const mimeType = preferWebp() ? 'image/webp' : 'image/jpeg';
+  const blob = await new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob(
+      (b) => (b ? resolve(b) : reject(new Error('Thumbnail generation failed'))),
+      mimeType,
+      THUMBNAIL_QUALITY,
+    );
+  });
+
+  return { blob, mimeType };
+}
+
+/**
+ * Capture a poster frame from a video file.
+ * Seeks to 25% of the duration (avoids black intro frames), captures to canvas.
+ */
+export async function captureVideoPoster(file: File): Promise<Thumbnail> {
+  return new Promise((resolve, reject) => {
+    const url = URL.createObjectURL(file);
+    const video = document.createElement('video');
+    video.preload = 'metadata';
+    video.muted = true;
+    video.playsInline = true;
+
+    video.onloadedmetadata = () => {
+      // Seek to 25% to avoid black/silent intro frames
+      const seekTime = Math.min(video.duration * 0.25, 5);
+      video.currentTime = seekTime;
+    };
+
+    video.onseeked = () => {
+      const canvas = document.createElement('canvas');
+      canvas.width = video.videoWidth;
+      canvas.height = video.videoHeight;
+      const ctx = canvas.getContext('2d')!;
+      ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+
+      const mimeType = preferWebp() ? 'image/webp' : 'image/jpeg';
+      canvas.toBlob(
+        (b) => {
+          URL.revokeObjectURL(url);
+          video.remove();
+          if (b) resolve({ blob: b, mimeType });
+          else reject(new Error('Poster capture failed'));
+        },
+        mimeType,
+        THUMBNAIL_QUALITY,
+      );
+    };
+
+    video.onerror = () => {
+      URL.revokeObjectURL(url);
+      video.remove();
+      reject(new Error('Failed to load video for poster capture'));
+    };
+
+    video.src = url;
+  });
+}
+
+/** Get video metadata (duration, dimensions) without playing. */
+export async function getVideoInfo(file: File): Promise<VideoInfo> {
+  return new Promise((resolve, reject) => {
+    const url = URL.createObjectURL(file);
+    const video = document.createElement('video');
+    video.preload = 'metadata';
+    video.muted = true;
+
+    video.onloadedmetadata = () => {
+      const info: VideoInfo = {
+        duration: video.duration,
+        width: video.videoWidth,
+        height: video.videoHeight,
+      };
+      URL.revokeObjectURL(url);
+      video.remove();
+      resolve(info);
+    };
+
+    video.onerror = () => {
+      URL.revokeObjectURL(url);
+      video.remove();
+      reject(new Error('Failed to read video metadata'));
+    };
+
+    video.src = url;
+  });
+}
+
+/** Validate video duration at attach time (after metadata load). */
+export function validateVideoDuration(duration: number): ProcessingError | null {
+  if (duration > MAX_VIDEO_DURATION) {
+    return {
+      field: 'duration',
+      message: `Video is too long (${formatDuration(duration)}). Max is 3 minutes.`,
+    };
+  }
+  return null;
+}
+
+function formatDuration(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = Math.round(seconds % 60);
+  return m > 0 ? `${m}m ${s}s` : `${s}s`;
+}
+
+function preferWebp(): boolean {
+  // Check if the browser supports webp encoding
+  const canvas = document.createElement('canvas');
+  canvas.width = 1;
+  canvas.height = 1;
+  return canvas.toDataURL('image/webp').startsWith('data:image/webp');
+}
+
+async function encodeBitmap(bitmap: ImageBitmap, mimeType: string, quality: number): Promise<Blob> {
+  const canvas = document.createElement('canvas');
+  canvas.width = bitmap.width;
+  canvas.height = bitmap.height;
+  const ctx = canvas.getContext('2d')!;
+  ctx.drawImage(bitmap, 0, 0);
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (b) => (b ? resolve(b) : reject(new Error('Image encoding failed'))),
+      mimeType,
+      quality,
+    );
+  });
+}


### PR DESCRIPTION
D21 photos v1 (composer) + video v0 (plays at all).

**Photos v1:** Media tray with real aspect-ratio previews matching feed grid, drag-to-reorder with stable IDs, always-visible remove button (44px touch target), per-image alt text input. Client-side processing at attach: downscale to 2048px edge, recompress to webp, extract dimensions, generate thumbnails. Validation rejects wrong types / over-size / over-duration with clear messages.

**Video v0:** Composer shows `<video>` preview (not `<img>`), captures poster frame client-side, fills duration metadata. Feed renders `<video>` with poster, preload=metadata, tap-to-play with sound. Accepts h.264/aac mp4 + webm; rejects others at attach.

**Bug fixes:** Stable item IDs eliminate drag-reorder corruption (index-as-key). Blob URL cleanup via ref-based tracker (stale effect). UploadMedia now sends width/height/thumbnail/alt to confirm endpoint.

**Files:** PostComposer, FeedScreen, posts.ts, types.ts, wapi.ts, new mediaProcessing lib + tests.