### PR TITLE
fix: PATCH /public/entries 422 on empty body (anon read)

### DIFF
--- a/api/app/endpoints/public.py
+++ b/api/app/endpoints/public.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Query
 
 import app.exceptions as exceptions
 from app.models.auth import Token
@@ -38,22 +38,17 @@ async def create_public_entry(token: Token):
 
 
 @router.patch("/public/entries", tags=["public"])
-async def query_public_entries(token: Token):
+async def query_public_entries(
+    schema_id: str | None = Query(None),
+    target: str | None = Query(None),
+    author: str | None = Query(None),
+    limit: int = Query(50, ge=1, le=200),
+    skip: int = Query(0, ge=0),
+):
     """Query the public ledger. Anon OK.
 
     Filter by schema_id, target, author via query params.
     """
-    schema_id = None
-    target = None
-    author = None
-    limit = 50
-    skip = 0
-    if token.query:
-        schema_id = token.query.get("schema_id")
-        target = token.query.get("target")
-        author = token.query.get("author")
-        limit = min(token.query.get("limit", 50), 200)
-        skip = token.query.get("skip", 0)
     return db.query_public_entries(
         schema_id=schema_id,
         target=target,

--- a/api/tests/test_discovery.py
+++ b/api/tests/test_discovery.py
@@ -346,28 +346,19 @@ class TestPublicQueryEntries:
         mock_public_col.find.return_value.sort.return_value.skip.return_value.limit.return_value = [
             {"_id": "e1", "author": "bob", "schema_id": "s1", "payload": {"action": "like"}},
         ]
-        resp = client.patch(
-            "/public/entries",
-            json={"token": None},
-        )
+        resp = client.patch("/public/entries")
         assert resp.status_code == 200
         assert len(resp.json()) == 1
 
     def test_query_filter_by_schema_id(self, client, mock_public_col):
         mock_public_col.find.return_value.sort.return_value.skip.return_value.limit.return_value = []
-        resp = client.patch(
-            "/public/entries",
-            json={"token": None, "query": {"schema_id": "api.localhost.uuid6:reactions"}},
-        )
+        resp = client.patch("/public/entries?schema_id=api.localhost.uuid6:reactions")
         assert resp.status_code == 200
         assert resp.json() == []
 
     def test_query_filter_by_target(self, client, mock_public_col):
         mock_public_col.find.return_value.sort.return_value.skip.return_value.limit.return_value = []
-        resp = client.patch(
-            "/public/entries",
-            json={"token": None, "query": {"target": "alice/posts/123"}},
-        )
+        resp = client.patch("/public/entries?target=alice/posts/123")
         assert resp.status_code == 200
 
 

--- a/persona-orchestration/seed_personas.py
+++ b/persona-orchestration/seed_personas.py
@@ -420,6 +420,7 @@ def read_records(base, username, service, token, query=None):
 def query_ledger(base, token, target=None, author=None, schema_id=None, limit=200):
     """PATCH /public/entries — query the public ledger (anon OK, token OK).
     Filter by target / author / schema_id. Returns list of entries."""
+    from urllib.parse import urlencode
     q = {"limit": limit}
     if target:
         q["target"] = target
@@ -427,7 +428,7 @@ def query_ledger(base, token, target=None, author=None, schema_id=None, limit=20
         q["author"] = author
     if schema_id:
         q["schema_id"] = schema_id
-    status, body = api(base, "PATCH", "/public/entries", {"token": token, "query": q})
+    status, body = api(base, "PATCH", f"/public/entries?{urlencode(q)}")
     if status == 200 and isinstance(body, list):
         return body
     return []


### PR DESCRIPTION
The PATCH /public/entries endpoint required a Token body model, causing 422 when the client sent filter params via URL query string with no body (anon read, no token to include).

Changes:
- Endpoint now reads schema_id, target, author, limit, skip from URL query params (FastAPI Query) — no body required.
- seed_personas.py query_ledger passes params via URL instead of JSON body.
- Tests updated to use URL query params (3/3 green).