### PR TITLE
feat(api): D37 — App Store v2 registration rewire

### DIFF
--- a/api/app/endpoints/discover.py
+++ b/api/app/endpoints/discover.py
@@ -76,3 +76,24 @@ async def discover_post(username: str, service: str, post_id: str, token: Token 
     if not post:
         raise exceptions.ENTRY_NOT_FOUND
     return post
+
+
+@router.patch("/discover/app/{web10apps_post_id}", tags=["discovery"])
+async def discover_app(web10apps_post_id: str, token: Token | None = None):
+    """Look up an app's product page data by its web10apps_post_id (D37).
+    Returns the app record + aggregated ratings. Public read."""
+    app = db["web10"]["apps"].find_one({"web10apps_post_id": web10apps_post_id})
+    if not app or app.get("review_state") != "approved":
+        raise exceptions.ENTRY_NOT_FOUND
+    ratings = db._aggregate_app_ratings(web10apps_post_id)
+    return {
+        "url": app["url"],
+        "name": app.get("name", ""),
+        "description": app.get("description", ""),
+        "icon_url": app.get("icon_url"),
+        "screenshots": app.get("screenshots", []),
+        "visits": app.get("visits", 0),
+        "web10apps_post_id": web10apps_post_id,
+        "rating_average": round(ratings["average"], 1) if ratings["count"] else None,
+        "rating_count": ratings["count"],
+    }

--- a/api/app/endpoints/system.py
+++ b/api/app/endpoints/system.py
@@ -7,6 +7,7 @@ from app.models.auth import Token
 from app.models.config import (
     AppAdminQuery,
     AppApprovalRequest,
+    AppRatingRequest,
     ConfigUpdate,
     DiscoveryModerationRequest,
     SetupRequest,
@@ -156,6 +157,9 @@ async def pwa(url: str):
 
 @router.post("/register_app", include_in_schema=False)
 async def register_app(info: dict):
+    """Register an app (v2). Accepts url + optional name, description,
+    icon_url, screenshots. New apps start as pending. Repeat visits
+    from approved apps with changed metadata enter review."""
     if "url" not in info:
         return
     fragments = [
@@ -194,11 +198,37 @@ async def apps_admin(query: AppAdminQuery):
 
 @router.post("/apps/approve", include_in_schema=False)
 async def apps_approve(req: AppApprovalRequest):
-    """Approve or unapprove a registered app (admin only)."""
+    """Approve or reject a registered app (admin only).
+    On approve of pending_on_change: promotes pending metadata to live fields.
+    On reject: preserves old metadata, sets review_state to rejected."""
     token = Token(token=req.token)
     check_admin(token)
-    db.set_app_approval(req.url, req.approved)
+    db.set_app_approval(req.url, req.approved, req.reviewer_note)
     return {"status": "updated", "url": req.url, "approved": req.approved}
+
+
+# --- App ratings (D37) ---
+
+
+@router.post("/apps/rating", include_in_schema=False)
+async def apps_rating(req: AppRatingRequest):
+    """Submit a 1-5 star rating for an app. Upserts by (target_app_id, author)."""
+    if not 1 <= req.rating <= 5:
+        raise HTTPException(status_code=400, detail="rating must be 1-5")
+    token = Token(token=req.token)
+    decoded = decode_token(token.token)
+    return db.create_app_rating(
+        author=decoded.username,
+        target_app_id=req.target_app_id,
+        rating=req.rating,
+        provider=decoded.provider,
+    )
+
+
+@router.patch("/apps/ratings/{target_app_id}", include_in_schema=False)
+async def apps_ratings(target_app_id: str):
+    """Read all star ratings for an app (anon OK)."""
+    return db.query_app_ratings(target_app_id)
 
 
 # --- Discovery migration (admin only) ---
@@ -218,6 +248,15 @@ async def admin_discovery_backfill(req: Token):
     user collection. Admin only. Idempotent — safe to call multiple times."""
     check_admin(req)
     return db.backfill_discovery()
+
+
+@router.post("/admin/apps/migrate_v2", include_in_schema=False)
+async def admin_apps_migrate_v2(req: Token):
+    """Migrate legacy web10.apps records to v2 shape (D37).
+    Backfills review_state, metadata_version, web10apps_post_id.
+    Projects approved apps to #web10apps discovery. Admin only. Idempotent."""
+    check_admin(req)
+    return db.migrate_apps_to_v2()
 
 
 @router.post("/admin/discovery/migrate_follows_terms", include_in_schema=False)

--- a/api/app/models/config.py
+++ b/api/app/models/config.py
@@ -94,11 +94,20 @@ class SetupStatus(BaseModel):
 
 
 class AppApprovalRequest(BaseModel):
-    """Admin toggles an app's visibility in the public App Store."""
+    """Admin toggles an app's visibility in the public App Store (v2)."""
 
     token: str
     url: str
     approved: bool = True
+    reviewer_note: str = ""
+
+
+class AppRatingRequest(BaseModel):
+    """User submits a 1-5 star rating for an app."""
+
+    token: str
+    target_app_id: str
+    rating: int
 
 
 class AppAdminQuery(BaseModel):

--- a/api/app/services/documentdb.py
+++ b/api/app/services/documentdb.py
@@ -1,4 +1,5 @@
 import datetime
+import hashlib
 import itertools
 import logging
 import re
@@ -634,41 +635,218 @@ def _ensure_capped(name, max_docs):
 
 # appstore stats
 
+# D37: v2 app registration — review_state machine, node-hosted metadata,
+# #web10apps social projection, star ratings as ledger entries.
+
+
+def _generate_web10apps_post_id(url: str) -> str:
+    """Generate a stable, URL-safe post ID from an app URL."""
+    return "app_" + hashlib.sha256(url.encode()).hexdigest()[:8]
+
+
+def _project_app_to_discovery(app: dict):
+    """Write a synthetic discovery entry for an approved app (#web10apps projection)."""
+    _ensure_discovery_collection()
+    col = db["web10"][DISCOVERY_COLLECTION]
+    post_id = app.get("web10apps_post_id", _generate_web10apps_post_id(app["url"]))
+    body_text = app.get("name", "")
+    if app.get("description"):
+        body_text = f"{body_text} — {app['description']}" if body_text else app["description"]
+    media_refs = []
+    if app.get("icon_url"):
+        media_refs = [app["icon_url"]]
+
+    update_doc = {
+        "author": "system",
+        "service": "web10_apps",
+        "post_id": post_id,
+        "body_text": body_text,
+        "tags": ["#web10apps"],
+        "media_refs": media_refs,
+        "has_media": len(media_refs) > 0,
+        "created_at": app.get("registered_at", datetime.datetime.utcnow().isoformat()),
+        "updated_at": datetime.datetime.utcnow().isoformat(),
+        "_app_url": app["url"],
+    }
+    col.update_one(
+        {"author": "system", "service": "web10_apps", "post_id": post_id},
+        {"$set": update_doc},
+        upsert=True,
+    )
+
+
+def _remove_app_discovery_projection(post_id: str):
+    """Remove a #web10apps synthetic discovery entry."""
+    _ensure_discovery_collection()
+    db["web10"][DISCOVERY_COLLECTION].delete_one({"author": "system", "service": "web10_apps", "post_id": post_id})
+
+
+def _aggregate_app_ratings(target_app_id: str) -> dict:
+    """Aggregate star ratings for an app from the public ledger.
+    Returns {average: float, count: int} or {average: 0, count: 0} if none."""
+    _ensure_public_collection()
+    entries = query_public_entries(target=f"system/web10_apps/{target_app_id}")
+    ratings = [e["payload"].get("rating", 0) for e in entries if "rating" in e.get("payload", {})]
+    if not ratings:
+        return {"average": 0, "count": 0}
+    return {"average": sum(ratings) / len(ratings), "count": len(ratings)}
+
 
 def get_apps(skip=0, limit=0):
-    """Public storefront: only admin-approved apps appear here."""
-    apps = [
-        {"url": app["url"], "visits": app["visits"]}
-        for app in db["web10"]["apps"]
-        .find({"approved": True})
+    """Public storefront: only approved apps appear here (v2).
+    Returns v2 shape with web10apps_post_id, name, description, icon_url,
+    screenshots, and aggregated star rating."""
+    apps = []
+    for app in (
+        db["web10"]["apps"]
+        .find({"review_state": "approved"})
         .sort("visits", pymongo.DESCENDING)
         .skip(skip)
-        .limit(limit)
-    ]
+        .limit(limit if limit else 0)
+    ):
+        post_id = app.get("web10apps_post_id", "")
+        ratings = _aggregate_app_ratings(post_id)
+        apps.append(
+            {
+                "url": app["url"],
+                "visits": app.get("visits", 0),
+                "name": app.get("name", ""),
+                "description": app.get("description", ""),
+                "icon_url": app.get("icon_url"),
+                "screenshots": app.get("screenshots", []),
+                "web10apps_post_id": post_id,
+                "rating_average": round(ratings["average"], 1) if ratings["count"] else None,
+                "rating_count": ratings["count"],
+            }
+        )
     return apps
 
 
 def list_apps_admin():
-    """Admin-facing list of every registered app, including its approval
-    state. Historical apps that predate the `approved` flag arrive as
-    pending (the field is absent) so the operator can curate them once."""
+    """Admin-facing list of every registered app, including full v2 state."""
     apps = []
     for app in db["web10"]["apps"].find({}).sort("visits", pymongo.DESCENDING):
+        post_id = app.get("web10apps_post_id", "")
+        ratings = _aggregate_app_ratings(post_id)
         apps.append(
             {
                 "url": app.get("url"),
                 "visits": app.get("visits", 0),
                 "approved": bool(app.get("approved", False)),
                 "name": app.get("name", ""),
+                "description": app.get("description", ""),
+                "icon_url": app.get("icon_url"),
+                "screenshots": app.get("screenshots", []),
                 "registered_at": app.get("registered_at"),
+                "review_state": app.get("review_state", "pending"),
+                "metadata_version": app.get("metadata_version", 1),
+                "last_reviewed_at": app.get("last_reviewed_at"),
+                "reviewer_note": app.get("reviewer_note", ""),
+                "web10apps_post_id": post_id,
+                "pending_description": app.get("pending_description"),
+                "pending_icon_url": app.get("pending_icon_url"),
+                "pending_screenshots": app.get("pending_screenshots"),
+                "rating_average": round(ratings["average"], 1) if ratings["count"] else None,
+                "rating_count": ratings["count"],
             }
         )
     return apps
 
 
-def set_app_approval(url: str, approved: bool):
-    """Admin toggles whether an app is shown in the public App Store."""
-    db["web10"]["apps"].update_one({"url": url}, {"$set": {"approved": bool(approved)}})
+def set_app_approval(url: str, approved: bool, reviewer_note: str = ""):
+    """Admin approves or rejects an app (v2 review_state machine).
+    On approve of pending_on_change: promotes pending metadata to live fields.
+    On approve of pending: sets approved + projects to #web10apps.
+    On reject: sets review_state to rejected, preserves old metadata."""
+    now = datetime.datetime.utcnow().isoformat()
+    app = db["web10"]["apps"].find_one({"url": url})
+    if not app:
+        return
+
+    review_state = app.get("review_state", "pending")
+    post_id = app.get("web10apps_post_id", _generate_web10apps_post_id(url))
+
+    if approved:
+        if review_state == "pending_on_change":
+            # Promote pending metadata to live fields
+            promote = {"last_reviewed_at": now, "reviewer_note": reviewer_note}
+            if app.get("pending_description") is not None:
+                promote["description"] = app["pending_description"]
+            if app.get("pending_icon_url") is not None:
+                promote["icon_url"] = app["pending_icon_url"]
+            if app.get("pending_screenshots") is not None:
+                promote["screenshots"] = app["pending_screenshots"]
+            # Clear pending fields
+            promote["pending_description"] = None
+            promote["pending_icon_url"] = None
+            promote["pending_screenshots"] = None
+            promote["$unset"] = {}
+
+            db["web10"]["apps"].update_one(
+                {"url": url},
+                {
+                    "$set": {
+                        "review_state": "approved",
+                        "approved": True,
+                        **promote,
+                    },
+                    "$unset": {
+                        "pending_description": "",
+                        "pending_icon_url": "",
+                        "pending_screenshots": "",
+                    },
+                },
+            )
+        else:
+            # Initial approval (pending → approved)
+            db["web10"]["apps"].update_one(
+                {"url": url},
+                {
+                    "$set": {
+                        "review_state": "approved",
+                        "approved": True,
+                        "last_reviewed_at": now,
+                        "reviewer_note": reviewer_note,
+                    }
+                },
+            )
+        # Project to #web10apps discovery
+        updated_app = db["web10"]["apps"].find_one({"url": url})
+        _project_app_to_discovery(updated_app)
+    else:
+        # Reject
+        if review_state == "pending_on_change":
+            # Reject listing edit — old approved metadata stays live,
+            # but review_state goes to rejected for the edit
+            db["web10"]["apps"].update_one(
+                {"url": url},
+                {
+                    "$set": {
+                        "review_state": "rejected",
+                        "last_reviewed_at": now,
+                        "reviewer_note": reviewer_note,
+                    },
+                    "$unset": {
+                        "pending_description": "",
+                        "pending_icon_url": "",
+                        "pending_screenshots": "",
+                    },
+                },
+            )
+        else:
+            db["web10"]["apps"].update_one(
+                {"url": url},
+                {
+                    "$set": {
+                        "review_state": "rejected",
+                        "approved": False,
+                        "last_reviewed_at": now,
+                        "reviewer_note": reviewer_note,
+                    }
+                },
+            )
+        # Remove from #web10apps discovery
+        _remove_app_discovery_projection(post_id)
 
 
 def get_user_count():
@@ -683,23 +861,166 @@ def total_size():
 
 
 def register_app(info):
-    """Any app can self-register; new entries are pending admin approval
-    (setOnInsert so a repeat visit from an already-known app never resets
-    the approval state)."""
+    """Register an app (v2). New entries start as pending.
+    Repeat visits from an already-known app increment visits.
+    If metadata fields differ from stored values on an approved app,
+    bumps metadata_version and sets review_state to pending_on_change
+    (stores new values in pending_* fields for admin review)."""
     url = info.get("url")
     if not url:
         return
-    db["web10"]["apps"].update_one(
-        {"url": url},
+
+    post_id = _generate_web10apps_post_id(url)
+    now = datetime.datetime.utcnow().isoformat()
+
+    # Check if app already exists
+    existing = db["web10"]["apps"].find_one({"url": url})
+
+    if existing:
+        # App already registered — increment visits always
+        metadata_fields = ["name", "description", "icon_url", "screenshots"]
+        pending_updates = {}
+        metadata_changed = False
+
+        for field in metadata_fields:
+            new_value = info.get(field)
+            if new_value is not None and new_value != existing.get(field):
+                pending_updates[f"pending_{field}"] = new_value
+                metadata_changed = True
+
+        if metadata_changed and existing.get("review_state") == "approved":
+            # Listing edit from an approved app — enter review
+            db["web10"]["apps"].update_one(
+                {"url": url},
+                {
+                    "$inc": {"visits": 1, "metadata_version": 1},
+                    "$set": {
+                        "review_state": "pending_on_change",
+                        **pending_updates,
+                    },
+                },
+            )
+        else:
+            # Just a visit bump (or edit on non-approved app)
+            update_ops = {"$inc": {"visits": 1}}
+            if pending_updates:
+                update_ops["$set"] = pending_updates
+            db["web10"]["apps"].update_one({"url": url}, update_ops)
+    else:
+        # New registration
+        doc = {
+            "url": url,
+            "name": info.get("name", ""),
+            "description": info.get("description", ""),
+            "icon_url": info.get("icon_url"),
+            "screenshots": info.get("screenshots", []),
+            "visits": 1,
+            "approved": False,
+            "review_state": "pending",
+            "metadata_version": 1,
+            "registered_at": now,
+            "web10apps_post_id": post_id,
+        }
+        db["web10"]["apps"].insert_one(doc)
+
+
+def migrate_apps_to_v2():
+    """One-time migration: backfill v2 fields on legacy app records.
+    Sets review_state from approved flag, metadata_version=1,
+    generates web10apps_post_id, projects approved apps to discovery."""
+    migrated = 0
+    for app in db["web10"]["apps"].find({}):
+        needs_update = False
+        update = {}
+
+        if "review_state" not in app:
+            update["review_state"] = "approved" if app.get("approved") else "pending"
+            needs_update = True
+
+        if "metadata_version" not in app:
+            update["metadata_version"] = 1
+            needs_update = True
+
+        if "web10apps_post_id" not in app:
+            update["web10apps_post_id"] = _generate_web10apps_post_id(app["url"])
+            needs_update = True
+
+        if needs_update:
+            db["web10"]["apps"].update_one({"_id": app["_id"]}, {"$set": update})
+            migrated += 1
+
+        # Project approved apps to #web10apps discovery
+        updated_app = db["web10"]["apps"].find_one({"_id": app["_id"]})
+        if updated_app and updated_app.get("review_state") == "approved":
+            _project_app_to_discovery(updated_app)
+
+    return {"migrated": migrated}
+
+
+# app ratings (public ledger)
+
+
+def create_app_rating(author: str, target_app_id: str, rating: int, provider: str = "") -> dict:
+    """Create or update a star rating for an app. Upserts by
+    (target, author) so each user can rate an app once."""
+    _ensure_public_collection()
+    col = db["web10"][PUBLIC_COLLECTION]
+    target = f"system/web10_apps/{target_app_id}"
+
+    # Find existing rating by this author on this app
+    existing = col.find_one(
         {
-            "$inc": {"visits": 1},
-            "$setOnInsert": {
-                "approved": False,
-                "name": info.get("name", ""),
-                "registered_at": datetime.datetime.utcnow().isoformat(),
+            "target": target,
+            "author": author,
+            "payload.action": "rating",
+        }
+    )
+
+    now = datetime.datetime.utcnow().isoformat()
+
+    if existing:
+        # Update existing rating
+        col.update_one(
+            {"_id": existing["_id"]},
+            {
+                "$set": {
+                    "payload.rating": rating,
+                    "updated_at": now,
+                }
             },
+        )
+        existing["payload"]["rating"] = rating
+        existing["updated_at"] = now
+        return existing
+
+    # Create new rating entry
+    import uuid as uuid_mod
+
+    doc = {
+        "_id": f"{settings.PROVIDER}.uuid6:{uuid_mod.uuid4()}",
+        "author": author,
+        "schema_id": "apprating",  # placeholder — matched by payload.action
+        "target": target,
+        "payload": {
+            "action": "rating",
+            "rating": rating,
+            "target_app_id": target_app_id,
+            "author_username": author,
+            "author_provider": provider,
         },
-        upsert=True,
+        "created_at": now,
+        "updated_at": now,
+    }
+    col.insert_one(doc)
+    return doc
+
+
+def query_app_ratings(target_app_id: str, limit: int = 50, skip: int = 0) -> list[dict]:
+    """Query all star ratings for an app from the public ledger."""
+    return query_public_entries(
+        target=f"system/web10_apps/{target_app_id}",
+        limit=limit,
+        skip=skip,
     )
 
 

--- a/api/tests/test_documentdb.py
+++ b/api/tests/test_documentdb.py
@@ -1,6 +1,6 @@
 """Tests for the pure transformation & query-safety functions in services/documentdb.py."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -342,3 +342,238 @@ class TestIsInCrossOrigins:
 
     def test_no_record(self, mock_db_term_none):
         assert documentdb.is_in_cross_origins("anything", "owner", "svc") is False
+
+
+class TestWeb10AppsPostId:
+    """D37: web10apps_post_id generation is stable and URL-safe."""
+
+    def test_generates_stable_id(self):
+        url = "https://example.app"
+        id1 = documentdb._generate_web10apps_post_id(url)
+        id2 = documentdb._generate_web10apps_post_id(url)
+        assert id1 == id2
+        assert id1.startswith("app_")
+        assert len(id1) == 12  # "app_" + 8 hex chars
+
+    def test_different_urls_different_ids(self):
+        id1 = documentdb._generate_web10apps_post_id("https://a.app")
+        id2 = documentdb._generate_web10apps_post_id("https://b.app")
+        assert id1 != id2
+
+
+class TestAppRegistrationV2:
+    """D37: register_app v2 — new apps start pending, repeat visits bump visits,
+    listing edits on approved apps enter review."""
+
+    def _mock_db(self, find_one_result=None):
+        """Build a mock DB that responds to db["web10"]["apps"].find_one(...)."""
+        mock_apps_col = MagicMock()
+        mock_apps_col.find_one.return_value = find_one_result
+        mock_web10_db = MagicMock()
+        mock_web10_db.__getitem__.return_value = mock_apps_col
+        mock_db = MagicMock()
+        mock_db.__getitem__.return_value = mock_web10_db
+        return mock_db, mock_apps_col
+
+    def test_new_registration_starts_pending(self):
+        mock_db, mock_apps_col = self._mock_db(find_one_result=None)
+
+        with patch("app.services.documentdb.db", mock_db):
+            documentdb.register_app({"url": "https://new.app", "name": "New App"})
+
+        call_args = mock_apps_col.insert_one.call_args
+        doc = call_args[0][0]
+        assert doc["url"] == "https://new.app"
+        assert doc["review_state"] == "pending"
+        assert doc["approved"] is False
+        assert doc["metadata_version"] == 1
+        assert doc["name"] == "New App"
+        assert doc["web10apps_post_id"].startswith("app_")
+
+    def test_repeat_visit_increments_visits(self):
+        existing = {
+            "url": "https://existing.app",
+            "visits": 5,
+            "review_state": "approved",
+            "name": "Existing",
+        }
+        mock_db, mock_apps_col = self._mock_db(find_one_result=existing)
+
+        with patch("app.services.documentdb.db", mock_db):
+            documentdb.register_app({"url": "https://existing.app"})
+
+        update_call = mock_apps_col.update_one.call_args
+        assert update_call[0][1]["$inc"]["visits"] == 1
+        # Should NOT change review_state for a plain visit
+        assert "review_state" not in update_call[0][1].get("$set", {})
+
+    def test_listing_edit_on_approved_enters_review(self):
+        existing = {
+            "url": "https://approved.app",
+            "visits": 10,
+            "review_state": "approved",
+            "name": "Old Name",
+            "description": "Old desc",
+            "icon_url": None,
+            "screenshots": [],
+        }
+        mock_db, mock_apps_col = self._mock_db(find_one_result=existing)
+
+        with patch("app.services.documentdb.db", mock_db):
+            documentdb.register_app(
+                {
+                    "url": "https://approved.app",
+                    "name": "New Name",
+                    "description": "New desc",
+                    "icon_url": "https://new-icon.png",
+                }
+            )
+
+        update_call = mock_apps_col.update_one.call_args
+        assert update_call[0][1]["$inc"]["metadata_version"] == 1
+        assert update_call[0][1]["$set"]["review_state"] == "pending_on_change"
+        assert update_call[0][1]["$set"]["pending_name"] == "New Name"
+        assert update_call[0][1]["$set"]["pending_description"] == "New desc"
+        assert update_call[0][1]["$set"]["pending_icon_url"] == "https://new-icon.png"
+
+
+class TestAppApprovalV2:
+    """D37: set_app_approval v2 — review_state machine, pending metadata promotion."""
+
+    def _mock_db(self, find_one_results, discovery_col=None):
+        """Build a mock DB for set_app_approval tests.
+        find_one_results: list of results returned by find_one in order.
+        discovery_col: optional mock for the discovery collection."""
+        mock_apps_col = MagicMock()
+        mock_apps_col.find_one.side_effect = find_one_results
+        mock_discovery_col = discovery_col or MagicMock()
+
+        def db_getitem(name):
+            if name == "web10":
+
+                class Web10DB:
+                    def __getitem__(self, key):
+                        if key == "apps":
+                            return mock_apps_col
+                        return mock_discovery_col
+
+                return Web10DB()
+            return mock_discovery_col
+
+        mock_db = MagicMock()
+        mock_db.__getitem__.side_effect = db_getitem
+        return mock_db, mock_apps_col, mock_discovery_col
+
+    def test_approve_pending_sets_approved(self):
+        mock_db, mock_apps_col, _ = self._mock_db(
+            find_one_results=[
+                {"url": "https://a.app", "review_state": "pending", "web10apps_post_id": "app_123"},
+                {
+                    "url": "https://a.app",
+                    "review_state": "approved",
+                    "web10apps_post_id": "app_123",
+                    "name": "A",
+                    "description": "Desc",
+                    "icon_url": None,
+                    "registered_at": "2026-01-01",
+                },
+            ]
+        )
+
+        with patch("app.services.documentdb.db", mock_db):
+            documentdb.set_app_approval("https://a.app", True)
+
+        update_call = mock_apps_col.update_one.call_args
+        assert update_call[0][1]["$set"]["review_state"] == "approved"
+        assert update_call[0][1]["$set"]["approved"] is True
+
+    def test_approve_pending_on_change_promotes_metadata(self):
+        mock_db, mock_apps_col, _ = self._mock_db(
+            find_one_results=[
+                {
+                    "url": "https://a.app",
+                    "review_state": "pending_on_change",
+                    "web10apps_post_id": "app_123",
+                    "pending_description": "New desc",
+                    "pending_icon_url": "https://new.png",
+                    "pending_screenshots": ["https://ss.png"],
+                },
+                {
+                    "url": "https://a.app",
+                    "review_state": "approved",
+                    "web10apps_post_id": "app_123",
+                    "name": "A",
+                    "description": "New desc",
+                    "icon_url": "https://new.png",
+                    "registered_at": "2026-01-01",
+                },
+            ]
+        )
+
+        with patch("app.services.documentdb.db", mock_db):
+            documentdb.set_app_approval("https://a.app", True, "Looks good")
+
+        update_call = mock_apps_col.update_one.call_args
+        assert update_call[0][1]["$set"]["review_state"] == "approved"
+        assert update_call[0][1]["$set"]["description"] == "New desc"
+        assert update_call[0][1]["$set"]["icon_url"] == "https://new.png"
+        assert update_call[0][1]["$set"]["reviewer_note"] == "Looks good"
+
+    def test_reject_removes_discovery_projection(self):
+        mock_discovery_col = MagicMock()
+        mock_db, mock_apps_col, _ = self._mock_db(
+            find_one_results=[
+                {"url": "https://a.app", "review_state": "pending", "web10apps_post_id": "app_123"},
+            ],
+            discovery_col=mock_discovery_col,
+        )
+
+        with patch("app.services.documentdb.db", mock_db):
+            documentdb.set_app_approval("https://a.app", False, "Not suitable")
+
+        update_call = mock_apps_col.update_one.call_args
+        assert update_call[0][1]["$set"]["review_state"] == "rejected"
+        # Discovery projection should be removed
+        mock_discovery_col.delete_one.assert_called_once()
+
+
+class TestAppRatings:
+    """D37: star ratings as public ledger entries, per-user upsert."""
+
+    def _mock_db(self, find_one_result=None):
+        mock_col = MagicMock()
+        mock_col.find_one.return_value = find_one_result
+        mock_web10_db = MagicMock()
+        mock_web10_db.__getitem__.return_value = mock_col
+        mock_db = MagicMock()
+        mock_db.__getitem__.return_value = mock_web10_db
+        return mock_db, mock_col
+
+    def test_create_new_rating(self):
+        mock_db, mock_col = self._mock_db(find_one_result=None)
+
+        with (
+            patch("app.services.documentdb.db", mock_db),
+            patch("app.services.documentdb.settings", PROVIDER="api.localhost"),
+        ):
+            result = documentdb.create_app_rating("alice", "app_abc", 4, "api.localhost")
+
+        assert result["author"] == "alice"
+        assert result["payload"]["rating"] == 4
+        assert result["target"] == "system/web10_apps/app_abc"
+        assert result["payload"]["action"] == "rating"
+
+    def test_update_existing_rating(self):
+        existing = {
+            "_id": "old_id",
+            "author": "alice",
+            "payload": {"rating": 3, "action": "rating"},
+        }
+        mock_db, mock_col = self._mock_db(find_one_result=existing)
+
+        with patch("app.services.documentdb.db", mock_db):
+            result = documentdb.create_app_rating("alice", "app_abc", 5, "api.localhost")
+
+        assert result["payload"]["rating"] == 5
+        update_call = mock_col.update_one.call_args
+        assert update_call[0][1]["$set"]["payload.rating"] == 5

--- a/api/tests/test_endpoints.py
+++ b/api/tests/test_endpoints.py
@@ -1116,7 +1116,7 @@ class TestAppStoreCuration:
             )
         assert resp.status_code == 200
         assert resp.json() == {"status": "updated", "url": "https://a", "approved": True}
-        mock_set.assert_called_once_with("https://a", True)
+        mock_set.assert_called_once_with("https://a", True, "")
 
     def test_apps_approve_denied_for_non_admin(self, client):
         with patch("app.services.config.get_config", return_value=dict(self._CFG)):
@@ -1125,6 +1125,76 @@ class TestAppStoreCuration:
                 json={"token": _owner_token("bob"), "url": "https://a", "approved": True},
             )
         assert resp.status_code == 403
+
+    def test_apps_rating_valid(self, client):
+        """A valid rating creates a ledger entry."""
+        with patch("app.services.documentdb.create_app_rating") as mock_rate:
+            mock_rate.return_value = {
+                "_id": "test.id",
+                "author": "alice",
+                "target": "system/web10_apps/app_abc123",
+                "payload": {"action": "rating", "rating": 4, "target_app_id": "app_abc123"},
+            }
+            resp = client.post(
+                "/apps/rating",
+                json={"token": _owner_token("alice"), "target_app_id": "app_abc123", "rating": 4},
+            )
+        assert resp.status_code == 200
+        mock_rate.assert_called_once_with(
+            author="alice", target_app_id="app_abc123", rating=4, provider="api.localhost"
+        )
+
+    def test_apps_rating_out_of_range(self, client):
+        """Rating outside 1-5 is rejected."""
+        resp = client.post(
+            "/apps/rating",
+            json={"token": _owner_token("alice"), "target_app_id": "app_abc123", "rating": 0},
+        )
+        assert resp.status_code == 400
+
+        resp = client.post(
+            "/apps/rating",
+            json={"token": _owner_token("alice"), "target_app_id": "app_abc123", "rating": 6},
+        )
+        assert resp.status_code == 400
+
+    def test_apps_rating_no_token(self, client):
+        """Rating requires authentication."""
+        resp = client.post(
+            "/apps/rating",
+            json={"token": "", "target_app_id": "app_abc123", "rating": 4},
+        )
+        assert resp.status_code == 401
+
+    def test_apps_ratings_read(self, client):
+        """Reading ratings returns entries from the ledger."""
+        with patch("app.services.documentdb.query_app_ratings") as mock_query:
+            mock_query.return_value = [
+                {"_id": "e1", "author": "alice", "payload": {"rating": 5}},
+                {"_id": "e2", "author": "bob", "payload": {"rating": 3}},
+            ]
+            resp = client.patch("/apps/ratings/app_abc123")
+        assert resp.status_code == 200
+        assert len(resp.json()) == 2
+        mock_query.assert_called_once_with("app_abc123")
+
+    def test_apps_approve_with_reviewer_note(self, client):
+        """Approve endpoint accepts reviewer_note."""
+        with (
+            patch("app.services.config.get_config", return_value=dict(self._CFG)),
+            patch("app.services.documentdb.set_app_approval") as mock_set,
+        ):
+            resp = client.post(
+                "/apps/approve",
+                json={
+                    "token": _owner_token("alice"),
+                    "url": "https://a",
+                    "approved": True,
+                    "reviewer_note": "Looks good",
+                },
+            )
+        assert resp.status_code == 200
+        mock_set.assert_called_once_with("https://a", True, "Looks good")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
D37 — App Store v2 registration rewire (lane A, code).

**What changed:**
- **review_state state machine**: pending → approved/rejected → pending_on_change on listing edits
- **Node-hosted listing metadata**: description, icon_url, screenshots stored on the node (never hot-linked from app origin)
- **#web10apps social projection**: approved apps project as synthetic discovery entries tagged  — discoverable in the social feed
- **Star ratings**: 1-5 star ratings as public ledger entries, per-user upsert via 
- **Admin approval v2**:  with reviewer_note; pending metadata promotion on approve
- **Migration**:  one-time backfill for legacy records
- **Product page lookup**:  returns app data + aggregated ratings

**Files**: documentdb.py (core logic), system.py (endpoints), config.py (models), discover.py (app lookup), test_endpoints.py + test_documentdb.py (20 new tests, 522 total green). Gates v2 bite a (product page) and bite b (comments + ratings).