### PR TITLE
feat(marketing-ui): D-appstore-browse — uniform small cards + search bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+1.0.251 || 30.07.2026
+feat(marketing-ui): D-appstore-browse — browse grid is now uniform small cards (icon, name, visits; no description text) with a client-side search bar filtering apps by name. AppCard gains `size='browse'` variant with fixed-height cells. Plug slots untouched. 167 tests green, tsc clean, vite build clean.
+
 1.0.250 || 30.07.2026
 docs: `imma rant` filing (docs only, nothing built). One operator complaint filed as a lane item: D-home-stats-bar-styling (ws-D/marketing(2), small — the 1.0.240 homepage stats bar's heavy bordered container "just looks bad"; kill the border, move "data liberated" up as the third stat's label for consistency with USERS/APPS, and bare-on-background vs sleek individual cards is explicitly the builder's taste call against design.md §12). Added to `parallel execution.txt` + plan.txt PHASE 8.6 for the next kickoff batch.
 

--- a/marketing/marketing-ui/src/components/AppCard.tsx
+++ b/marketing/marketing-ui/src/components/AppCard.tsx
@@ -2,7 +2,7 @@ import { ArrowUpRight } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import type { LucideIcon } from 'lucide-react'
 
-export type AppCardSize = 'default' | 'plug'
+export type AppCardSize = 'default' | 'plug' | 'browse'
 
 export interface AppCardProps {
   iconSrc?: string
@@ -32,6 +32,18 @@ export function AppCard({
   'data-testid': testId,
 }: AppCardProps) {
   if (skeleton) {
+    if (size === 'browse') {
+      return (
+        <div
+          className="flex flex-col items-center gap-3 rounded-2xl border border-border bg-surface p-5"
+          data-testid={testId ?? 'app-card-skeleton'}
+        >
+          <div className="h-16 w-16 animate-pulse rounded-2xl bg-elevated" />
+          <div className="h-4 w-20 animate-pulse rounded bg-elevated" />
+          <div className="h-3 w-16 animate-pulse rounded bg-elevated" />
+        </div>
+      )
+    }
     return (
       <div
         className="flex flex-col items-center gap-4 rounded-2xl border border-border bg-surface p-8"
@@ -54,7 +66,7 @@ export function AppCard({
           alt={name}
           className={cn(
             'object-contain',
-            size === 'plug' ? 'h-11 w-11' : 'h-14 w-14 sm:h-16 sm:w-16',
+            size === 'plug' ? 'h-11 w-11' : size === 'browse' ? 'h-14 w-14' : 'h-14 w-14 sm:h-16 sm:w-16',
           )}
           loading="lazy"
           onError={(e) => {
@@ -68,7 +80,7 @@ export function AppCard({
         data-fallback="true"
         className={cn(
           'absolute inset-0 flex items-center justify-center font-semibold text-muted-foreground',
-          size === 'plug' ? 'text-xl' : 'text-2xl sm:text-3xl',
+          size === 'plug' ? 'text-xl' : size === 'browse' ? 'text-2xl' : 'text-2xl sm:text-3xl',
           iconSrc ? 'hidden' : '',
         )}
       >
@@ -119,6 +131,29 @@ export function AppCard({
             {visitsEl}
           </div>
           {openBtn}
+        </div>
+      </a>
+    )
+  }
+
+  if (size === 'browse') {
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="group block"
+        data-testid={testId ?? 'app-card'}
+      >
+        <div className="flex flex-col items-center gap-3 rounded-2xl border border-border bg-surface p-5 transition-all duration-150 ease-out hover:-translate-y-0.5 hover:border-brand-muted hover:shadow-lg hover:shadow-brand/5">
+          <div className="h-16 w-16">{iconBlock}</div>
+
+          <div className="flex flex-col items-center gap-1 text-center">
+            <span className="line-clamp-1 text-sm font-semibold text-foreground">
+              {name}
+            </span>
+            {visitsEl}
+          </div>
         </div>
       </a>
     )

--- a/marketing/marketing-ui/src/components/AppStore.test.tsx
+++ b/marketing/marketing-ui/src/components/AppStore.test.tsx
@@ -5,6 +5,7 @@ import '@testing-library/jest-dom';
 vi.mock('lucide-react', () => {
   const icons: Record<string, React.FC<React.SVGProps<SVGSVGElement>>> = {
     ArrowUpRight: (props) => <svg data-testid="arrow-up-right" {...props} />,
+    Search: (props) => <svg data-testid="search-icon" {...props} />,
   };
   return {
     ...icons,
@@ -27,10 +28,27 @@ describe('AppCard', () => {
         description="A test app description."
         href="https://test.web10.app"
         visits={42}
+        size="default"
       />
     );
     expect(screen.getByText('Test App')).toBeInTheDocument();
     expect(screen.getByText('A test app description.')).toBeInTheDocument();
+  });
+
+  it('browse size renders name and visits but no description', async () => {
+    const { AppCard } = await import('@/components/AppCard');
+    render(
+      <AppCard
+        name="Test App"
+        description="Should not appear."
+        href="https://test.web10.app"
+        visits={42}
+        size="browse"
+      />
+    );
+    expect(screen.getByText('Test App')).toBeInTheDocument();
+    expect(screen.getByText('42 visits')).toBeInTheDocument();
+    expect(screen.queryByText('Should not appear.')).not.toBeInTheDocument();
   });
 
   it('renders visit count', async () => {
@@ -234,7 +252,7 @@ describe('AppStore page', () => {
   it('renders skeleton cards while loading', async () => {
     const { default: AppStore } = await import('@/pages/AppStore');
     render(<AppStore />);
-    const skeletons = screen.getAllByTestId(/app-card-skeleton/);
+    const skeletons = screen.getAllByTestId(/browse-card-skeleton/);
     expect(skeletons.length).toBeGreaterThan(0);
   });
 
@@ -275,6 +293,23 @@ describe('AppStore page', () => {
       const plugSlot = screen.getByTestId('plug-slot-0');
       expect(plugSlot).toHaveAttribute('href', 'https://social.web10.app');
       expect(plugSlot.textContent).toContain('Flagship');
+    });
+  });
+
+  it('renders browse search bar', async () => {
+    const { default: AppStore } = await import('@/pages/AppStore');
+    render(<AppStore />);
+    await vi.waitFor(() => {
+      expect(screen.getByTestId('browse-search')).toBeInTheDocument();
+    });
+    expect(screen.getByPlaceholderText('Search apps…')).toBeInTheDocument();
+  });
+
+  it('browse section renders', async () => {
+    const { default: AppStore } = await import('@/pages/AppStore');
+    render(<AppStore />);
+    await vi.waitFor(() => {
+      expect(screen.getByTestId('browse-section')).toBeInTheDocument();
     });
   });
 });

--- a/marketing/marketing-ui/src/pages/AppStore.tsx
+++ b/marketing/marketing-ui/src/pages/AppStore.tsx
@@ -1,3 +1,4 @@
+import { Search } from 'lucide-react'
 import { useEffect, useState, useMemo } from 'react'
 import { trackFunnel } from '@/lib/analytics'
 import { AUTH_ORIGIN, SOCIAL_ORIGIN } from '@/lib/origins'
@@ -94,6 +95,7 @@ interface PlugSlot {
 function AppStore() {
   const [stats, setStats] = useState<Stats | null>(null)
   const [loading, setLoading] = useState(true)
+  const [searchQuery, setSearchQuery] = useState('')
 
   useEffect(() => {
     trackFunnel('app_store_view')
@@ -276,32 +278,56 @@ function AppStore() {
           </div>
         )}
 
-        {/* Uniform grid */}
-        <div className="reveal mt-12 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-          {loading
-            ? Array.from({ length: 6 }).map((_, i) => (
-                <AppCard
-                  key={`skeleton-${i}`}
-                  skeleton
-                  name=""
-                  description=""
-                  href=""
-                  data-testid={`app-card-skeleton-${i}`}
-                />
-              ))
-            : allApps.filter((app) => !plugSlots.some((p) => p.href === app.href)).map((app, i) => (
-                <AppCard
-                  key={app.href}
-                  iconSrc={app.iconSrc}
-                  iconLetter={app.name.charAt(0)}
-                  name={app.name}
-                  description={app.description}
-                  href={app.href}
-                  visits={app.visits}
-                  flagship={app.flagship}
-                  data-testid={`app-card-${i}`}
-                />
-              ))}
+        {/* Browse — search + uniform small cards */}
+        <div className="reveal mt-12" data-testid="browse-section">
+          {!loading && allApps.length > 0 && (
+            <div className="relative mb-6">
+              <Search className="absolute left-3.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" strokeWidth={2} />
+              <input
+                type="text"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                placeholder="Search apps…"
+                className="w-full rounded-full border border-border bg-surface py-2.5 pl-10 pr-4 text-sm text-foreground placeholder-muted-foreground outline-none transition-colors duration-150 focus:border-brand"
+                data-testid="browse-search"
+              />
+            </div>
+          )}
+
+          <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+            {loading
+              ? Array.from({ length: 10 }).map((_, i) => (
+                  <AppCard
+                    key={`skeleton-${i}`}
+                    size="browse"
+                    skeleton
+                    name=""
+                    description=""
+                    href=""
+                    data-testid={`browse-card-skeleton-${i}`}
+                  />
+                ))
+              : allApps
+                .filter((app) => !plugSlots.some((p) => p.href === app.href))
+                .filter((app) => app.name.toLowerCase().includes(searchQuery.toLowerCase()))
+                .map((app, i) => (
+                  <AppCard
+                    key={app.href}
+                    size="browse"
+                    iconSrc={app.iconSrc}
+                    iconLetter={app.name.charAt(0)}
+                    name={app.name}
+                    description=""
+                    href={app.href}
+                    visits={app.visits}
+                    data-testid={`browse-card-${i}`}
+                  />
+                ))}
+          </div>
+
+          {!loading && searchQuery && allApps.filter((app) => !plugSlots.some((p) => p.href === app.href)).filter((app) => app.name.toLowerCase().includes(searchQuery.toLowerCase())).length === 0 && (
+            <p className="py-12 text-center text-muted-foreground">No apps match &ldquo;{searchQuery}&rdquo;.</p>
+          )}
         </div>
       </div>
     </div>

--- a/parallel execution.txt
+++ b/parallel execution.txt
@@ -2528,7 +2528,7 @@ LANE D — docs / apps / mobile (owns: mobile/**, marketing/, examples/
       (it needs the App-schema public entries to exist — lane A's
       spec note should spec the #web10apps projection explicitly).
 
-[ ] D-appstore-browse (sub-lane ws-D/marketing(2), AFTER
+[✓ 1.0.251] D-appstore-browse (sub-lane ws-D/marketing(2), AFTER
       D-appstore-plugs — same AppStore page; operator, 29.07 rant,
       two screenshots — the uneven v1 grid + a small icon+name-only
       card as the desired size): "if the cards were like that big


### PR DESCRIPTION
## What

Browse grid (below plug slots) now uses **uniform small cards**: big icon, name, visits only. No description text on browse cards — descriptions live on the product page.

Plus a **client-side search bar** filtering the loaded catalog by app name.

## Changes

- **AppCard.tsx**: new `size='browse'` variant — fixed-height card, icon/name/visits only, no description, no Open button. Browse skeleton added.
- **AppStore.tsx**: browse section uses `size='browse'` cards, wider grid (5 cols on xl), search input with Lucide Search icon, empty state message.
- **AppStore.test.tsx**: new tests for browse card shape, search bar, browse section. Skeleton testids updated.

## Screenshots

Will add after dev server screenshot.

## Gates

- D-appstore-plugs merged (1.0.230) — CLEARED
- Click-through: current app links preserved (product page not yet built; coordinate via .context/ when v2 product page lands)

## Verification

- 167 tests green
- tsc clean
- vite build clean