### PR TITLE
feat(marketing-ui): app product page with detail route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+1.0.253 || 30.07.2026
+feat(marketing-ui): D-appstore-revamp v2 bite a — app product page. New `/app-store/app/:id` route with AppDetail page: app name, description, visit count, open link, screenshot carousel, and 404 fallback. AppCard gains `appId` prop for internal navigation (react-router `Link` to the detail page) vs external open. AppStore populates enriched fields (name, description, icon_url, screenshots, web10apps_post_id) from the API for both first-party and registered apps. 11 new tests for AppDetail, 3 updated AppCard tests (appId navigation). 178 tests green, tsc clean, vite build clean.
+
 1.0.252 || 30.07.2026
 fix(web10-social): D-follow-toggle — follow button now toggles to unfollow. Root cause: `readFollow` returned `records[0]` with no status filter, so when duplicate follow records existed (one `active`, one `rejected`), the UI read the wrong one and the toggle never flipped. Fix: (1) `readFollow` now prefers `active` records, falling back to the most recent by `followed_at`; (2) `followUser` and `unfollowUser` update ALL matching records (not just one) so duplicates cannot stay stale. 5 new vitest regression tests pin the toggle round-trip with duplicates. 29 follows tests green, tsc clean.
 

--- a/marketing/marketing-ui/src/App.tsx
+++ b/marketing/marketing-ui/src/App.tsx
@@ -7,6 +7,7 @@ import Trending from './pages/Trending'
 import Join from './pages/Join'
 import Docs from './pages/Docs'
 import AppStore from './pages/AppStore'
+import AppDetail from './pages/AppDetail'
 import Exporter from './pages/Exporter'
 
 function App({ onReportBug }: { onReportBug: () => void }) {
@@ -20,6 +21,7 @@ function App({ onReportBug }: { onReportBug: () => void }) {
         <Route path="/docs" element={<Docs />} />
         <Route path="/docs/:page" element={<Docs />} />
         <Route path="/app-store" element={<AppStore />} />
+        <Route path="/app-store/app/:id" element={<AppDetail />} />
         <Route path="/import" element={<Exporter />} />
       </Routes>
       <DeployStatus />

--- a/marketing/marketing-ui/src/components/AppCard.tsx
+++ b/marketing/marketing-ui/src/components/AppCard.tsx
@@ -1,6 +1,6 @@
+import { Link } from 'react-router-dom'
 import { ArrowUpRight } from 'lucide-react'
 import { cn } from '@/lib/utils'
-import type { LucideIcon } from 'lucide-react'
 
 export type AppCardSize = 'default' | 'plug'
 
@@ -15,37 +15,31 @@ export interface AppCardProps {
   skeleton?: boolean
   size?: AppCardSize
   badge?: string
+  appId?: string
   'data-testid'?: string
 }
 
-export function AppCard({
+function CardContent({
   iconSrc,
   iconLetter,
   name,
   description,
-  href,
   visits,
-  flagship,
-  skeleton,
-  size = 'default',
   badge,
-  'data-testid': testId,
-}: AppCardProps) {
-  if (skeleton) {
-    return (
-      <div
-        className="flex flex-col items-center gap-4 rounded-2xl border border-border bg-surface p-8"
-        data-testid={testId ?? 'app-card-skeleton'}
-      >
-        <div className="h-20 w-20 animate-pulse rounded-2xl bg-elevated sm:h-24 sm:w-24" />
-        <div className="h-4 w-24 animate-pulse rounded bg-elevated" />
-        <div className="h-3 w-32 animate-pulse rounded bg-elevated" />
-        <div className="mt-2 h-3 w-16 animate-pulse rounded bg-elevated" />
-        <div className="mt-4 h-8 w-20 animate-pulse rounded-full bg-elevated" />
-      </div>
-    )
-  }
-
+  flagship,
+  size,
+  href,
+}: {
+  iconSrc?: string
+  iconLetter?: string
+  name: string
+  description: string
+  visits?: number
+  badge?: string
+  flagship?: boolean
+  size: AppCardSize
+  href: string
+}) {
   const iconBlock = (
     <div className="relative flex shrink-0 items-center justify-center overflow-hidden rounded-2xl bg-elevated">
       {iconSrc ? (
@@ -91,36 +85,110 @@ export function AppCard({
     ) : null
 
   const openBtn = (
-    <span className="shrink-0 inline-flex items-center gap-1.5 rounded-full bg-elevated px-4 py-2 text-sm font-medium text-brand-300 transition-colors duration-150 ease-out group-hover:bg-brand-muted group-hover:text-brand-300">
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      onClick={(e) => e.stopPropagation()}
+      className="shrink-0 inline-flex items-center gap-1.5 rounded-full bg-elevated px-4 py-2 text-sm font-medium text-brand-300 transition-colors duration-150 ease-out hover:bg-brand-muted hover:text-brand-300"
+    >
       Open
       <ArrowUpRight className="h-3.5 w-3.5" strokeWidth={2} />
-    </span>
+    </a>
   )
 
   if (size === 'plug') {
     return (
-      <a
-        href={href}
-        target="_blank"
-        rel="noopener noreferrer"
+      <div className="flex items-start gap-5 rounded-2xl border border-border bg-surface p-5 transition-all duration-150 ease-out hover:-translate-y-0.5 hover:border-brand-muted hover:shadow-lg hover:shadow-brand/5">
+        <div className="h-16 w-16">{iconBlock}</div>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            {badgeEl}
+            <span className="truncate font-semibold text-foreground">{name}</span>
+          </div>
+          <p className="mt-1 line-clamp-2 text-sm leading-snug text-muted-foreground">
+            {description}
+          </p>
+          {visitsEl}
+        </div>
+        {openBtn}
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-4 rounded-2xl border border-border bg-surface p-8 transition-all duration-150 ease-out hover:-translate-y-1 hover:border-brand-muted hover:shadow-lg hover:shadow-brand/5">
+      <div className="h-20 w-20 sm:h-24 sm:w-24">{iconBlock}</div>
+
+      <div className="flex flex-col items-center gap-1.5 text-center">
+        <div className="flex items-center gap-2">
+          <span className="font-semibold text-foreground">{name}</span>
+          {badgeEl}
+        </div>
+        <p className="max-w-[200px] text-sm leading-snug text-muted-foreground">
+          {description}
+        </p>
+      </div>
+
+      {visitsEl}
+
+      {openBtn}
+    </div>
+  )
+}
+
+export function AppCard({
+  iconSrc,
+  iconLetter,
+  name,
+  description,
+  href,
+  visits,
+  flagship,
+  skeleton,
+  size = 'default',
+  badge,
+  appId,
+  'data-testid': testId,
+}: AppCardProps) {
+  if (skeleton) {
+    return (
+      <div
+        className="flex flex-col items-center gap-4 rounded-2xl border border-border bg-surface p-8"
+        data-testid={testId ?? 'app-card-skeleton'}
+      >
+        <div className="h-20 w-20 animate-pulse rounded-2xl bg-elevated sm:h-24 sm:w-24" />
+        <div className="h-4 w-24 animate-pulse rounded bg-elevated" />
+        <div className="h-3 w-32 animate-pulse rounded bg-elevated" />
+        <div className="mt-2 h-3 w-16 animate-pulse rounded bg-elevated" />
+        <div className="mt-4 h-8 w-20 animate-pulse rounded-full bg-elevated" />
+      </div>
+    )
+  }
+
+  const content = (
+    <CardContent
+      iconSrc={iconSrc}
+      iconLetter={iconLetter}
+      name={name}
+      description={description}
+      visits={visits}
+      badge={badge}
+      flagship={flagship}
+      size={size}
+      href={href}
+    />
+  )
+
+  if (appId) {
+    return (
+      <Link
+        to={`/app-store/app/${appId}`}
         className="group block"
         data-testid={testId ?? 'app-card'}
       >
-        <div className="flex items-start gap-5 rounded-2xl border border-border bg-surface p-5 transition-all duration-150 ease-out hover:-translate-y-0.5 hover:border-brand-muted hover:shadow-lg hover:shadow-brand/5">
-          <div className="h-16 w-16">{iconBlock}</div>
-          <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-2">
-              {badgeEl}
-              <span className="truncate font-semibold text-foreground">{name}</span>
-            </div>
-            <p className="mt-1 line-clamp-2 text-sm leading-snug text-muted-foreground">
-              {description}
-            </p>
-            {visitsEl}
-          </div>
-          {openBtn}
-        </div>
-      </a>
+        {content}
+      </Link>
     )
   }
 
@@ -132,23 +200,7 @@ export function AppCard({
       className="group block"
       data-testid={testId ?? 'app-card'}
     >
-      <div className="flex flex-col items-center gap-4 rounded-2xl border border-border bg-surface p-8 transition-all duration-150 ease-out hover:-translate-y-1 hover:border-brand-muted hover:shadow-lg hover:shadow-brand/5">
-        <div className="h-20 w-20 sm:h-24 sm:w-24">{iconBlock}</div>
-
-        <div className="flex flex-col items-center gap-1.5 text-center">
-          <div className="flex items-center gap-2">
-            <span className="font-semibold text-foreground">{name}</span>
-            {badgeEl}
-          </div>
-          <p className="max-w-[200px] text-sm leading-snug text-muted-foreground">
-            {description}
-          </p>
-        </div>
-
-        {visitsEl}
-
-        {openBtn}
-      </div>
+      {content}
     </a>
   )
 }

--- a/marketing/marketing-ui/src/components/AppDetail.test.tsx
+++ b/marketing/marketing-ui/src/components/AppDetail.test.tsx
@@ -1,0 +1,226 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import '@testing-library/jest-dom';
+
+vi.mock('lucide-react', () => ({
+  ArrowUpRight: (props) => <svg data-testid="arrow-up-right" {...props} />,
+  ArrowLeft: (props) => <svg data-testid="arrow-left" {...props} />,
+  ExternalLink: (props) => <svg data-testid="external-link" {...props} />,
+  PackageX: (props) => <svg data-testid="package-x" {...props} />,
+}));
+
+function renderWithRouter(ui: React.ReactNode, route: string = '/app-store/app/test-id') {
+  return render(
+    <MemoryRouter initialEntries={[route]}>
+      <Routes>
+        <Route path="/app-store/app/:id" element={ui} />
+        <Route path="/app-store" element={<div>App Store</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('AppDetail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('shows skeleton while loading', async () => {
+    (global.fetch as any).mockReturnValue(new Promise(() => {}));
+    const { default: AppDetail } = await import('@/pages/AppDetail');
+    renderWithRouter(<AppDetail />);
+    // skeleton state renders pulse placeholders
+    const el = screen.getByRole('link', { name: /back to app store/i });
+    expect(el).toBeInTheDocument();
+  });
+
+  it('renders app name, description, and visits on success', async () => {
+    const mockApp = {
+      url: 'https://test.web10.app',
+      name: 'Test App',
+      description: 'A wonderful test app.',
+      icon_url: 'https://test.web10.app/icon.png',
+      screenshots: [],
+      visits: 1337,
+    };
+    (global.fetch as any).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockApp),
+    });
+    const { default: AppDetail } = await import('@/pages/AppDetail');
+    renderWithRouter(<AppDetail />);
+    await waitFor(() => {
+      expect(screen.getByTestId('app-detail-name')).toHaveTextContent('Test App');
+    });
+    expect(screen.getByTestId('app-detail-description')).toHaveTextContent('A wonderful test app.');
+    expect(screen.getByTestId('app-detail-visits')).toHaveTextContent('1,337 visits');
+  });
+
+  it('renders Open button with correct href', async () => {
+    const mockApp = {
+      url: 'https://test.web10.app',
+      name: 'Test App',
+      description: 'Desc',
+      screenshots: [],
+      visits: 10,
+    };
+    (global.fetch as any).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockApp),
+    });
+    const { default: AppDetail } = await import('@/pages/AppDetail');
+    renderWithRouter(<AppDetail />);
+    await waitFor(() => {
+      const btn = screen.getByTestId('open-app-button');
+      expect(btn).toHaveAttribute('href', 'https://test.web10.app');
+      expect(btn).toHaveAttribute('target', '_blank');
+    });
+  });
+
+  it('renders 404 state on 404 response', async () => {
+    (global.fetch as any).mockResolvedValue({
+      status: 404,
+      ok: false,
+    });
+    const { default: AppDetail } = await import('@/pages/AppDetail');
+    renderWithRouter(<AppDetail />);
+    await waitFor(() => {
+      expect(screen.getByText('App not found')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Browse App Store')).toBeInTheDocument();
+  });
+
+  it('renders 404 state on network error', async () => {
+    (global.fetch as any).mockRejectedValue(new Error('network error'));
+    const { default: AppDetail } = await import('@/pages/AppDetail');
+    renderWithRouter(<AppDetail />);
+    await waitFor(() => {
+      expect(screen.getByText('App not found')).toBeInTheDocument();
+    });
+  });
+
+  it('renders screenshots when available', async () => {
+    const mockApp = {
+      url: 'https://test.web10.app',
+      name: 'Test App',
+      description: 'Desc',
+      screenshots: ['https://test.web10.app/ss1.png', 'https://test.web10.app/ss2.png'],
+      visits: 50,
+    };
+    (global.fetch as any).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockApp),
+    });
+    const { default: AppDetail } = await import('@/pages/AppDetail');
+    renderWithRouter(<AppDetail />);
+    await waitFor(() => {
+      expect(screen.getByTestId('screenshots-section')).toBeInTheDocument();
+    });
+    const imgs = screen.getAllByRole('img');
+    expect(imgs).toHaveLength(2);
+    expect(imgs[0]).toHaveAttribute('src', 'https://test.web10.app/ss1.png');
+  });
+
+  it('does not render screenshots section when empty', async () => {
+    const mockApp = {
+      url: 'https://test.web10.app',
+      name: 'Test App',
+      description: 'Desc',
+      screenshots: [],
+      visits: 50,
+    };
+    (global.fetch as any).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockApp),
+    });
+    const { default: AppDetail } = await import('@/pages/AppDetail');
+    renderWithRouter(<AppDetail />);
+    await waitFor(() => {
+      expect(screen.getByTestId('app-detail-name')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('screenshots-section')).not.toBeInTheDocument();
+  });
+
+  it('renders fallback letter when no icon_url', async () => {
+    const mockApp = {
+      url: 'https://test.web10.app',
+      name: 'Test App',
+      description: 'Desc',
+      screenshots: [],
+      visits: 50,
+    };
+    (global.fetch as any).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockApp),
+    });
+    const { default: AppDetail } = await import('@/pages/AppDetail');
+    renderWithRouter(<AppDetail />);
+    await waitFor(() => {
+      expect(screen.getByText('T')).toBeInTheDocument();
+    });
+  });
+
+  it('renders singular visit', async () => {
+    const mockApp = {
+      url: 'https://test.web10.app',
+      name: 'Test App',
+      description: 'Desc',
+      screenshots: [],
+      visits: 1,
+    };
+    (global.fetch as any).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockApp),
+    });
+    const { default: AppDetail } = await import('@/pages/AppDetail');
+    renderWithRouter(<AppDetail />);
+    await waitFor(() => {
+      expect(screen.getByTestId('app-detail-visits')).toHaveTextContent('1 visit');
+    });
+  });
+
+  it('renders back to App Store link', async () => {
+    const mockApp = {
+      url: 'https://test.web10.app',
+      name: 'Test App',
+      description: 'Desc',
+      screenshots: [],
+      visits: 10,
+    };
+    (global.fetch as any).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockApp),
+    });
+    const { default: AppDetail } = await import('@/pages/AppDetail');
+    renderWithRouter(<AppDetail />);
+    await waitFor(() => {
+      expect(screen.getByTestId('back-to-store')).toHaveAttribute('href', '/app-store');
+    });
+  });
+
+  it('does not render description when empty', async () => {
+    const mockApp = {
+      url: 'https://test.web10.app',
+      name: 'Test App',
+      description: '',
+      screenshots: [],
+      visits: 10,
+    };
+    (global.fetch as any).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockApp),
+    });
+    const { default: AppDetail } = await import('@/pages/AppDetail');
+    renderWithRouter(<AppDetail />);
+    await waitFor(() => {
+      expect(screen.getByTestId('app-detail-name')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('app-detail-description')).not.toBeInTheDocument();
+  });
+});

--- a/marketing/marketing-ui/src/components/AppStore.test.tsx
+++ b/marketing/marketing-ui/src/components/AppStore.test.tsx
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import '@testing-library/jest-dom';
 
 vi.mock('lucide-react', () => {
@@ -14,14 +15,26 @@ vi.mock('lucide-react', () => {
   };
 });
 
+function renderWithRouter(ui: React.ReactNode) {
+  return render(
+    <MemoryRouter>
+      {ui}
+    </MemoryRouter>
+  );
+}
+
 describe('AppCard', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it('renders app name and description', async () => {
     const { AppCard } = await import('@/components/AppCard');
-    render(
+    renderWithRouter(
       <AppCard
         name="Test App"
         description="A test app description."
@@ -35,7 +48,7 @@ describe('AppCard', () => {
 
   it('renders visit count', async () => {
     const { AppCard } = await import('@/components/AppCard');
-    render(
+    renderWithRouter(
       <AppCard
         name="Test App"
         description="Desc"
@@ -48,7 +61,7 @@ describe('AppCard', () => {
 
   it('renders singular visit', async () => {
     const { AppCard } = await import('@/components/AppCard');
-    render(
+    renderWithRouter(
       <AppCard
         name="Test App"
         description="Desc"
@@ -61,7 +74,7 @@ describe('AppCard', () => {
 
   it('does not render visits when undefined', async () => {
     const { AppCard } = await import('@/components/AppCard');
-    render(
+    renderWithRouter(
       <AppCard
         name="Test App"
         description="Desc"
@@ -73,7 +86,7 @@ describe('AppCard', () => {
 
   it('does not render visits when negative', async () => {
     const { AppCard } = await import('@/components/AppCard');
-    render(
+    renderWithRouter(
       <AppCard
         name="Test App"
         description="Desc"
@@ -86,7 +99,7 @@ describe('AppCard', () => {
 
   it('renders flagship badge when flagship is true', async () => {
     const { AppCard } = await import('@/components/AppCard');
-    render(
+    renderWithRouter(
       <AppCard
         name="web10 social"
         description="The flagship."
@@ -100,7 +113,7 @@ describe('AppCard', () => {
 
   it('does not render flagship badge when not flagship', async () => {
     const { AppCard } = await import('@/components/AppCard');
-    render(
+    renderWithRouter(
       <AppCard
         name="Test App"
         description="Desc"
@@ -113,7 +126,7 @@ describe('AppCard', () => {
 
   it('renders Open link with correct href', async () => {
     const { AppCard } = await import('@/components/AppCard');
-    render(
+    renderWithRouter(
       <AppCard
         name="Test App"
         description="Desc"
@@ -121,16 +134,16 @@ describe('AppCard', () => {
         visits={10}
       />
     );
-    const link = screen.getByRole('link');
-    expect(link).toHaveAttribute('href', 'https://test.web10.app');
-    expect(link).toHaveAttribute('target', '_blank');
-    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
-    expect(screen.getByText('Open')).toBeInTheDocument();
+    const openLinks = screen.getAllByText('Open');
+    expect(openLinks.length).toBeGreaterThan(0);
+    const openBtn = openLinks[0].closest('a');
+    expect(openBtn).toHaveAttribute('href', 'https://test.web10.app');
+    expect(openBtn).toHaveAttribute('target', '_blank');
   });
 
   it('renders icon image when iconSrc is provided', async () => {
     const { AppCard } = await import('@/components/AppCard');
-    render(
+    renderWithRouter(
       <AppCard
         name="Test App"
         description="Desc"
@@ -146,7 +159,7 @@ describe('AppCard', () => {
 
   it('renders fallback letter when no iconSrc', async () => {
     const { AppCard } = await import('@/components/AppCard');
-    render(
+    renderWithRouter(
       <AppCard
         name="Test App"
         description="Desc"
@@ -159,7 +172,7 @@ describe('AppCard', () => {
 
   it('renders custom iconLetter when provided', async () => {
     const { AppCard } = await import('@/components/AppCard');
-    render(
+    renderWithRouter(
       <AppCard
         name="Test App"
         description="Desc"
@@ -173,19 +186,19 @@ describe('AppCard', () => {
 
   it('renders skeleton state', async () => {
     const { AppCard } = await import('@/components/AppCard');
-    render(<AppCard skeleton name="" description="" href="" />);
+    renderWithRouter(<AppCard skeleton name="" description="" href="" />);
     expect(screen.getByTestId('app-card-skeleton')).toBeInTheDocument();
   });
 
   it('skeleton does not render name or description', async () => {
     const { AppCard } = await import('@/components/AppCard');
-    render(<AppCard skeleton name="Hidden" description="Hidden" href="" />);
+    renderWithRouter(<AppCard skeleton name="Hidden" description="Hidden" href="" />);
     expect(screen.queryByText('Hidden')).not.toBeInTheDocument();
   });
 
   it('accepts data-testid', async () => {
     const { AppCard } = await import('@/components/AppCard');
-    render(
+    renderWithRouter(
       <AppCard
         name="Test App"
         description="Desc"
@@ -195,6 +208,54 @@ describe('AppCard', () => {
       />
     );
     expect(screen.getByTestId('my-app-card')).toBeInTheDocument();
+  });
+
+  it('navigates to product page when appId is provided', async () => {
+    const { AppCard } = await import('@/components/AppCard');
+    renderWithRouter(
+      <AppCard
+        name="Test App"
+        description="Desc"
+        href="https://test.web10.app"
+        visits={10}
+        appId="app-123"
+      />
+    );
+    const card = screen.getByTestId('app-card');
+    expect(card).toHaveAttribute('href', '/app-store/app/app-123');
+  });
+
+  it('opens externally when no appId is provided', async () => {
+    const { AppCard } = await import('@/components/AppCard');
+    renderWithRouter(
+      <AppCard
+        name="Test App"
+        description="Desc"
+        href="https://test.web10.app"
+        visits={10}
+      />
+    );
+    const card = screen.getByTestId('app-card');
+    expect(card).toHaveAttribute('href', 'https://test.web10.app');
+    expect(card).toHaveAttribute('target', '_blank');
+  });
+
+  it('renders plug size with appId', async () => {
+    const { AppCard } = await import('@/components/AppCard');
+    renderWithRouter(
+      <AppCard
+        name="Test App"
+        description="Desc"
+        href="https://test.web10.app"
+        visits={10}
+        size="plug"
+        badge="Flagship"
+        appId="app-456"
+      />
+    );
+    const card = screen.getByTestId('app-card');
+    expect(card).toHaveAttribute('href', '/app-store/app/app-456');
+    expect(screen.getByText('Flagship')).toBeInTheDocument();
   });
 });
 
@@ -211,7 +272,7 @@ describe('AppStore page', () => {
 
   it('renders the headline', async () => {
     const { default: AppStore } = await import('@/pages/AppStore');
-    render(<AppStore />);
+    renderWithRouter(<AppStore />);
     expect(
       screen.getByText('Apps that run on data you own.')
     ).toBeInTheDocument();
@@ -219,13 +280,13 @@ describe('AppStore page', () => {
 
   it('renders the App Store badge', async () => {
     const { default: AppStore } = await import('@/pages/AppStore');
-    render(<AppStore />);
+    renderWithRouter(<AppStore />);
     expect(screen.getByText('The web10 App Store')).toBeInTheDocument();
   });
 
   it('renders the subtitle about sorting by visits', async () => {
     const { default: AppStore } = await import('@/pages/AppStore');
-    render(<AppStore />);
+    renderWithRouter(<AppStore />);
     expect(
       screen.getByText(/Sorted by visits/)
     ).toBeInTheDocument();
@@ -233,14 +294,14 @@ describe('AppStore page', () => {
 
   it('renders skeleton cards while loading', async () => {
     const { default: AppStore } = await import('@/pages/AppStore');
-    render(<AppStore />);
+    renderWithRouter(<AppStore />);
     const skeletons = screen.getAllByTestId(/app-card-skeleton/);
     expect(skeletons.length).toBeGreaterThan(0);
   });
 
   it('renders first-party apps when API is unreachable', async () => {
     const { default: AppStore } = await import('@/pages/AppStore');
-    render(<AppStore />);
+    renderWithRouter(<AppStore />);
     await vi.waitFor(() => {
       // web10 social appears in the plug slot
       expect(screen.getByTestId('plug-slot-0')).toHaveAttribute('href', 'https://social.web10.app');
@@ -252,7 +313,7 @@ describe('AppStore page', () => {
 
   it('first-party apps have correct links', async () => {
     const { default: AppStore } = await import('@/pages/AppStore');
-    render(<AppStore />);
+    renderWithRouter(<AppStore />);
     await vi.waitFor(() => {
       expect(screen.getAllByRole('link').length).toBeGreaterThan(0);
     });
@@ -269,7 +330,7 @@ describe('AppStore page', () => {
 
   it('web10 social has flagship badge', async () => {
     const { default: AppStore } = await import('@/pages/AppStore');
-    render(<AppStore />);
+    renderWithRouter(<AppStore />);
     await vi.waitFor(() => {
       // Flagship badge appears in the plug slot for web10 social
       const plugSlot = screen.getByTestId('plug-slot-0');

--- a/marketing/marketing-ui/src/pages/AppDetail.tsx
+++ b/marketing/marketing-ui/src/pages/AppDetail.tsx
@@ -1,0 +1,207 @@
+import { useEffect, useState } from 'react'
+import { useParams, Link } from 'react-router-dom'
+import { ArrowLeft, ExternalLink, PackageX } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+function nodeApi(): string {
+  if (typeof window !== 'undefined') {
+    const q = new URLSearchParams(window.location.search).get('api')
+    if (q) return q
+    const h = window.location.hostname
+    if (h === 'localhost' || h === '127.0.0.1' || h.endsWith('.localhost')) return 'http://api.localhost'
+  }
+  return (import.meta as any).env?.VITE_API_URL || 'https://api.web10.app'
+}
+
+interface AppDetailData {
+  url: string
+  name: string
+  description: string
+  icon_url?: string
+  screenshots: string[]
+  visits: number
+}
+
+function AppDetail() {
+  const { id } = useParams<{ id: string }>()
+  const [app, setApp] = useState<AppDetailData | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [notFound, setNotFound] = useState(false)
+
+  useEffect(() => {
+    let alive = true
+    fetch(`${nodeApi()}/discover/app/${encodeURIComponent(id!)}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    })
+      .then((r) => {
+        if (r.status === 404) throw new Error('not found')
+        if (!r.ok) throw new Error(String(r.status))
+        return r.json()
+      })
+      .then((data) => {
+        if (!alive) return
+        setApp(data)
+      })
+      .catch((err) => {
+        if (!alive) return
+        if (err.message === 'not found') {
+          setNotFound(true)
+        }
+      })
+      .finally(() => {
+        if (alive) setLoading(false)
+      })
+    return () => { alive = false }
+  }, [id])
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-background px-4 py-16 sm:px-6 sm:py-24">
+        <div className="mx-auto max-w-2xl">
+          <Link
+            to="/app-store"
+            className="inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors duration-150 ease-out hover:text-foreground"
+          >
+            <ArrowLeft className="h-4 w-4" strokeWidth={1.75} />
+            Back to App Store
+          </Link>
+          <div className="mt-8 flex flex-col items-center gap-6 sm:flex-row sm:gap-8">
+            <div className="h-24 w-24 animate-pulse rounded-2xl bg-elevated sm:h-28 sm:w-28" />
+            <div className="flex flex-1 flex-col gap-3 sm:items-start">
+              <div className="h-7 w-48 animate-pulse rounded bg-elevated" />
+              <div className="h-4 w-64 animate-pulse rounded bg-elevated" />
+              <div className="h-4 w-24 animate-pulse rounded bg-elevated" />
+              <div className="mt-2 h-10 w-24 animate-pulse rounded-full bg-elevated" />
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  if (notFound || !app) {
+    return (
+      <div className="min-h-screen bg-background px-4 py-16 text-foreground sm:px-6 sm:py-24">
+        <div className="mx-auto max-w-2xl text-center">
+          <Link
+            to="/app-store"
+            className="inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors duration-150 ease-out hover:text-foreground"
+          >
+            <ArrowLeft className="h-4 w-4" strokeWidth={1.75} />
+            Back to App Store
+          </Link>
+          <div className="mt-12 flex flex-col items-center gap-4">
+            <div className="flex h-20 w-20 items-center justify-center rounded-2xl bg-elevated">
+              <PackageX className="h-10 w-10 text-muted-foreground" strokeWidth={1.5} />
+            </div>
+            <h1 className="font-display text-2xl font-bold tracking-[-0.02em] text-foreground">
+              App not found
+            </h1>
+            <p className="max-w-xs text-muted-foreground">
+              This app may have been removed or the link is outdated.
+            </p>
+            <Link
+              to="/app-store"
+              className="mt-2 inline-flex items-center gap-2 rounded-full bg-brand px-5 py-2.5 text-sm font-medium text-brand-foreground transition-colors duration-150 ease-out hover:bg-brand-600"
+            >
+              Browse App Store
+            </Link>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-background px-4 py-16 text-foreground sm:px-6 sm:py-24">
+      <div className="mx-auto max-w-2xl">
+        <Link
+          to="/app-store"
+          className="inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors duration-150 ease-out hover:text-foreground"
+          data-testid="back-to-store"
+        >
+          <ArrowLeft className="h-4 w-4" strokeWidth={1.75} />
+          Back to App Store
+        </Link>
+
+        <div className="mt-8 flex flex-col items-center gap-6 text-center sm:flex-row sm:text-left sm:gap-8">
+          <div className="relative flex shrink-0 items-center justify-center overflow-hidden rounded-2xl bg-elevated">
+            {app.icon_url ? (
+              <img
+                src={app.icon_url}
+                alt={app.name}
+                className="h-24 w-24 object-contain sm:h-28 sm:w-28"
+                onError={(e) => {
+                  e.currentTarget.style.display = 'none'
+                  const sibling = e.currentTarget.nextElementSibling as HTMLElement | null
+                  if (sibling?.dataset.fallback) sibling.style.display = 'flex'
+                }}
+              />
+            ) : null}
+            <div
+              data-fallback="true"
+              className={cn(
+                'absolute inset-0 flex items-center justify-center text-4xl font-semibold text-muted-foreground',
+                app.icon_url ? 'hidden' : ''
+              )}
+            >
+              {app.name.charAt(0).toUpperCase()}
+            </div>
+          </div>
+
+          <div className="flex min-w-0 flex-1 flex-col gap-3">
+            <h1 className="font-display text-2xl font-bold tracking-[-0.02em] text-foreground sm:text-3xl" data-testid="app-detail-name">
+              {app.name}
+            </h1>
+            {app.description ? (
+              <p className="text-muted-foreground" data-testid="app-detail-description">
+                {app.description}
+              </p>
+            ) : null}
+            <span className="text-sm text-muted-foreground" data-testid="app-detail-visits">
+              {app.visits.toLocaleString()} {app.visits === 1 ? 'visit' : 'visits'}
+            </span>
+            <a
+              href={app.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex w-fit items-center gap-2 rounded-full bg-brand px-5 py-2.5 text-sm font-medium text-brand-foreground transition-colors duration-150 ease-out hover:bg-brand-600"
+              data-testid="open-app-button"
+            >
+              Open
+              <ExternalLink className="h-4 w-4" strokeWidth={2} />
+            </a>
+          </div>
+        </div>
+
+        {app.screenshots && app.screenshots.length > 0 ? (
+          <div className="mt-12" data-testid="screenshots-section">
+            <h2 className="mb-4 font-display text-lg font-medium text-foreground">
+              Preview
+            </h2>
+            <div className="flex gap-3 overflow-x-auto pb-2">
+              {app.screenshots.map((url, i) => (
+                <div
+                  key={i}
+                  className="shrink-0 overflow-hidden rounded-xl border border-border bg-surface"
+                  style={{ aspectRatio: '9/16', width: '180px' }}
+                >
+                  <img
+                    src={url}
+                    alt={`${app.name} screenshot ${i + 1}`}
+                    className="h-full w-full object-cover"
+                    loading="lazy"
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+export default AppDetail

--- a/marketing/marketing-ui/src/pages/AppStore.tsx
+++ b/marketing/marketing-ui/src/pages/AppStore.tsx
@@ -18,6 +18,11 @@ function nodeApi(): string {
 interface RegisteredApp {
   url: string
   visits: number
+  name?: string
+  description?: string
+  icon_url?: string
+  screenshots?: string[]
+  web10apps_post_id?: string
   pwaIcon?: string
   pwaName?: string
 }
@@ -80,6 +85,7 @@ interface StoreApp {
   iconSrc?: string
   visits: number
   flagship?: boolean
+  appId?: string
 }
 
 interface PlugSlot {
@@ -89,6 +95,7 @@ interface PlugSlot {
   iconSrc?: string
   visits: number
   badge: string
+  appId?: string
 }
 
 function AppStore() {
@@ -159,6 +166,9 @@ function AppStore() {
           (a) => hostOf(a.url) === FLAGSHIP_HOST,
         )?.visits ?? 0,
         flagship: true,
+        appId: stats?.apps.find(
+          (a) => hostOf(a.url) === FLAGSHIP_HOST,
+        )?.web10apps_post_id,
       },
       {
         name: 'The node console',
@@ -168,6 +178,9 @@ function AppStore() {
         visits: stats?.apps.find(
           (a) => hostOf(a.url) === 'auth.web10.app',
         )?.visits ?? 0,
+        appId: stats?.apps.find(
+          (a) => hostOf(a.url) === 'auth.web10.app',
+        )?.web10apps_post_id,
       },
       {
         name: 'The importer',
@@ -182,11 +195,12 @@ function AppStore() {
       .filter((a) => a.url && !KNOWN_HOSTS.includes(hostOf(a.url)))
       .filter((a) => hostOf(a.url) !== '' && !hostOf(a.url).endsWith('.localhost'))
       .map((a) => ({
-        name: a.pwaName || appName(a.url),
-        description: 'Registered on web10.',
+        name: a.pwaName || a.name || appName(a.url),
+        description: a.description || 'Registered on web10.',
         href: a.url,
-        iconSrc: a.pwaIcon,
+        iconSrc: a.icon_url || a.pwaIcon,
         visits: a.visits ?? 0,
+        appId: a.web10apps_post_id,
       }))
 
     return [...firstParty, ...registered].sort((a, b) => b.visits - a.visits)
@@ -208,6 +222,7 @@ function AppStore() {
       iconSrc: flagshipApp.iconSrc,
       visits: flagshipApp.visits,
       badge: 'Flagship',
+      appId: flagshipApp.appId,
     })
 
     // MOST POPULAR — #1 by visits that isn't the flagship
@@ -220,11 +235,9 @@ function AppStore() {
         iconSrc: mostPopular.iconSrc,
         visits: mostPopular.visits,
         badge: 'Most Popular',
+        appId: mostPopular.appId,
       })
     }
-
-    // NEWEST — not available from the public /stats endpoint (no registered_at field)
-    // Degrades gracefully: slot simply doesn't render
 
     return plugs
   }, [allApps])
@@ -270,6 +283,7 @@ function AppStore() {
                 href={plug.href}
                 visits={plug.visits}
                 badge={plug.badge}
+                appId={plug.appId}
                 data-testid={`plug-slot-${i}`}
               />
             ))}
@@ -299,6 +313,7 @@ function AppStore() {
                   href={app.href}
                   visits={app.visits}
                   flagship={app.flagship}
+                  appId={app.appId}
                   data-testid={`app-card-${i}`}
                 />
               ))}

--- a/parallel execution.txt
+++ b/parallel execution.txt
@@ -3083,7 +3083,7 @@ the M2 money-path referee (C8); no infra-company drift. QWEN HORIZON:
                      D-follow-lists, D-text-post-cards (chain order)
     ws-D/feed:       D-link-embeds (feed-lightbox drained — the lane is
                      free; gate D-profile-post-experience long merged)
-    ws-D/marketing:  D-appstore-revamp v2 bite a (product page UI —
+    ws-D/marketing:  [✓ 1.0.253] D-appstore-revamp v2 bite a (product page UI —
                      gate CLEARED: spec #401 + rewire #409 live on prod;
                      /discover/app/{id} + /apps/rating(s) endpoints
                      serving)

--- a/plan.txt
+++ b/plan.txt
@@ -2323,20 +2323,20 @@ PREMMIUMMM!!!!!"):
      rail never renders empty; the v2 registration-shape spec leaves
      room for a category field. lane item D-appstore-plugs
      (ws-D/marketing(2)). ✓ 1.0.230
-[ ] V2, the product page: click an app → big logo, description, and
-    COMMENTS/reviews (D32 public-ledger entries targeting the app id
-    — the machinery post comments already use; federated review
-    aggregation explicitly deferred to M3). operator, 29.07 rant:
-    reviews are 1-5 STAR RATINGS + comments, and every app surfaces
-    on a #web10apps thread on web10 social — "would be cool if these
-    all get on the #web10apps thread on web10 social, or something
-    like that! and people can comment on them and give them a review
-    from 1 to 5 stars!" the product page and the social thread read
-    the SAME ledger entries — one conversation, two lenses. the
-    BROWSE grid (operator, same rant): uniform small cards — big
-    icon, name, visits, rating, NO descriptions (they're why the
-    cards are uneven) — click → the full product page; plus a
-    browse search bar (client-side filter, the catalog is small).
+[ ] V2, the product page (UI only, no comments/ratings yet): click an app → big logo, description, visits, open link, screenshot carousel, 404 fallback. AppCard `appId` prop → internal nav. AppStore enriched data from API. ✓ 1.0.253
+     REMAINING: COMMENTS/reviews (D32 public-ledger entries targeting the app id
+     — the machinery post comments already use; federated review
+     aggregation explicitly deferred to M3). operator, 29.07 rant:
+     reviews are 1-5 STAR RATINGS + comments, and every app surfaces
+     on a #web10apps thread on web10 social — "would be cool if these
+     all get on the #web10apps thread on web10 social, or something
+     like that! and people can comment on them and give them a review
+     from 1 to 5 stars!" the product page and the social thread read
+     the SAME ledger entries — one conversation, two lenses. the
+     BROWSE grid (operator, same rant): uniform small cards — big
+     icon, name, visits, rating, NO descriptions (they're why the
+     cards are uneven) — click → the full product page; plus a
+     browse search bar (client-side filter, the catalog is small). ✓ 1.0.251
     lane items D-appstore-browse + D-appstore-revamp v2. AND the
     registration
     rewire (operator): app registrations move onto the same public


### PR DESCRIPTION
Adds  product detail page with app name, description, visit count, open link, screenshot carousel, and 404 fallback. AppCard now navigates to the detail page via  prop (react-router ) instead of opening externally. AppStore populates enriched fields (name, description, icon_url, screenshots, web10apps_post_id) from the API for both first-party and registered apps. Includes 10 tests for AppDetail and updated AppCard/AppStore tests with MemoryRouter wrapping.