### PR TITLE
feat(api): A19 — /stats includes S3 media blob bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+1.0.263 || 30.07.2026
+feat(api): A19 — /stats includes S3 media blob bytes. `total_s3_size()` sums `size_bytes` across all media metadata records in every user collection (option b: metadata sum, not bucket API — works with any S3-compatible backend, no MinIO-specific admin dependency). Cached with a 60s TTL to avoid a cross-collection scan on every request. `storage` in the response is now mongo + S3 combined (back-compat shape, marketing-ui needs no change). 7 unit tests for total_s3_size (sum, skip missing, skip zero/negative, empty, cache TTL, cache expiry), 3 endpoint tests (stats includes S3, S3 zero when no media, combined total). 534 tests green, ruff clean.
+
 1.0.262 || 30.07.2026
 docs: web10web10! pass #16 — ship record + board refresh (audit #16). Docs-only dev batch (#428 rant filings) gated clean and promoted dev→main via merge commit (#429); deploy-prod + cd green; prod verified live (7/7 public endpoints). Board drift fixed: audit #15's fleet still queued three merged items (D-dm-header-profile-link 1.0.251, D-appstore-browse 1.0.251, D-follow-toggle 1.0.252) — fleet queues corrected; ws-D/messages now starts at D-deep-links bite 1 (the operator's priority call), ws-D/marketing(2) is D-home-stats-bar-styling only. Qwen horizon: 7 immediately-kickoffable parallel-safe bites across 7 sub-lanes.
 

--- a/api/app/endpoints/system.py
+++ b/api/app/endpoints/system.py
@@ -142,8 +142,9 @@ async def ready():
 async def stats(skip: int = 0, limit: int = 0):
     apps = db.get_apps(skip, limit)
     users = db.get_user_count()
-    size = db.total_size()
-    return {"apps": apps, "users": users, "storage": size}
+    mongo_size = db.total_size()
+    s3_size = db.total_s3_size()
+    return {"apps": apps, "users": users, "storage": mongo_size + s3_size}
 
 
 @router.get("/pwa_listing", include_in_schema=False)

--- a/api/app/services/documentdb.py
+++ b/api/app/services/documentdb.py
@@ -867,6 +867,43 @@ def total_size():
     return db.command("dbstats")["storageSize"]
 
 
+# --- Object-store (S3/MinIO) media size ---
+
+_S3_SIZE_CACHE: float = 0.0
+_S3_SIZE_CACHE_TIME: float = 0.0
+_S3_SIZE_TTL = 60  # seconds — dbstats is already a scan; don't hammer on every /stats
+
+
+def total_s3_size() -> int:
+    """Sum of size_bytes across all media metadata records in every user collection.
+
+    Media blobs live in the object store (MinIO/S3); only metadata lives in
+    MongoDB. This function scans the metadata to recover the total blob size
+    so the /stats "storage" number reflects both DB and object-store bytes.
+
+    Cached with a short TTL to avoid a cross-collection scan on every request.
+    """
+    global _S3_SIZE_CACHE, _S3_SIZE_CACHE_TIME
+    now = datetime.datetime.utcnow().timestamp()
+    if now - _S3_SIZE_CACHE_TIME < _S3_SIZE_TTL:
+        return int(_S3_SIZE_CACHE)
+
+    total = 0
+    for coll_name in db.list_collection_names():
+        coll = db[coll_name]
+        for doc in coll.find(
+            {"service": {"$in": ["media", "public_media"]}, "body.size_bytes": {"$exists": True}},
+            {"body.size_bytes": 1, "_id": 0},
+        ):
+            sb = doc.get("body", {}).get("size_bytes")
+            if isinstance(sb, (int, float)) and sb > 0:
+                total += int(sb)
+
+    _S3_SIZE_CACHE = total
+    _S3_SIZE_CACHE_TIME = now
+    return total
+
+
 # app registration
 
 

--- a/api/tests/test_documentdb.py
+++ b/api/tests/test_documentdb.py
@@ -656,3 +656,126 @@ class TestGetAppsLegacyCompat:
             result = documentdb.get_apps()
 
         assert len(result) == 0
+
+
+class TestTotalS3Size:
+    """total_s3_size sums size_bytes across media metadata in every user collection."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_cache(self):
+        """Reset the module-level cache before each test."""
+        documentdb._S3_SIZE_CACHE = 0.0
+        documentdb._S3_SIZE_CACHE_TIME = 0.0
+
+    def test_sums_size_bytes_across_collections(self):
+        mock_db = MagicMock()
+        mock_db.list_collection_names.return_value = ["alice", "bob"]
+
+        alice_coll = MagicMock()
+        alice_coll.find.return_value = [
+            {"body": {"size_bytes": 1000}},
+            {"body": {"size_bytes": 2000}},
+        ]
+
+        bob_coll = MagicMock()
+        bob_coll.find.return_value = [
+            {"body": {"size_bytes": 3000}},
+        ]
+
+        mock_db.__getitem__.side_effect = lambda name: {"alice": alice_coll, "bob": bob_coll}[name]
+
+        with patch("app.services.documentdb.db", mock_db):
+            total = documentdb.total_s3_size()
+        assert total == 6000
+
+    def test_skips_missing_size_bytes(self):
+        mock_db = MagicMock()
+        mock_db.list_collection_names.return_value = ["alice"]
+
+        alice_coll = MagicMock()
+        alice_coll.find.return_value = [
+            {"body": {"filename": "no_size.jpg"}},  # no size_bytes
+            {"body": {"size_bytes": 500}},
+        ]
+        mock_db.__getitem__.return_value = alice_coll
+
+        with patch("app.services.documentdb.db", mock_db):
+            total = documentdb.total_s3_size()
+        assert total == 500
+
+    def test_skips_non_media_service(self):
+        """Only media and public_media services should be counted."""
+        mock_db = MagicMock()
+        mock_db.list_collection_names.return_value = ["alice"]
+
+        alice_coll = MagicMock()
+        alice_coll.find.return_value = [
+            {"body": {"size_bytes": 100}},
+        ]
+        mock_db.__getitem__.return_value = alice_coll
+
+        with patch("app.services.documentdb.db", mock_db):
+            total = documentdb.total_s3_size()
+        assert total == 100
+
+    def test_skips_zero_and_negative_size(self):
+        mock_db = MagicMock()
+        mock_db.list_collection_names.return_value = ["alice"]
+
+        alice_coll = MagicMock()
+        alice_coll.find.return_value = [
+            {"body": {"size_bytes": 0}},
+            {"body": {"size_bytes": -100}},
+            {"body": {"size_bytes": 200}},
+        ]
+        mock_db.__getitem__.return_value = alice_coll
+
+        with patch("app.services.documentdb.db", mock_db):
+            total = documentdb.total_s3_size()
+        assert total == 200
+
+    def test_empty_collections_return_zero(self):
+        mock_db = MagicMock()
+        mock_db.list_collection_names.return_value = ["alice"]
+
+        alice_coll = MagicMock()
+        alice_coll.find.return_value = []
+        mock_db.__getitem__.return_value = alice_coll
+
+        with patch("app.services.documentdb.db", mock_db):
+            total = documentdb.total_s3_size()
+        assert total == 0
+
+    def test_caches_result_within_ttl(self):
+        """Second call within TTL should not re-query the DB."""
+        mock_db = MagicMock()
+        mock_db.list_collection_names.return_value = ["alice"]
+        alice_coll = MagicMock()
+        alice_coll.find.return_value = [{"body": {"size_bytes": 100}}]
+        mock_db.__getitem__.return_value = alice_coll
+
+        with patch("app.services.documentdb.db", mock_db):
+            r1 = documentdb.total_s3_size()
+            r2 = documentdb.total_s3_size()
+        assert r1 == 100
+        assert r2 == 100
+        alice_coll.find.assert_called_once()
+
+    def test_cache_expires_after_ttl(self):
+        """After TTL expires, the DB is queried again."""
+        mock_db = MagicMock()
+        mock_db.list_collection_names.return_value = ["alice"]
+        alice_coll = MagicMock()
+        alice_coll.find.return_value = [{"body": {"size_bytes": 100}}]
+        mock_db.__getitem__.return_value = alice_coll
+
+        with patch("app.services.documentdb.db", mock_db):
+            documentdb.total_s3_size()
+
+        # Force cache expiry
+        documentdb._S3_SIZE_CACHE_TIME = documentdb._S3_SIZE_CACHE_TIME - documentdb._S3_SIZE_TTL - 1
+        alice_coll.find.reset_mock()
+
+        with patch("app.services.documentdb.db", mock_db):
+            documentdb.total_s3_size()
+        alice_coll.find.assert_called_once()

--- a/api/tests/test_endpoints.py
+++ b/api/tests/test_endpoints.py
@@ -1005,6 +1005,7 @@ class TestSystem:
             patch("app.services.documentdb.get_apps", return_value=[]),
             patch("app.services.documentdb.get_user_count", return_value=5),
             patch("app.services.documentdb.total_size", return_value=1024),
+            patch("app.services.documentdb.total_s3_size", return_value=2048),
         ):
             resp = client.post("/stats")
         assert resp.status_code == 200
@@ -1012,6 +1013,31 @@ class TestSystem:
         assert "apps" in data
         assert "users" in data
         assert "storage" in data
+        assert data["storage"] == 3072  # mongo 1024 + s3 2048
+
+    def test_stats_s3_bytes_included(self, client):
+        """storage must include both MongoDB dbstats and S3 media blob bytes."""
+        with (
+            patch("app.services.documentdb.get_apps", return_value=[]),
+            patch("app.services.documentdb.get_user_count", return_value=1),
+            patch("app.services.documentdb.total_size", return_value=0),
+            patch("app.services.documentdb.total_s3_size", return_value=5000),
+        ):
+            resp = client.post("/stats")
+        data = resp.json()
+        assert data["storage"] == 5000
+
+    def test_stats_s3_zero_when_no_media(self, client):
+        """When no media exists, S3 contribution is 0 and storage == mongo only."""
+        with (
+            patch("app.services.documentdb.get_apps", return_value=[]),
+            patch("app.services.documentdb.get_user_count", return_value=1),
+            patch("app.services.documentdb.total_size", return_value=4096),
+            patch("app.services.documentdb.total_s3_size", return_value=0),
+        ):
+            resp = client.post("/stats")
+        data = resp.json()
+        assert data["storage"] == 4096
 
 
 class TestNodeConfig:

--- a/parallel execution.txt
+++ b/parallel execution.txt
@@ -365,7 +365,7 @@ LANE A — api / backend        (owns: api/**, docker-compose, settings)
       indexes has_media=false), ruff clean. gate: none. unblocks:
       D-trending-card-media, the D-user-profile-media grid half.
 
-[ ] A19-stats-s3-bytes (lane A, api/**, SMALL; operator, 30.07 rant:
+[✓ 1.0.263] A19-stats-s3-bytes (lane A, api/**, SMALL; operator, 30.07 rant:
       "the data liberated tab isnt counting s3 data! should also add
       up all s3 data in the count!"): the marketing homepage "data
       liberated" stat (Home.tsx → POST /stats → system.py:140-146)

--- a/plan.txt
+++ b/plan.txt
@@ -2482,7 +2482,7 @@ D-dm-header-profile-link (ws-D/messages, tiny). merged 1.0.251.
     bare-on-background vs sleek individual cards is the builder's
     taste call against design.md §12. lane item
     D-home-stats-bar-styling (ws-D/marketing(2), small).
-[ ] data liberated counts S3 bytes too (operator, 30.07 rant: "the
+[✓ 1.0.263] data liberated counts S3 bytes too (operator, 30.07 rant: "the
     data liberated tab isnt counting s3 data! should also add up all
     s3 data in the count!"): /stats' `storage` is mongo dbstats
     storageSize only (documentdb.py:867) — media blobs live in the


### PR DESCRIPTION
## A19-stats-s3-bytes

The marketing homepage "data liberated" stat (`POST /stats`) reported `storage` = MongoDB dbstats `storageSize` only. Media blobs live in the object store (MinIO/S3) — only metadata in Mongo — so every uploaded photo/video was missing from the count.

**Fix:** `total_s3_size()` sums `size_bytes` across all media metadata records in every user collection. Cached with a 60s TTL. `storage` in the response is now mongo + S3 combined.

**Decision:** option (b) — summed size_bytes over media metadata records. Works with any S3-compatible backend, no MinIO-specific admin API dependency.

**Back-compat:** response shape unchanged (`storage` stays the summed field). marketing-ui needs no change — `formatBytes` already renders it. Lane D notified via `.context/`.

**Tests:** 7 unit tests for `total_s3_size` (sum, skip missing, skip zero/negative, empty, cache TTL, cache expiry), 3 endpoint tests (stats includes S3, S3 zero when no media, combined total). 534 tests green, ruff clean.