### PR TITLE
fix(web10-social): D-public-media-client bite b — cross-user readers pass service='public_media'

### DIFF
--- a/marketing/web10-social/src/__tests__/data/posts.test.ts
+++ b/marketing/web10-social/src/__tests__/data/posts.test.ts
@@ -393,6 +393,39 @@ describe('posts data layer', () => {
 
       expect(mock.getReadUrl).toHaveBeenCalledTimes(1);
     });
+
+    it('D35: resolveMediaRefs reads from public_media when service is passed', async () => {
+      // Cross-user reads must use public_media so the presign endpoint
+      // checks the anon-readable terms instead of the owner-only media terms.
+      mock.read.mockResolvedValue([
+        { _id: 'm1', url: 'https://s3.local/bob/abc/photo.png', created_at: '2026-07-18T00:00:00Z' },
+      ]);
+      mock.getReadUrl.mockResolvedValue({ readUrl: 'https://signed/photo', expiresIn: 60 });
+
+      await posts.resolveMediaRefs(['m1'], { username: 'bob', provider: 'node.web10.app' }, 'public_media');
+
+      expect(mock.read).toHaveBeenCalledWith('public_media', { _id: { $in: ['m1'] } });
+      // deriveObjectKey strips the host prefix -> 'bob/abc/photo.png' becomes
+      // the path after the first / (the bucket). The URL's path is /bob/abc/photo.png,
+      // so the derived key is 'abc/photo.png' (bucket = first path segment).
+      expect(mock.getReadUrl).toHaveBeenCalledWith(
+        'abc/photo.png',
+        'bob',
+        'node.web10.app',
+        'public_media',
+      );
+    });
+
+    it('D35: resolveMediaRefs defaults to media service when not specified', async () => {
+      mock.read.mockResolvedValue([
+        { _id: 'm1', url: 'https://s3.local/alice/abc/photo.png', created_at: '2026-07-18T00:00:00Z' },
+      ]);
+      mock.getReadUrl.mockResolvedValue({ readUrl: 'https://signed/photo', expiresIn: 60 });
+
+      await posts.resolveMediaRefs(['m1']);
+
+      expect(mock.read).toHaveBeenCalledWith('media', { _id: { $in: ['m1'] } });
+    });
   });
 
   describe('refreshMediaUrl (single-record convenience)', () => {

--- a/marketing/web10-social/src/components/Bio/UserProfileScreen.tsx
+++ b/marketing/web10-social/src/components/Bio/UserProfileScreen.tsx
@@ -85,20 +85,20 @@ export default function UserProfileScreen({ username, provider, onBack }: UserPr
       setFollowRecord(fr);
       setFollowing(fr?.status === 'active' || false);
 
-      // Resolve avatar and banner media refs
+      // Resolve avatar and banner media refs (cross-user: public_media)
       const profileRefs: string[] = [];
       if (p?.avatar_ref) profileRefs.push(p.avatar_ref);
       if (p?.banner_ref) profileRefs.push(p.banner_ref);
+      const mediaMapInit: Record<string, MediaRecord> = {};
       if (profileRefs.length) {
-        const media = await resolveMediaRefs(profileRefs, { username, provider });
-        const map: Record<string, MediaRecord> = {};
+        const media = await resolveMediaRefs(profileRefs, { username, provider }, 'public_media');
         media.forEach((m) => {
-          if (m._id) map[m._id] = m;
+          if (m._id) mediaMapInit[m._id] = m;
         });
-        setMediaMap(map);
       }
 
       // Fetch posts from discovery API (public posts index)
+      let postMediaRefs: string[] = [];
       try {
         const resp = await fetch(
           `${API_ORIGIN}/discover/posts?sort=recent&limit=50`,
@@ -108,20 +108,38 @@ export default function UserProfileScreen({ username, provider, onBack }: UserPr
           const allPosts: DiscoveryPost[] = await resp.json();
           const userPosts = allPosts
             .filter((dp) => dp.author === username && dp.provider === provider)
-            .map((dp) => ({
-              _id: dp.post_id,
-              text: dp.text,
-              created_at: dp.created_at,
-              likes: dp.likes,
-              comments: dp.comments,
-              reposts: dp.reposts,
-              tags: dp.tags,
-            }));
-          setPosts(userPosts as unknown as PostRecord[]);
+            .map((dp) => {
+              const post: PostRecord = {
+                _id: dp.post_id,
+                text: dp.text,
+                created_at: dp.created_at,
+                tags: dp.tags,
+              };
+              if (dp.media_refs?.length) {
+                post.media_refs = dp.media_refs;
+                postMediaRefs.push(...dp.media_refs);
+              }
+              return post;
+            });
+          setPosts(userPosts);
         }
       } catch {
         // Discovery API unavailable - posts will be empty
       }
+
+      // Resolve post media refs (cross-user: public_media)
+      if (postMediaRefs.length) {
+        const postMedia = await resolveMediaRefs(
+          [...new Set(postMediaRefs)],
+          { username, provider },
+          'public_media',
+        );
+        postMedia.forEach((m) => {
+          if (m._id) mediaMapInit[m._id] = m;
+        });
+      }
+
+      setMediaMap(mediaMapInit);
 
       // Follower/following counts from discovery API
       try {

--- a/marketing/web10-social/src/components/Discover/DiscoverScreen.tsx
+++ b/marketing/web10-social/src/components/Discover/DiscoverScreen.tsx
@@ -569,25 +569,43 @@ export default function DiscoverScreen() {
       // Resolve media for posts that have image/video tags
       // Group refs by author so resolveMediaRefs reads from the correct
       // owner's media collection (discovery posts belong to other users).
-      const postsWithMedia = results.filter(p => p.tags?.some(t => ['image', 'video', 'music'].includes(t)));
+      const postsWithMedia = results.filter(p => p.media_refs?.length || p.tags?.some(t => ['image', 'video', 'music'].includes(t)));
       if (postsWithMedia.length) {
         try {
-          const byAuthor = new Map<string, { post: typeof results[0]; refs: string[] }>();
+          // Group posts by author, accumulate all refs per author
+          const byAuthor = new Map<string, { posts: typeof postsWithMedia; refs: string[] }>();
           for (const p of postsWithMedia) {
             const key = `${p.author}@${p.provider}`;
             const entry = byAuthor.get(key);
             if (entry) {
-              entry.post = p;
+              entry.posts.push(p);
+              if (p.media_refs?.length) {
+                entry.refs.push(...p.media_refs);
+              }
             } else {
-              byAuthor.set(key, { post: p, refs: [] });
+              byAuthor.set(key, {
+                posts: [p],
+                refs: p.media_refs || [],
+              });
             }
           }
+          // Resolve each author's media and assign to the correct posts
           const mMap: Record<string, MediaRecord[]> = {};
           for (const [key, entry] of byAuthor) {
             const [username, provider] = key.split('@');
-            const media = await resolveMediaRefs(entry.refs, { username, provider });
-            if (media.length) {
-              mMap[entry.post.post_id] = media;
+            const isOwn = username === token.username && provider === token.provider;
+            const uniqueRefs = [...new Set(entry.refs)];
+            if (!uniqueRefs.length) continue;
+            const media = await resolveMediaRefs(
+              uniqueRefs,
+              { username, provider },
+              isOwn ? 'media' : 'public_media',
+            );
+            // Assign resolved media to each post that references it
+            for (const p of entry.posts) {
+              if (p.media_refs?.length) {
+                mMap[p.post_id] = media.filter(m => p.media_refs?.includes(m._id || ''));
+              }
             }
           }
           if (Object.keys(mMap).length) {

--- a/marketing/web10-social/src/components/Feed/FeedScreen.tsx
+++ b/marketing/web10-social/src/components/Feed/FeedScreen.tsx
@@ -362,6 +362,7 @@ export default function FeedScreen({ onAuthorClick }: { onAuthorClick?: (usernam
   const [commentMap, setCommentMap] = useState<Record<string, number>>({});
   const [likedMap, setLikedMap] = useState<Record<string, boolean>>({});
   const [profileMap, setProfileMap] = useState<Record<string, ProfileRecord>>({});
+  const [avatarUrlMap, setAvatarUrlMap] = useState<Record<string, string>>({});
 
   const loadFeed = useCallback(async () => {
     setLoading(true);
@@ -397,12 +398,57 @@ export default function FeedScreen({ onAuthorClick }: { onAuthorClick?: (usernam
         if (p._id) posts[p._id] = p;
       }
 
+      // Resolve media refs — group by post author so cross-user media
+      // reads from the correct collection with public_media service.
       const allMediaRefs = [...new Set(Object.values(posts).flatMap((p) => p.media_refs || []))];
-      const mediaRecords = allMediaRefs.length ? await resolveMediaRefs(allMediaRefs) : [];
       const mMedia: Record<string, MediaRecord[]> = {};
-      for (const p of Object.values(posts)) {
-        if (p.media_refs?.length && p._id) {
-          mMedia[p._id] = mediaRecords.filter((m) => p.media_refs?.includes(m._id || ''));
+      if (allMediaRefs.length) {
+        // Build a post-id -> author map for grouping
+        const postAuthors = new Map<string, { username: string; provider: string }>();
+        for (const item of feed) {
+          const post = posts[item.post_id];
+          if (post && post.media_refs?.length) {
+            postAuthors.set(item.post_id, {
+              username: item.author_username,
+              provider: item.author_provider,
+            });
+          }
+        }
+        // Group refs by author
+        const refsByAuthor = new Map<string, string[]>();
+        for (const [postId, author] of postAuthors) {
+          const post = posts[postId];
+          const key = `${author.username}@${author.provider}`;
+          const existing = refsByAuthor.get(key) || [];
+          refsByAuthor.set(key, [...new Set([...existing, ...(post.media_refs || [])])]);
+        }
+        // Also handle own posts (author = current user)
+        const ownRefs = Object.entries(posts)
+          .filter(([postId]) => !postAuthors.has(postId))
+          .flatMap(([, p]) => p.media_refs || []);
+        if (ownRefs.length) {
+          refsByAuthor.set(`${token.username}@${token.provider}`, [...new Set(ownRefs)]);
+        }
+        // Resolve each author's refs
+        for (const [key, refs] of refsByAuthor) {
+          const [authorUsername, authorProvider] = key.split('@');
+          const isOwn = authorUsername === token.username && authorProvider === token.provider;
+          const mediaRecords = await resolveMediaRefs(
+            refs,
+            { username: authorUsername, provider: authorProvider },
+            isOwn ? 'media' : 'public_media',
+          );
+          // Assign resolved media to each post that references it
+          for (const [postId, author] of postAuthors) {
+            if (author.username === authorUsername && author.provider === authorProvider) {
+              const post = posts[postId];
+              if (post.media_refs?.length && !mMedia[postId]) {
+                mMedia[postId] = mediaRecords.filter((m) =>
+                  post.media_refs?.includes(m._id || ''),
+                );
+              }
+            }
+          }
         }
       }
 
@@ -420,9 +466,42 @@ export default function FeedScreen({ onAuthorClick }: { onAuthorClick?: (usernam
         }),
       );
 
+      // Resolve author avatars — collect unique avatar_refs from profiles
+      // and resolve them via public_media for cross-user reads.
+      const avatarByAuthor: Record<string, string> = {};
+      const avatarRefsByAuthor = new Map<string, string>();
+      for (const [key, profile] of Object.entries(profiles)) {
+        if (profile.avatar_ref) {
+          const [u, p] = key.split('@');
+          avatarRefsByAuthor.set(profile.avatar_ref, `${u}@${p}`);
+        }
+      }
+      if (avatarRefsByAuthor.size) {
+        const avatarRefs = [...avatarRefsByAuthor.keys()];
+        // Group by author
+        const avatarsByAuth = new Map<string, string[]>();
+        for (const [ref, key] of avatarRefsByAuthor) {
+          const existing = avatarsByAuth.get(key) || [];
+          avatarsByAuth.set(key, [...new Set([...existing, ref])]);
+        }
+        for (const [key, refs] of avatarsByAuth) {
+          const [u, p] = key.split('@');
+          const isOwn = u === token.username && p === token.provider;
+          const avatars = await resolveMediaRefs(
+            refs,
+            { username: u, provider: p },
+            isOwn ? 'media' : 'public_media',
+          );
+          for (const m of avatars) {
+            if (m._id) avatarByAuthor[m._id] = m.url;
+          }
+        }
+      }
+
       setPostsMap(posts);
       setMediaMap(mMedia);
       setProfileMap(profiles);
+      setAvatarUrlMap(avatarByAuthor);
       setReactionMap(reactions);
       setCommentMap(comments);
       setLikedMap(liked);
@@ -490,9 +569,7 @@ export default function FeedScreen({ onAuthorClick }: { onAuthorClick?: (usernam
                 authorUsername={item.author_username}
                 authorProvider={item.author_provider}
                 authorAvatar={
-                  profile?.avatar_ref
-                    ? mediaMap[item.post_id]?.find((m) => m._id === profile.avatar_ref)?.url
-                    : undefined
+                  profile?.avatar_ref ? avatarUrlMap[profile.avatar_ref] : undefined
                 }
                 mediaItems={mediaItems}
                 reactionCount={reactionMap[item.post_id] || 0}

--- a/marketing/web10-social/src/data/feed.ts
+++ b/marketing/web10-social/src/data/feed.ts
@@ -152,6 +152,7 @@ export function mapRawDiscoveryPost(raw: RawDiscoveryPost): DiscoveryPost {
     post_id: raw.post_id,
     text: raw.body_text || undefined,
     tags: raw.tags?.length ? raw.tags : undefined,
+    media_refs: raw.media_refs?.length ? raw.media_refs : undefined,
     created_at: raw.created_at,
     likes: raw.engagement.likes,
     comments: raw.engagement.comments,

--- a/marketing/web10-social/src/data/types.ts
+++ b/marketing/web10-social/src/data/types.ts
@@ -183,6 +183,7 @@ export interface RawDiscoveryPost {
   post_id: string;
   body_text: string;
   tags: string[];
+  media_refs?: string[];
   created_at: string;
   engagement: {
     likes: number;
@@ -198,6 +199,7 @@ export interface DiscoveryPost {
   post_id: string;
   text?: string;
   tags?: string[];
+  media_refs?: string[];
   created_at: string;
   likes: number;
   comments: number;


### PR DESCRIPTION
## D-public-media-client bite b: READERS + VERIFY

Cross-user read paths now pass `service='public_media'` so non-owner presigns check the anon-readable terms instead of the owner-only `media` terms.

### Changes

**UserProfileScreen.tsx** — resolves avatar/banner and post media with `service='public_media'` for other users' content. Also resolves post media refs from the discovery API (previously only avatar/banner were resolved, so the post grid showed no images).

**FeedScreen.tsx** — groups media refs by post author and resolves cross-user posts via `public_media` (own posts still use `media`). Also resolves author avatars separately — no longer looks for the avatar in the post's media items (the bug from D-feed-avatar-resolution).

**DiscoverScreen.tsx** — passes `service='public_media'` for cross-user media resolution. Fixed the refs accumulation bug: the `byAuthor` map was overwriting the post reference instead of accumulating refs per author. Now accumulates all refs per author, resolves once, then assigns to each post.

**data/types.ts + data/feed.ts** — `DiscoveryPost` and `RawDiscoveryPost` gain `media_refs` field, wired through `mapRawDiscoveryPost`.

**Tests** — 2 new tests pin the service parameter in `resolveMediaRefs`: one for `public_media` (reads from correct collection + presigns with correct service) and one for the default `media` fallback. 346 tests green.

### Seam
Owns `marketing/web10-social/**`. Data seam: own exports only (`media_refs` on DiscoveryPost/RawDiscoveryPost, mapped in feed.ts). Coordinates with ws-D/follow on UserProfileScreen.tsx (this bite touches media resolution; follow-persistence touches follow/count/posts-load logic).

### Acceptance
- Second account sees the author's public-post photos + avatar (zero 403s)
- Owner's own legacy records still resolve via `media` (fallback intact)
- 346 tests green, vitest clean