### PR TITLE
docs: rant filing — E-dependabot-hackathon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+1.0.236 || 30.07.2026
+docs: rant filing — E-dependabot-hackathon (operator, 30.07, linking the repo's dependabot alerts page: "i am seeing alot of stuff in here, we should do a hackathon and kill a bunch of these, can be done later though"). The dependabot backlog (161 alerts — 13 critical, 67 high, 58 moderate, 23 low at filing) gets a dedicated batch-cleanup hackathon when the operator calls it: group by lockfile, criticals first as their own small PRs, mechanical bumps next, dismiss non-applicable alerts with stated reasons so the count is honest. Parked behind the complaint-driven product work per the operator's "can be done later though" — filed in `parallel execution.txt` (lane E) + `plan.txt` (cross-cutting security) for the fleet, not implemented here per the `imma rant` rule.
+
 1.0.235 || 30.07.2026
 docs: rant re-confirmation — D-docs-gfm is STILL OPEN (operator, 30.07, second screenshot of the same /docs premise table still rendering as `| --- |` pipe soup: "more ranting i do still see the markdown looking meh with the || signs, has that been worked on yet?"). Not worked on yet — filed 29.07, queued for the fleet; now a twice-complained item, bumped for the next kickoff batch.
 

--- a/parallel execution.txt
+++ b/parallel execution.txt
@@ -2814,6 +2814,32 @@ LANE E — infrastructure / deployment (owns: proxmox provisioning,
       signing certs/provisioning, review. NOT now (post-M0, gated on
       the encryptor actually doing e2e key management) — parked here
       so it's on the board, not lost.
+  [ ] E-dependabot-hackathon (lane E/infra, LATER — operator, 30.07
+      rant, link to github.com/jacoby149/web10/security/dependabot:
+      "i am seeing alot of stuff in here, we should do a hackathon
+      and kill a bunch of these, can be done later though"): the
+      dependabot backlog is at 161 open alerts (13 critical, 67
+      high, 58 moderate, 23 low per the GitHub banner, 30.07) and
+      growing — a batch-cleanup HACKATHON, not a steady drip: one
+      dedicated session (or one fleet wave) that burns the list
+      down. shape when picked up: (1) group alerts by package
+      ecosystem + manifest (ui/, marketing-ui/, web10-social/,
+      sdk/, api/ pip, mobile/encryptor) — most of the 161 will
+      collapse into a handful of dependency bumps per lockfile;
+      (2) land the safe mechanical bumps first (patch/minor,
+      tests + tsc + builds green per package), then the majors
+      one breaking-change per PR; (3) criticals FIRST as their
+      own small PRs (13 of them — each is a bite); (4) dismiss
+      with a stated reason the alerts that don't apply (dev-only,
+      unreachable code path) so the count is HONEST, not just
+      hidden. operator sequencing note: "can be done later
+      though" — this is parked behind the current complaint-
+      driven product work; kick it off as a fleet wave when the
+      operator calls the hackathon, not before. acceptance (when
+      run): critical + high count driven to ~0 or every remaining
+      alert carries a dismissal reason; all package test suites
+      green after the bumps; CHANGELOG lines per bump batch.
+      gate: none (parked by operator priority, not by code).
   [ ] E-run-discovery-migration (ops, small, HIGH demo impact; operator
       screenshot 26.07: his real public post absent from /trending
       Newest on the deployed app): A13 (✓ 1.0.178) shipped the

--- a/plan.txt
+++ b/plan.txt
@@ -3095,6 +3095,13 @@ other known issues, fix early (phase 0/1, before any real users):
 [ ] before the first creator-node pitch: external security review /
     pen test of the node stack + a responsible disclosure policy.
     "we've been audited" is a sales document in this business.
+[ ] dependabot hackathon (operator, 30.07: "i am seeing alot of
+    stuff in here, we should do a hackathon and kill a bunch of
+    these, can be done later though"): the dependabot backlog
+    (161 alerts — 13 critical, 67 high at filing) gets burned
+    down in one dedicated batch session, criticals first, not a
+    steady drip. parked behind the complaint-driven product work
+    until the operator calls it. lane item E-dependabot-hackathon.
 
 quality:
 [ ] frontend cache headers: index.html must ship no-cache on all


### PR DESCRIPTION
Operator rant (30.07) filed per the `imma rant` rule — docs only, nothing implemented.

- **E-dependabot-hackathon** (new, lane E, parked): the dependabot backlog — 161 alerts (13 critical, 67 high, 58 moderate, 23 low) — gets burned down in one dedicated hackathon session, not a steady drip. Shape when picked up: group by lockfile, criticals first as their own small PRs, mechanical patch/minor bumps next (tests + tsc + builds green per package), majors one-per-PR, dismiss non-applicable alerts with stated reasons so the count stays honest.
- Operator sequencing honored: "can be done later though" — parked behind the complaint-driven product work until the operator calls the hackathon.
- plan.txt cross-cutting security section carries the item; CHANGELOG 1.0.236 (collides with #396's 1.0.236 — union-merge + renumber per AGENTS.md at merge time).