### PR TITLE
fix(web10-social): DM header avatar + name link to profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+1.0.251 || 30.07.2026
+fix(web10-social): D-dm-header-profile-link — DM conversation header avatar + display name now wrap in a Link to /u/:username. Clicking either navigates to the other user's profile; browser back returns to the thread. Back and delete-conversation buttons untouched. 368 tests green, tsc clean.
+
 1.0.250 || 30.07.2026
 docs: `imma rant` filing (docs only, nothing built). One operator complaint filed as a lane item: D-home-stats-bar-styling (ws-D/marketing(2), small — the 1.0.240 homepage stats bar's heavy bordered container "just looks bad"; kill the border, move "data liberated" up as the third stat's label for consistency with USERS/APPS, and bare-on-background vs sleek individual cards is explicitly the builder's taste call against design.md §12). Added to `parallel execution.txt` + plan.txt PHASE 8.6 for the next kickoff batch.
 

--- a/marketing/web10-social/src/components/Chat/DmsScreen.tsx
+++ b/marketing/web10-social/src/components/Chat/DmsScreen.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams, Link } from 'react-router-dom';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -864,18 +864,23 @@ export default function DmsScreen() {
           >
             <ChevronLeft className="w-5 h-5" />
           </button>
-          <div className="relative">
-            <Avatar className="h-8 w-8">
-              <AvatarFallback className="bg-brand-muted text-brand-300 text-xs font-semibold">
-                {displayName.charAt(0).toUpperCase()}
-              </AvatarFallback>
-            </Avatar>
-            <div className={cn(
-              'absolute -bottom-0.5 -right-0.5 w-2.5 h-2.5 rounded-full border-2 border-background',
-              'bg-success animate-glow-pulse',
-            )} />
-          </div>
-          <span className="font-medium text-sm text-foreground flex-1">{displayName}</span>
+          <Link
+            to={`/u/${otherUser.split('/')[1]}`}
+            className="flex items-center gap-3 flex-1 min-w-0"
+          >
+            <div className="relative flex-shrink-0">
+              <Avatar className="h-8 w-8">
+                <AvatarFallback className="bg-brand-muted text-brand-300 text-xs font-semibold">
+                  {displayName.charAt(0).toUpperCase()}
+                </AvatarFallback>
+              </Avatar>
+              <div className={cn(
+                'absolute -bottom-0.5 -right-0.5 w-2.5 h-2.5 rounded-full border-2 border-background',
+                'bg-success animate-glow-pulse',
+              )} />
+            </div>
+            <span className="font-medium text-sm text-foreground truncate">{displayName}</span>
+          </Link>
           <button
             onClick={() => handleDeleteConversation(selectedConv)}
             className="flex items-center justify-center h-11 w-11 hover:bg-danger-muted rounded-lg transition-colors duration-150 text-muted-foreground hover:text-danger"

--- a/parallel execution.txt
+++ b/parallel execution.txt
@@ -2193,7 +2193,7 @@ LANE D — docs / apps / mobile (owns: mobile/**, marketing/, examples/
       tests + tsc green; screenshot the hero at desktop + 375px and
       LOOK. gate: none.
 
-[ ] D-dm-header-profile-link (sub-lane ws-D/messages, TINY; operator,
+[✓ 1.0.251] D-dm-header-profile-link (sub-lane ws-D/messages, TINY; operator,
       30.07 rant: "i am in the chat, when i click my friends bubble /
       name on the top of the chat, it doesnt bring me to their
       profile."): the DM conversation header in DmsScreen.tsx

--- a/plan.txt
+++ b/plan.txt
@@ -2455,11 +2455,11 @@ item D-inapp-discover-knobs (ws-D/discover, bites: [✓ 1.0.230] cards+controls,
     muted/loop/playsInline on cards, pause offscreen, sound on tap
     (insta pattern; respects prefers-reduced-motion). lane item
     D-video-autoplay-muted (ws-D/marketing).
-[ ] DM header links to profile (operator, 30.07 rant: "when i click my
+[✓] DM header links to profile (operator, 30.07 rant: "when i click my
     friends bubble / name on the top of the chat, it doesnt bring me
     to their profile"): the DM conversation header's avatar + name are
     dead text — make them a Link to /u/:username. lane item
-    D-dm-header-profile-link (ws-D/messages, tiny).
+    D-dm-header-profile-link (ws-D/messages, tiny). merged 1.0.251.
 [ ] follow button toggles to unfollow (operator, 30.07 rant: "when i
     hit follow, it doesnt toggle and let me unfollow!"): the toggle
     handlers exist on both UserProfileScreen and DiscoverScreen — this


### PR DESCRIPTION
Wraps the DM conversation header avatar and display name in a `Link` to `/u/:username`, so clicking navigates to the other user's profile. Browser back returns to the thread. Back and delete-conversation buttons are untouched. Includes plan.txt and parallel execution.txt ticks. 368 tests green, tsc clean.