### PR TITLE
fix(marketing-ui): knob label clipping + fetch recent posts

### DIFF
--- a/marketing/marketing-ui/src/components/RotaryKnob.tsx
+++ b/marketing/marketing-ui/src/components/RotaryKnob.tsx
@@ -112,7 +112,7 @@ function RotaryKnob({
 
   return (
     <div
-      className={`group/knob flex flex-col items-center gap-1 ${tickClass}`}
+      className={`group/knob flex flex-col items-center gap-2 ${tickClass}`}
       data-testid={dataTestId ?? 'rotary-knob'}
     >
       {/* Readout */}
@@ -124,7 +124,7 @@ function RotaryKnob({
       <div className="relative flex items-center justify-center">
         {/* Scale track */}
         <div
-          className="absolute z-0 h-24 w-1 rounded-full bg-elevated"
+          className="absolute z-0 h-20 w-1 rounded-full bg-elevated"
           onClick={handleScaleClick}
           role="presentation"
         >

--- a/marketing/marketing-ui/src/components/Trending.test.tsx
+++ b/marketing/marketing-ui/src/components/Trending.test.tsx
@@ -207,7 +207,10 @@ describe('Trending page', () => {
       vi.mocked(fetch).mock.calls
         .filter(c => String(c[0]).includes('/discover/posts'))
         .map(c => String(c[1]?.body));
-    expect(discoverBodies()).toEqual(['{"query":{"sort":"trending","limit":20}}']);
+    expect(discoverBodies()).toEqual([
+      '{"query":{"sort":"trending","limit":20}}',
+      '{"query":{"sort":"recent","limit":20}}',
+    ]);
     fireEvent.click(loadMore);
     await waitFor(() =>
       expect(discoverBodies()).toContain('{"query":{"sort":"trending","limit":40}}'),

--- a/marketing/marketing-ui/src/index.css
+++ b/marketing/marketing-ui/src/index.css
@@ -118,6 +118,16 @@ body {
 .dialog-content[data-state='open'] { animation: dialog-content-in 220ms ease-out; }
 .dialog-content[data-state='closed'] { animation: dialog-content-in 150ms ease-out reverse; }
 
+@keyframes scale-tick {
+  0% { transform: scale(1); }
+  30% { transform: scale(1.08); }
+  100% { transform: scale(1); }
+}
+
+.scale-tick {
+  animation: scale-tick 150ms ease-out;
+}
+
 /*
  * Docs prose (design.md §5: 65-75ch measure, Space Grotesk headings,
  * JetBrains Mono code). The markdown pipeline (remark) emits raw HTML via

--- a/marketing/marketing-ui/src/pages/Trending.tsx
+++ b/marketing/marketing-ui/src/pages/Trending.tsx
@@ -78,8 +78,20 @@ function Trending() {
   const loadFeed = useCallback(async (nextLimit: number, append: boolean) => {
     if (append) setLoadingMore(true); else setLoading(true);
     try {
-      const results = await fetchDiscoverFeed('trending', nextLimit);
-      const posts = results.map(mapDiscoveryToFeedPost);
+      const [trendingResults, recentResults] = await Promise.all([
+        fetchDiscoverFeed('trending', nextLimit),
+        fetchDiscoverFeed('recent', nextLimit),
+      ]);
+      // Merge both sources, deduplicate by post id
+      const all = [...trendingResults];
+      const seen = new Set(all.map(p => p.id));
+      for (const p of recentResults) {
+        if (!seen.has(p.id)) {
+          all.push(p);
+          seen.add(p.id);
+        }
+      }
+      const posts = all.map(mapDiscoveryToFeedPost);
       setAllPosts(posts);
       setHasMore(posts.length === nextLimit && nextLimit < MAX_RESULTS);
     } catch {


### PR DESCRIPTION
Two fixes for the /trending page:

1. **Knob label clipping** — added the missing `scale-tick` animation keyframes, reduced the scale track height (h-24 → h-20), and increased column gap (gap-1 → gap-2) so readout labels and bottom labels no longer overlap with the scale track.

2. **Missing recent posts** — the trending page now fetches both `trending` and `recent` feeds in parallel and deduplicates by post id, so brand-new posts with zero engagement appear in the pool regardless of knob settings.

101 tests green.