### PR TITLE
fix: canonical engagement target {author}/{service}/{post_id} in client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+1.0.231 || 30.07.2026
+fix(web10-social+marketing-ui): D-engagement-target-client — the social client's comments.ts and reactions.ts now write ledger targets in the canonical format `{author}/{service}/{post_id}` (e.g. `alice/public_posts/p1`) instead of the hardcoded `posts:{post_id}` that the discovery aggregation cannot match. Added `buildCommentTarget`/`buildReactionTarget` helpers with fallback to legacy format. Threaded `postAuthor`/`postService` through createComment, updateComment, deleteComment, createReaction, toggleReaction and all call sites (FeedScreen, PostLightbox, ProfileScreen, CommentThread, Web10SocialAdapter). FeedPreview.tsx InlineCommentPanel reads the canonical target. Tests pin the canonical string. 368 web10-social + 142 marketing-ui tests green, tsc clean.
+
 1.0.230 || 30.07.2026
 fix(api): A18 — revert A15's engagement target conversion. `_ledger_engagement_for_post` now $matches the raw canonical post_key `{author}/{service}/{post_id}` directly instead of converting to `service:post_id`. The seed script writes canonical targets, so prod badges will show real counts again. Legacy `posts:{post_id}` entries are documented as orphaned (not matched). Discovery tests extended to pin the canonical format; A15's N-comments and delete-decrements tests ported to canonical targets.
 

--- a/marketing/marketing-ui/src/components/FeedPreview.tsx
+++ b/marketing/marketing-ui/src/components/FeedPreview.tsx
@@ -370,12 +370,15 @@ function commentTimeAgo(dateStr: string): string {
   return `${days}d`;
 }
 
-async function fetchComments(postId: string): Promise<LedgerComment[]> {
+async function fetchComments(postId: string, postAuthor?: string, postService?: string): Promise<LedgerComment[]> {
+  const target = postAuthor && postService
+    ? `${postAuthor}/${postService}/${postId}`
+    : `posts:${postId}`;
   const resp = await fetch(`${COMMENT_API}/public/entries`, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
-      query: { target: `posts:${postId}`, limit: 50 },
+      query: { target, limit: 50 },
     }),
   });
   if (!resp.ok) return [];
@@ -383,7 +386,7 @@ async function fetchComments(postId: string): Promise<LedgerComment[]> {
   return entries.filter(e => e.payload?.action === 'comment');
 }
 
-function InlineCommentPanel({ postId }: { postId: string }) {
+function InlineCommentPanel({ postId, postAuthor, postService }: { postId: string; postAuthor?: string; postService?: string }) {
   const [comments, setComments] = useState<LedgerComment[]>([]);
   const [loading, setLoading] = useState(true);
   const [text, setText] = useState('');
@@ -391,11 +394,11 @@ function InlineCommentPanel({ postId }: { postId: string }) {
 
   useEffect(() => {
     let cancelled = false;
-    fetchComments(postId)
+    fetchComments(postId, postAuthor, postService)
       .then(c => { if (!cancelled) { setComments(c); setLoading(false); } })
       .catch(() => { if (!cancelled) { setComments([]); setLoading(false); } });
     return () => { cancelled = true; };
-  }, [postId]);
+  }, [postId, postAuthor, postService]);
 
   const handleCompose = () => {
     trackFunnel('trending_comment_attempt', { post_id: postId });
@@ -645,7 +648,7 @@ function TrendingCard({
             </>
           )}
         </div>
-        {commentOpen && !readOnly && <InlineCommentPanel postId={post.id} />}
+        {commentOpen && !readOnly && <InlineCommentPanel postId={post.id} postAuthor={post.author} postService={'public_posts'} />}
       </div>
     </Card>
   );

--- a/marketing/web10-social/src/__tests__/data/comments.test.ts
+++ b/marketing/web10-social/src/__tests__/data/comments.test.ts
@@ -50,6 +50,24 @@ function mockWapi() {
     vi.restoreAllMocks();
   });
 
+  describe('buildCommentTarget', () => {
+    it('builds canonical target when author and service provided', () => {
+      expect(comments.buildCommentTarget('p1', 'alice', 'public_posts')).toBe('alice/public_posts/p1');
+    });
+
+    it('falls back to legacy format when author missing', () => {
+      expect(comments.buildCommentTarget('p1', undefined, 'public_posts')).toBe('posts:p1');
+    });
+
+    it('falls back to legacy format when service missing', () => {
+      expect(comments.buildCommentTarget('p1', 'alice', undefined)).toBe('posts:p1');
+    });
+
+    it('falls back to legacy format when both missing', () => {
+      expect(comments.buildCommentTarget('p1')).toBe('posts:p1');
+    });
+  });
+
   describe('readComments', () => {
     it('reads all comments for a post', async () => {
       const list = [
@@ -94,18 +112,30 @@ function mockWapi() {
     it('mirrors to the public ledger with action=comment', async () => {
       const comment = { post_id: 'p1', text: 'Great post!', created_at: '2026-07-18T00:00:00Z' };
       mock.create.mockResolvedValue({ _id: 'cm1', ...comment });
-      await comments.createComment(comment);
+      await comments.createComment(comment, 'alice', 'public_posts');
 
       expect(feed.createPublicEntry).toHaveBeenCalledWith(
         expect.objectContaining({
           schema_id: commentSchemaId,
-          target: 'posts:p1',
+          target: 'alice/public_posts/p1',
           payload: expect.objectContaining({
             action: 'comment',
             text: 'Great post!',
             author_username: 'alice',
             author_provider: 'api.web10.app',
           }),
+        }),
+      );
+    });
+
+    it('falls back to legacy target when author/service not provided', async () => {
+      const comment = { post_id: 'p1', text: 'fallback', created_at: '2026-07-18T00:00:00Z' };
+      mock.create.mockResolvedValue({ _id: 'cm1', ...comment });
+      await comments.createComment(comment);
+
+      expect(feed.createPublicEntry).toHaveBeenCalledWith(
+        expect.objectContaining({
+          target: 'posts:p1',
         }),
       );
     });
@@ -135,17 +165,18 @@ function mockWapi() {
         {
           _id: 'le-old',
           schema_id: commentSchemaId,
-          target: 'posts:p1',
+          target: 'alice/public_posts/p1',
           payload: { action: 'comment', text: 'Old text', author_username: 'alice', author_provider: 'api.web10.app' },
         },
       ]);
-      await comments.updateComment('cm1', { text: 'Updated comment' });
+      await comments.updateComment('cm1', { text: 'Updated comment' }, 'alice', 'public_posts');
       expect(globalThis.fetch).toHaveBeenCalledWith(
         expect.stringContaining('/public/entries/le-old'),
         expect.objectContaining({ method: 'DELETE' }),
       );
       expect(feed.createPublicEntry).toHaveBeenCalledWith(
         expect.objectContaining({
+          target: 'alice/public_posts/p1',
           payload: expect.objectContaining({
             text: 'Updated comment',
           }),
@@ -167,8 +198,8 @@ function mockWapi() {
 
     it('queries the ledger for matching entries', async () => {
       mock.delete.mockResolvedValue(undefined);
-      await comments.deleteComment('cm1');
-      expect(feed.queryPublicEntries).toHaveBeenCalledWith({ target: 'posts:p1' });
+      await comments.deleteComment('cm1', 'alice', 'public_posts');
+      expect(feed.queryPublicEntries).toHaveBeenCalledWith({ target: 'alice/public_posts/p1' });
     });
 
     it('deletes matching ledger entry when found', async () => {
@@ -176,12 +207,12 @@ function mockWapi() {
         {
           _id: 'le-matching',
           schema_id: commentSchemaId,
-          target: 'posts:p1',
+          target: 'alice/public_posts/p1',
           payload: { action: 'comment', text: 'delete me', author_username: 'alice', author_provider: 'api.web10.app' },
         },
       ]);
       mock.delete.mockResolvedValue(undefined);
-      await comments.deleteComment('cm1');
+      await comments.deleteComment('cm1', 'alice', 'public_posts');
       expect(globalThis.fetch).toHaveBeenCalledWith(
         expect.stringContaining('/public/entries/le-matching'),
         expect.objectContaining({ method: 'DELETE' }),
@@ -193,12 +224,12 @@ function mockWapi() {
         {
           _id: 'le-other',
           schema_id: commentSchemaId,
-          target: 'posts:p1',
+          target: 'alice/public_posts/p1',
           payload: { action: 'comment', text: 'other text', author_username: 'bob', author_provider: 'other' },
         },
       ]);
       mock.delete.mockResolvedValue(undefined);
-      await comments.deleteComment('cm1');
+      await comments.deleteComment('cm1', 'alice', 'public_posts');
       expect(globalThis.fetch).not.toHaveBeenCalled();
     });
   });

--- a/marketing/web10-social/src/__tests__/data/reactions.test.ts
+++ b/marketing/web10-social/src/__tests__/data/reactions.test.ts
@@ -45,6 +45,24 @@ describe('reactions data layer', () => {
     vi.restoreAllMocks();
   });
 
+  describe('buildReactionTarget', () => {
+    it('builds canonical target when author and service provided', () => {
+      expect(reactions.buildReactionTarget('p1', 'alice', 'public_posts')).toBe('alice/public_posts/p1');
+    });
+
+    it('falls back to legacy format when author missing', () => {
+      expect(reactions.buildReactionTarget('p1', undefined, 'public_posts')).toBe('posts:p1');
+    });
+
+    it('falls back to legacy format when service missing', () => {
+      expect(reactions.buildReactionTarget('p1', 'alice', undefined)).toBe('posts:p1');
+    });
+
+    it('falls back to legacy format when both missing', () => {
+      expect(reactions.buildReactionTarget('p1')).toBe('posts:p1');
+    });
+  });
+
   describe('readReactions', () => {
     it('reads reactions for a post', async () => {
       const list = [
@@ -70,10 +88,11 @@ describe('reactions data layer', () => {
     it('mirrors to ledger with action=like for like reactions', async () => {
       const reaction: Omit<ReactionRecord, '_id'> = { target_service: 'posts', target_id: 'p1', type: 'like', created_at: '2026-07-18T00:00:00Z', author_username: 'alice', author_provider: 'api.web10.app' };
       mock.create.mockResolvedValue({ _id: 'r1', ...reaction });
-      await reactions.createReaction(reaction);
+      await reactions.createReaction(reaction, 'alice', 'public_posts');
 
       expect(feed.createPublicEntry).toHaveBeenCalledWith(
         expect.objectContaining({
+          target: 'alice/public_posts/p1',
           payload: expect.objectContaining({
             action: 'like',
           }),
@@ -84,13 +103,26 @@ describe('reactions data layer', () => {
     it('mirrors to ledger with action=reaction for non-like types', async () => {
       const reaction: Omit<ReactionRecord, '_id'> = { target_service: 'posts', target_id: 'p1', type: 'love', created_at: '2026-07-18T00:00:00Z', author_username: 'alice', author_provider: 'api.web10.app' };
       mock.create.mockResolvedValue({ _id: 'r2', ...reaction });
+      await reactions.createReaction(reaction, 'alice', 'public_posts');
+
+      expect(feed.createPublicEntry).toHaveBeenCalledWith(
+        expect.objectContaining({
+          target: 'alice/public_posts/p1',
+          payload: expect.objectContaining({
+            action: 'reaction',
+          }),
+        }),
+      );
+    });
+
+    it('falls back to legacy target when author/service not provided', async () => {
+      const reaction: Omit<ReactionRecord, '_id'> = { target_service: 'posts', target_id: 'p1', type: 'like', created_at: '2026-07-18T00:00:00Z', author_username: 'alice', author_provider: 'api.web10.app' };
+      mock.create.mockResolvedValue({ _id: 'r1', ...reaction });
       await reactions.createReaction(reaction);
 
       expect(feed.createPublicEntry).toHaveBeenCalledWith(
         expect.objectContaining({
-          payload: expect.objectContaining({
-            action: 'reaction',
-          }),
+          target: 'posts:p1',
         }),
       );
     });

--- a/marketing/web10-social/src/components/Bio/PostLightbox.tsx
+++ b/marketing/web10-social/src/components/Bio/PostLightbox.tsx
@@ -36,9 +36,11 @@ interface PostLightboxProps {
   mediaMap: Record<string, MediaRecord>;
   onClose: () => void;
   onReload?: () => void;
+  postAuthor?: string;
+  postService?: string;
 }
 
-export function PostLightbox({ post, mediaMap, onClose, onReload }: PostLightboxProps) {
+export function PostLightbox({ post, mediaMap, onClose, onReload, postAuthor, postService }: PostLightboxProps) {
   const media = (post.media_refs || [])
     .map(ref => mediaMap[ref])
     .filter((m): m is MediaRecord => Boolean(m));
@@ -119,7 +121,7 @@ export function PostLightbox({ post, mediaMap, onClose, onReload }: PostLightbox
       setBurstKey(k => k + 1);
     }
     try {
-      await toggleReaction('posts', post._id || '', 'like', token.username, token.provider);
+      await toggleReaction('posts', post._id || '', 'like', token.username, token.provider, postAuthor, postService);
     } catch (e) {
       console.error('Failed to toggle reaction:', e);
       setLiked(wasLiked);
@@ -330,6 +332,8 @@ export function PostLightbox({ post, mediaMap, onClose, onReload }: PostLightbox
             postId={post._id || ''}
             isOpen={commentsOpen}
             count={commentCount}
+            postAuthor={postAuthor}
+            postService={postService}
             onCountChange={setCommentCount}
           />
 

--- a/marketing/web10-social/src/components/Bio/ProfileScreen.tsx
+++ b/marketing/web10-social/src/components/Bio/ProfileScreen.tsx
@@ -520,6 +520,8 @@ export default function ProfileScreen() {
           mediaMap={mediaMap}
           onClose={() => setLightboxPost(null)}
           onReload={loadData}
+          postAuthor={getWapi().readToken()?.username}
+          postService={'public_posts'}
         />
       )}
     </div>

--- a/marketing/web10-social/src/components/Feed/CommentThread.tsx
+++ b/marketing/web10-social/src/components/Feed/CommentThread.tsx
@@ -11,9 +11,11 @@ interface CommentThreadProps {
   isOpen: boolean;
   count: number;
   onCountChange: (n: number) => void;
+  postAuthor?: string;
+  postService?: string;
 }
 
-export function CommentThread({ postId, isOpen, onCountChange }: CommentThreadProps) {
+export function CommentThread({ postId, isOpen, onCountChange, postAuthor, postService }: CommentThreadProps) {
   const [comments, setComments] = useState<CommentRecord[]>([]);
   const [loading, setLoading] = useState(true);
   const [draft, setDraft] = useState('');
@@ -44,7 +46,7 @@ export function CommentThread({ postId, isOpen, onCountChange }: CommentThreadPr
         post_id: postId,
         text: draft.trim(),
         created_at: new Date().toISOString(),
-      });
+      }, postAuthor, postService);
       const next = [...comments, created];
       setComments(next);
       onCountChange(next.length);

--- a/marketing/web10-social/src/components/Feed/FeedScreen.tsx
+++ b/marketing/web10-social/src/components/Feed/FeedScreen.tsx
@@ -172,6 +172,8 @@ interface PostCardProps {
   onToggleLike: () => void;
   onCommentCountChange: (n: number) => void;
   onAuthorClick?: (username: string, provider: string) => void;
+  postAuthor?: string;
+  postService?: string;
 }
 
 function PostCard({
@@ -188,6 +190,8 @@ function PostCard({
   onToggleLike,
   onCommentCountChange,
   onAuthorClick,
+  postAuthor,
+  postService,
 }: PostCardProps) {
   const [commentsOpen, setCommentsOpen] = useState(false);
   const [localCount, setLocalCount] = useState(commentCount);
@@ -305,6 +309,8 @@ function PostCard({
         postId={post._id || ''}
         isOpen={commentsOpen}
         count={localCount}
+        postAuthor={postAuthor}
+        postService={postService}
         onCountChange={(n) => {
           setLocalCount(n);
           onCommentCountChange(n);
@@ -515,13 +521,13 @@ export default function FeedScreen({ onAuthorClick }: { onAuthorClick?: (usernam
     loadFeed();
   }, [loadFeed]);
 
-  async function handleToggleLike(postId: string) {
+  async function handleToggleLike(postId: string, postAuthor?: string, postService?: string) {
     const token = getWapi().readToken();
     if (!token) return;
     setLikedMap((prev) => ({ ...prev, [postId]: !prev[postId] }));
     setReactionMap((prev) => ({ ...prev, [postId]: (prev[postId] || 0) + (likedMap[postId] ? -1 : 1) }));
     try {
-      await toggleReaction('posts', postId, 'like', token.username, token.provider);
+      await toggleReaction('posts', postId, 'like', token.username, token.provider, postAuthor, postService);
     } catch (e) {
       console.error('Failed to toggle reaction:', e);
       setLikedMap((prev) => ({ ...prev, [postId]: !prev[postId] }));
@@ -576,11 +582,13 @@ export default function FeedScreen({ onAuthorClick }: { onAuthorClick?: (usernam
                 commentCount={commentMap[item.post_id] || 0}
                 liked={!!likedMap[item.post_id]}
                 timestamp={post.created_at || item.delivered_at}
-                onToggleLike={() => handleToggleLike(item.post_id)}
+                onToggleLike={() => handleToggleLike(item.post_id, item.author_username, 'public_posts')}
                 onCommentCountChange={(n) =>
                   setCommentMap((prev) => ({ ...prev, [item.post_id]: n }))
                 }
                 onAuthorClick={onAuthorClick}
+                postAuthor={item.author_username}
+                postService={'public_posts'}
               />
             );
           })

--- a/marketing/web10-social/src/data/comments.ts
+++ b/marketing/web10-social/src/data/comments.ts
@@ -10,6 +10,21 @@ import type { CommentRecord } from './types';
 // discourse, the collection-level terms is the security boundary.
 
 /**
+ * Build the canonical ledger target: `{author}/{service}/{post_id}`.
+ * Falls back to the legacy `posts:{post_id}` if author/service unknown.
+ */
+export function buildCommentTarget(
+  postId: string,
+  postAuthor?: string,
+  postService?: string,
+): string {
+  if (postAuthor && postService) {
+    return `${postAuthor}/${postService}/${postId}`;
+  }
+  return `posts:${postId}`;
+}
+
+/**
  * Read all comments for a post.
  */
 export async function readComments(postId: string): Promise<CommentRecord[]> {
@@ -40,7 +55,11 @@ export async function readReplies(commentId: string): Promise<CommentRecord[]> {
  * Create a new comment on a post.
  * Phase 5.5: also writes to the public ledger unconditionally (D32).
  */
-export async function createComment(comment: Omit<CommentRecord, '_id'>): Promise<CommentRecord> {
+export async function createComment(
+  comment: Omit<CommentRecord, '_id'>,
+  postAuthor?: string,
+  postService?: string,
+): Promise<CommentRecord> {
   const wapi = getWapi();
   const record = await wapi.create<CommentRecord>('comments', comment);
 
@@ -50,7 +69,7 @@ export async function createComment(comment: Omit<CommentRecord, '_id'>): Promis
     const token = wapi.readToken();
     createPublicEntry({
       schema_id: commentSchema._id,
-      target: `posts:${comment.post_id}`,
+      target: buildCommentTarget(comment.post_id, postAuthor, postService),
       payload: {
         action: 'comment',
         text: comment.text,
@@ -67,14 +86,19 @@ export async function createComment(comment: Omit<CommentRecord, '_id'>): Promis
  * Update a comment by ID.
  * Also updates the mirrored ledger entry so the trending feed reflects the edit.
  */
-export async function updateComment(id: string, updates: Partial<CommentRecord>): Promise<CommentRecord> {
+export async function updateComment(
+  id: string,
+  updates: Partial<CommentRecord>,
+  postAuthor?: string,
+  postService?: string,
+): Promise<CommentRecord> {
   const wapi = getWapi();
   const record = await wapi.update<CommentRecord>('comments', { _id: id }, { $set: updates });
 
   // Update the mirrored ledger entry: delete old, create new with updated text
   const commentSchema = getCachedSchema('Comment');
   if (commentSchema?._id && record.post_id) {
-    const target = `posts:${record.post_id}`;
+    const target = buildCommentTarget(record.post_id, postAuthor, postService);
     const entries = await queryPublicEntries({ target });
     const matching = entries.filter(
       (e) =>
@@ -116,7 +140,11 @@ export async function updateComment(id: string, updates: Partial<CommentRecord>)
  * Delete a comment by ID.
  * Also removes the mirrored ledger entry so the comment drops out of the count.
  */
-export async function deleteComment(id: string): Promise<void> {
+export async function deleteComment(
+  id: string,
+  postAuthor?: string,
+  postService?: string,
+): Promise<void> {
   const wapi = getWapi();
 
   // Read the comment to find its post_id and author for ledger cleanup
@@ -124,7 +152,7 @@ export async function deleteComment(id: string): Promise<void> {
   if (comment.length > 0) {
     const c = comment[0];
     const token = wapi.readToken();
-    const target = `posts:${c.post_id}`;
+    const target = buildCommentTarget(c.post_id, postAuthor, postService);
 
     // Query the ledger for the matching entry and delete it
     const entries = await queryPublicEntries({ target });

--- a/marketing/web10-social/src/data/reactions.ts
+++ b/marketing/web10-social/src/data/reactions.ts
@@ -8,6 +8,21 @@ import type { ReactionRecord, ReactionTargetService } from './types';
 // can read engagement counts.
 
 /**
+ * Build the canonical ledger target: `{author}/{service}/{post_id}`.
+ * Falls back to the legacy `{target_service}:{target_id}` if author/service unknown.
+ */
+export function buildReactionTarget(
+  targetId: string,
+  postAuthor?: string,
+  postService?: string,
+): string {
+  if (postAuthor && postService) {
+    return `${postAuthor}/${postService}/${targetId}`;
+  }
+  return `posts:${targetId}`;
+}
+
+/**
  * Read all reactions for a target (post or comment).
  */
 export async function readReactions(
@@ -25,7 +40,11 @@ export async function readReactions(
  * Create a new reaction.
  * Phase 5.5: also writes to the public ledger if the Reaction schema is registered.
  */
-export async function createReaction(reaction: Omit<ReactionRecord, '_id'>): Promise<ReactionRecord> {
+export async function createReaction(
+  reaction: Omit<ReactionRecord, '_id'>,
+  postAuthor?: string,
+  postService?: string,
+): Promise<ReactionRecord> {
   const wapi = getWapi();
   const record = await wapi.create<ReactionRecord>('reactions', reaction);
 
@@ -34,7 +53,7 @@ export async function createReaction(reaction: Omit<ReactionRecord, '_id'>): Pro
   if (reactionSchema?._id) {
     createPublicEntry({
       schema_id: reactionSchema._id,
-      target: `${reaction.target_service}:${reaction.target_id}`,
+      target: buildReactionTarget(reaction.target_id, postAuthor, postService),
       payload: {
         action: reaction.type === 'like' ? 'like' : 'reaction',
         type: reaction.type,
@@ -58,6 +77,8 @@ export async function toggleReaction(
   type: string,
   authorUsername: string,
   authorProvider: string,
+  postAuthor?: string,
+  postService?: string,
 ): Promise<boolean> {
   const existing = await readReactions(targetService, targetId);
   const mine = existing.find(
@@ -79,7 +100,7 @@ export async function toggleReaction(
     created_at: new Date().toISOString(),
     author_username: authorUsername,
     author_provider: authorProvider,
-  });
+  }, postAuthor, postService);
   return true;
 }
 

--- a/marketing/web10-social/src/interfaces/Web10SocialAdapter.ts
+++ b/marketing/web10-social/src/interfaces/Web10SocialAdapter.ts
@@ -144,20 +144,22 @@ interface Web10SocialAdapter {
   readCommentsForPost: (postId: string) => Promise<CommentRecord[]>;
   readTopLevelComments: (postId: string) => Promise<CommentRecord[]>;
   readCommentReplies: (commentId: string) => Promise<CommentRecord[]>;
-  createCommentRecord: (comment: Omit<CommentRecord, '_id'>) => Promise<CommentRecord>;
-  updateCommentRecord: (id: string, updates: Partial<CommentRecord>) => Promise<CommentRecord>;
-  deleteCommentRecord: (id: string) => Promise<void>;
+  createCommentRecord: (comment: Omit<CommentRecord, '_id'>, postAuthor?: string, postService?: string) => Promise<CommentRecord>;
+  updateCommentRecord: (id: string, updates: Partial<CommentRecord>, postAuthor?: string, postService?: string) => Promise<CommentRecord>;
+  deleteCommentRecord: (id: string, postAuthor?: string, postService?: string) => Promise<void>;
   countCommentsForPost: (postId: string) => Promise<number>;
 
   // Reactions
   readReactionsForTarget: (targetService: 'posts' | 'comments', targetId: string) => Promise<ReactionRecord[]>;
-  createReactionRecord: (reaction: Omit<ReactionRecord, '_id'>) => Promise<ReactionRecord>;
+  createReactionRecord: (reaction: Omit<ReactionRecord, '_id'>, postAuthor?: string, postService?: string) => Promise<ReactionRecord>;
   toggleReactionOnTarget: (
     targetService: 'posts' | 'comments',
     targetId: string,
     type: string,
     authorUsername: string,
     authorProvider: string,
+    postAuthor?: string,
+    postService?: string,
   ) => Promise<boolean>;
   deleteReactionRecord: (id: string) => Promise<void>;
   countReactionsForTarget: (targetService: 'posts' | 'comments', targetId: string) => Promise<number>;

--- a/parallel execution.txt
+++ b/parallel execution.txt
@@ -1640,7 +1640,7 @@ LANE D — docs / apps / mobile (owns: mobile/**, marketing/, examples/
       first-run state walks you through post/follow/monetize) —
       capture-only, stage when the onboarding pass comes.
 
-[ ] D-engagement-target-client (sub-lane ws-D/feed + one marketing-ui
+[✓ 1.0.231] D-engagement-target-client (sub-lane ws-D/feed + one marketing-ui
       file; PRIORITY 1 with A18 — the client half of the 29.07
       zero-counts regression; read A18's diagnosis first, the format
       DECISION is recorded there): the canonical ledger target is

--- a/plan.txt
+++ b/plan.txt
@@ -2359,7 +2359,7 @@ says 3 comments while the expanded panel renders more than that):
     but distinct: real-account interactions don't mirror AT ALL
     (D-ledger-mirror-fix) — this item is the seeded/ledger data
     agreeing with itself. lane item A15-engagement-count-accuracy.
-[✓ 1.0.230] REGRESSION (operator, 29.07, screenshot: every /trending card at
+[✓ 1.0.230/1.0.231] REGRESSION (operator, 29.07, screenshot: every /trending card at
     0 likes / 0 comments): A15's fix made it worse — the prod ledger
     has THREE target formats (seed script writes
     `{author}/public_posts/{post_id}`, the app client writes


### PR DESCRIPTION
Fixes the zero-engagement regression: the social client's comments.ts and reactions.ts now write ledger targets in the canonical format (e.g. alice/public_posts/p1) instead of the hardcoded posts:p1 that the discovery aggregation cannot match.

**Changes:**
- Added buildCommentTarget and buildReactionTarget helpers with fallback to legacy format.
- Threaded postAuthor/postService through createComment, updateComment, deleteComment, createReaction, toggleReaction.
- Updated all call sites: FeedScreen, PostLightbox, ProfileScreen, CommentThread, Web10SocialAdapter.
- FeedPreview.tsx InlineCommentPanel reads the canonical target for the trending comment panel.
- Tests pin the canonical string; 368 web10-social + 142 marketing-ui tests green, tsc clean.