### PR TITLE
D35: public_media service for anon-readable media presigns

### DIFF
--- a/marketing/web10-social/src/__tests__/data/posts.test.ts
+++ b/marketing/web10-social/src/__tests__/data/posts.test.ts
@@ -146,6 +146,7 @@ describe('posts data layer', () => {
         durationSeconds: null,
         thumbnailUrl: null,
         altText: null,
+        service: undefined,
       });
       expect(result._id).toBe('m1');
 
@@ -221,7 +222,7 @@ describe('posts data layer', () => {
       mock.getReadUrl.mockResolvedValue({ readUrl: presigned, expiresIn: 60 });
 
       const result = await posts.resolveMediaRefs(['m9']);
-      expect(mock.getReadUrl).toHaveBeenCalledWith('alice/abc/pic.png', undefined, undefined);
+      expect(mock.getReadUrl).toHaveBeenCalledWith('alice/abc/pic.png', undefined, undefined, undefined);
       expect(result[0].url).toBe(presigned);
     });
 
@@ -234,7 +235,7 @@ describe('posts data layer', () => {
       mock.getReadUrl.mockResolvedValue({ readUrl: 'https://signed/real', expiresIn: 60 });
 
       await posts.resolveMediaRefs(['mK']);
-      expect(mock.getReadUrl).toHaveBeenCalledWith('bob/zz/real.png', undefined, undefined);
+      expect(mock.getReadUrl).toHaveBeenCalledWith('bob/zz/real.png', undefined, undefined, undefined);
     });
 
     it('D23: thumbnail gets its own presigned URL when it differs from the full image', async () => {
@@ -251,8 +252,8 @@ describe('posts data layer', () => {
 
       const result = await posts.resolveMediaRefs(['m1']);
 
-      expect(mock.getReadUrl).toHaveBeenNthCalledWith(1, 'alice/abc/photo.png', undefined, undefined);
-      expect(mock.getReadUrl).toHaveBeenNthCalledWith(2, 'alice/abc/photo-thumb.png', undefined, undefined);
+      expect(mock.getReadUrl).toHaveBeenNthCalledWith(1, 'alice/abc/photo.png', undefined, undefined, undefined);
+      expect(mock.getReadUrl).toHaveBeenNthCalledWith(2, 'alice/abc/photo-thumb.png', undefined, undefined, undefined);
       expect(result[0].url).toBe('https://signed/photo?sig=full');
       expect(result[0].thumbnail_url).toBe('https://signed/photo-thumb?sig=thumb');
     });

--- a/marketing/web10-social/src/data/posts.ts
+++ b/marketing/web10-social/src/data/posts.ts
@@ -155,6 +155,11 @@ export async function deletePost(id: string): Promise<void> {
  * D21: if width/height/durationSeconds/thumbnailFile/altText are provided,
  * they are sent to the confirm endpoint so the media record carries real
  * dimensions, a thumbnail URL (for video posters), and alt text.
+ *
+ * D35: the optional `service` on MediaUploadRequest targets the confirm
+ * endpoint. Public-post attachments and avatar/banner use `public_media`
+ * so non-owners can presign reads. DM/private-post media defaults to
+ * `media` (owner-only, legacy fallback).
  */
 export async function uploadMedia(request: MediaUploadRequest): Promise<MediaRecord> {
   const wapi = getWapi();
@@ -162,7 +167,7 @@ export async function uploadMedia(request: MediaUploadRequest): Promise<MediaRec
   // Upload the thumbnail/poster first (if provided) so we have its URL
   let thumbnailUrl: string | null = null;
   if (request.thumbnailFile) {
-    const thumbRecord = await uploadMedia({ file: request.thumbnailFile });
+    const thumbRecord = await uploadMedia({ file: request.thumbnailFile, service: request.service });
     thumbnailUrl = thumbRecord.url;
   }
 
@@ -199,6 +204,7 @@ export async function uploadMedia(request: MediaUploadRequest): Promise<MediaRec
     durationSeconds: request.durationSeconds ?? null,
     thumbnailUrl,
     altText: request.altText ?? null,
+    service: request.service,
   });
 }
 
@@ -241,15 +247,23 @@ export async function deleteMedia(id: string): Promise<void> {
  * user; pass an explicit `owner` to refresh media authored by someone
  * else (the feed's own posts resolve from the current user's media
  * collection — the cross-user avatar path is a separate concern).
+ *
+ * D35: the optional `service` parameter targets the correct collection.
+ * For cross-user reads of public content, `public_media` must be used
+ * so the presign endpoint checks the anon-readable terms instead of
+ * the owner-only `media` terms. Defaults to `media` for backward
+ * compatibility (owner reads, legacy records).
  */
 export async function resolveMediaRefs(
   refs: string[],
   owner?: { username: string; provider: string },
+  service?: 'media' | 'public_media',
 ): Promise<MediaRecord[]> {
   if (!refs.length) return [];
   const wapi = getWapi();
-  const records = await wapi.read<MediaRecord>('media', { _id: { $in: refs } });
-  return refreshMediaUrls(records, owner);
+  const targetService = service || 'media';
+  const records = await wapi.read<MediaRecord>(targetService, { _id: { $in: refs } });
+  return refreshMediaUrls(records, owner, service);
 }
 
 /**
@@ -259,10 +273,15 @@ export async function resolveMediaRefs(
  * from the stored URL. Records whose URL can't be resolved to a key
  * (e.g. a non-S3 legacy url) are passed through unchanged so a bad
  * derivation never breaks a render worse than before.
+ *
+ * D35: the optional `service` parameter is passed through to
+ * `getReadUrl` so presigns check the correct terms (`public_media`
+ * for cross-user public content, `media` for owner reads).
  */
 export async function refreshMediaUrls(
   records: MediaRecord[],
   owner?: { username: string; provider: string },
+  service?: 'media' | 'public_media',
 ): Promise<MediaRecord[]> {
   if (!records.length) return records;
   const wapi = getWapi();
@@ -271,13 +290,13 @@ export async function refreshMediaUrls(
       const objectKey = (r.object_key as string | undefined) || deriveObjectKey(r.url);
       if (!objectKey) return r;
       try {
-        const { readUrl } = await wapi.getReadUrl(objectKey, owner?.username, owner?.provider);
+        const { readUrl } = await wapi.getReadUrl(objectKey, owner?.username, owner?.provider, service);
         let thumbnail_url = r.thumbnail_url ? readUrl : r.thumbnail_url;
         if (r.thumbnail_url && r.thumbnail_url !== r.url) {
           const thumbKey = deriveObjectKey(r.thumbnail_url);
           if (thumbKey && thumbKey !== objectKey) {
             try {
-              const { readUrl: thumbReadUrl } = await wapi.getReadUrl(thumbKey, owner?.username, owner?.provider);
+              const { readUrl: thumbReadUrl } = await wapi.getReadUrl(thumbKey, owner?.username, owner?.provider, service);
               thumbnail_url = thumbReadUrl;
             } catch (thumbErr) {
               console.warn(
@@ -306,6 +325,7 @@ export async function refreshMediaUrls(
 export async function refreshMediaUrl(
   record: MediaRecord,
   owner?: { username: string; provider: string },
+  service?: 'media' | 'public_media',
 ): Promise<MediaRecord> {
-  return (await refreshMediaUrls([record], owner))[0];
+  return (await refreshMediaUrls([record], owner, service))[0];
 }

--- a/marketing/web10-social/src/data/serviceTerms.ts
+++ b/marketing/web10-social/src/data/serviceTerms.ts
@@ -129,6 +129,17 @@ export function buildSocialServiceSirs(crossOrigins: string[]): Sir[] {
       service: 'media',
       cross_origins: crossOrigins,
     },
+    // ── D35: public_media — anon-readable mirror of media for public
+    // content. Public-post attachments and avatar/banner confirm into
+    // `public_media` so non-owners can presign reads. DM/private-post
+    // media stays in `media` (owner-only). The anon-read whitelist
+    // matches `public_posts` / `profile` so any viewer (including
+    // unauthenticated) can presign against it once terms are active.
+    {
+      service: 'public_media',
+      cross_origins: crossOrigins,
+      whitelist: [{ provider: '.*', username: '.*', read: true }], // anon-read for public content
+    },
     {
       service: 'follows',
       cross_origins: crossOrigins,

--- a/marketing/web10-social/src/data/types.ts
+++ b/marketing/web10-social/src/data/types.ts
@@ -66,6 +66,10 @@ export interface MediaUploadRequest {
   durationSeconds?: number;
   thumbnailFile?: File; // thumbnail/poster blob to upload alongside
   altText?: string;
+  // D35: target service for the media record. "public_media" for
+  // public-post attachments / avatar/banner so non-owners can
+  // presign reads. Defaults to "media" (owner-only, legacy fallback).
+  service?: 'media' | 'public_media';
 }
 
 // ── profile ─────────────────────────────────────────────────────────────────

--- a/marketing/web10-social/src/data/wapi.ts
+++ b/marketing/web10-social/src/data/wapi.ts
@@ -82,6 +82,8 @@ export interface WapiWrapper {
     durationSeconds?: number | null;
     thumbnailUrl?: string | null;
     altText?: string | null;
+    // D35: target service for the media record. Defaults to "media".
+    service?: 'media' | 'public_media';
   }) => Promise<T>;
 
   // Media presigned READ url (POST /media/{user}/read). Returns an
@@ -95,6 +97,8 @@ export interface WapiWrapper {
     objectKey: string,
     username?: string,
     provider?: string,
+    // D35: service to presign against. Defaults to "media".
+    service?: 'media' | 'public_media',
   ) => Promise<{ readUrl: string; expiresIn: number }>;
 
   // P2P (legacy, kept for existing chat)
@@ -103,8 +107,9 @@ export interface WapiWrapper {
 }
 
 // ── Presigned read-URL cache (expiry-aware, in-flight dedupe) ────────────
-// Keyed by `${provider}/${username}/${objectKey}` so media owned by
-// different users on different nodes never collide. Each entry caches
+// Keyed by `${provider}/${username}/${objectKey}/${service}` so media
+// owned by different users, on different nodes, or in different
+// services never collide. Each entry caches
 // the presigned GET URL and the absolute time it expires (`now +
 // expiresIn*1000`); a request returns the cached URL if it is at least
 // `EXPIRY_MARGIN_MS` from expiry, otherwise re-fetches. A concurrent
@@ -122,8 +127,8 @@ interface CachedReadUrl {
 
 const readUrlCache = new Map<string, CachedReadUrl | Promise<CachedReadUrl>>();
 
-function readUrlCacheKey(provider: string, username: string, objectKey: string): string {
-  return `${provider}/${username}/${objectKey}`;
+function readUrlCacheKey(provider: string, username: string, objectKey: string, service: string = 'media'): string {
+  return `${provider}/${username}/${objectKey}/${service}`;
 }
 
 /**
@@ -291,7 +296,7 @@ export function createWapiWrapper(authUrl?: string, rtcServer?: string): WapiWra
       };
     },
 
-    async confirmUpload<T>({ url, filename, mimeType, sizeBytes, width = null, height = null, durationSeconds = null, thumbnailUrl = null, altText = null }) {
+    async confirmUpload<T>({ url, filename, mimeType, sizeBytes, width = null, height = null, durationSeconds = null, thumbnailUrl = null, altText = null, service = 'media' }) {
       const token = getToken();
       if (!token) throw new Error('not authenticated');
       const proto = getProtocol();
@@ -304,6 +309,7 @@ export function createWapiWrapper(authUrl?: string, rtcServer?: string): WapiWra
           token,
           url,
           filename,
+          service,
           mime_type: mimeType,
           size_bytes: sizeBytes,
           width,
@@ -318,13 +324,13 @@ export function createWapiWrapper(authUrl?: string, rtcServer?: string): WapiWra
       return (json.data || json) as T;
     },
 
-    async getReadUrl(objectKey, username, provider) {
+    async getReadUrl(objectKey, username, provider, service = 'media') {
       const token = getToken();
       if (!token) throw new Error('not authenticated');
       const proto = getProtocol();
       const p = provider || raw.readToken().provider;
       const u = username || raw.readToken().username;
-      const cacheKey = readUrlCacheKey(p, u, objectKey);
+      const cacheKey = readUrlCacheKey(p, u, objectKey, service);
 
       // Reuse a still-fresh cached URL...
       const cached = readUrlCache.get(cacheKey);
@@ -343,7 +349,7 @@ export function createWapiWrapper(authUrl?: string, rtcServer?: string): WapiWra
         const resp = await fetch(`${proto}//${p}/${u}/read`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ token, object_key: objectKey }),
+          body: JSON.stringify({ token, object_key: objectKey, service }),
         });
         if (!resp.ok) throw new Error(`getReadUrl failed: ${resp.status}`);
         const json = await resp.json();


### PR DESCRIPTION
Adds the  service so non-owners can presign reads of public content. Media uploads now accept an optional  parameter ( or ), flowing through confirm-upload, presign read, and the cache key. The  SIR carries an anon-read whitelist matching /.  and  accept a  parameter to target the correct collection and presign against the right terms.