### PR TITLE
feat: discover deep links with search input

### DIFF
--- a/marketing/web10-social/src/__tests__/discoverScreen.test.tsx
+++ b/marketing/web10-social/src/__tests__/discoverScreen.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import '@testing-library/jest-dom';
 import * as data from '@/data';
 
@@ -37,7 +38,11 @@ describe('DiscoverScreen', () => {
 
   it('renders skeleton while loading', async () => {
     const { default: DiscoverScreen } = await import('@/components/Discover/DiscoverScreen');
-    render(<DiscoverScreen />);
+    render(
+      <MemoryRouter initialEntries={['/discover']}>
+        <DiscoverScreen />
+      </MemoryRouter>,
+    );
     await waitFor(() => {
       expect(screen.getByTestId('discover-grid-skeleton')).toBeInTheDocument();
     });
@@ -45,7 +50,11 @@ describe('DiscoverScreen', () => {
 
   it('renders empty state when discovery returns nothing', async () => {
     const { default: DiscoverScreen } = await import('@/components/Discover/DiscoverScreen');
-    render(<DiscoverScreen />);
+    render(
+      <MemoryRouter initialEntries={['/discover']}>
+        <DiscoverScreen />
+      </MemoryRouter>,
+    );
     await waitFor(() => {
       expect(screen.getByTestId('discover-empty')).toBeInTheDocument();
     });
@@ -82,7 +91,11 @@ describe('DiscoverScreen', () => {
     ]);
 
     const { default: DiscoverScreen } = await import('@/components/Discover/DiscoverScreen');
-    render(<DiscoverScreen />);
+    render(
+      <MemoryRouter initialEntries={['/discover']}>
+        <DiscoverScreen />
+      </MemoryRouter>,
+    );
 
     await waitFor(() => {
       expect(screen.getByTestId('discover-grid')).toBeInTheDocument();
@@ -148,7 +161,11 @@ describe('DiscoverScreen', () => {
     ]);
 
     const { default: DiscoverScreen } = await import('@/components/Discover/DiscoverScreen');
-    render(<DiscoverScreen />);
+    render(
+      <MemoryRouter initialEntries={['/discover']}>
+        <DiscoverScreen />
+      </MemoryRouter>,
+    );
 
     await waitFor(() => {
       expect(screen.getAllByTestId('discover-card').length).toBeGreaterThanOrEqual(1);
@@ -187,7 +204,11 @@ describe('DiscoverScreen', () => {
     ]);
 
     const { default: DiscoverScreen } = await import('@/components/Discover/DiscoverScreen');
-    render(<DiscoverScreen />);
+    render(
+      <MemoryRouter initialEntries={['/discover']}>
+        <DiscoverScreen />
+      </MemoryRouter>,
+    );
 
     // Wait for grid to appear (posts loaded)
     await waitFor(() => {
@@ -228,7 +249,11 @@ describe('DiscoverScreen', () => {
     ]);
 
     const { default: DiscoverScreen } = await import('@/components/Discover/DiscoverScreen');
-    render(<DiscoverScreen />);
+    render(
+      <MemoryRouter initialEntries={['/discover']}>
+        <DiscoverScreen />
+      </MemoryRouter>,
+    );
 
     await waitFor(() => {
       expect(screen.getAllByTestId('discover-card').length).toBeGreaterThanOrEqual(2);
@@ -261,7 +286,11 @@ describe('DiscoverScreen', () => {
     ]);
 
     const { default: DiscoverScreen } = await import('@/components/Discover/DiscoverScreen');
-    render(<DiscoverScreen />);
+    render(
+      <MemoryRouter initialEntries={['/discover']}>
+        <DiscoverScreen />
+      </MemoryRouter>,
+    );
 
     await waitFor(() => {
       expect(screen.getByTestId('discover-card')).toBeInTheDocument();
@@ -301,7 +330,11 @@ describe('DiscoverScreen', () => {
     ]);
 
     const { default: DiscoverScreen } = await import('@/components/Discover/DiscoverScreen');
-    render(<DiscoverScreen />);
+    render(
+      <MemoryRouter initialEntries={['/discover']}>
+        <DiscoverScreen />
+      </MemoryRouter>,
+    );
 
     await waitFor(() => {
       expect(screen.getByTestId('discover-grid')).toBeInTheDocument();
@@ -323,5 +356,319 @@ describe('DiscoverScreen', () => {
     await waitFor(() => {
       expect(screen.getByTestId('preset-most-loved').classList).toContain('border-brand');
     });
+  });
+
+  // ── Deep-link tests: ?tag= and ?q= ──────────────────────────────────
+
+  it('restores active tag from ?tag= on initial render', async () => {
+    (data.readDiscoverFeed as ReturnType<typeof vi.fn>).mockResolvedValue([
+      {
+        author: 'user1',
+        provider: 'api.web10.app',
+        post_id: 'p1',
+        text: 'Cooking post',
+        tags: ['cooking'],
+        created_at: new Date().toISOString(),
+        likes: 10,
+        comments: 2,
+        reposts: 1,
+        score: 14,
+      },
+      {
+        author: 'user2',
+        provider: 'api.web10.app',
+        post_id: 'p2',
+        text: 'Tech post',
+        tags: ['tech'],
+        created_at: new Date().toISOString(),
+        likes: 5,
+        comments: 1,
+        reposts: 0,
+        score: 7,
+      },
+    ]);
+
+    const { default: DiscoverScreen } = await import('@/components/Discover/DiscoverScreen');
+    render(
+      <MemoryRouter initialEntries={['/discover?tag=cooking']}>
+        <DiscoverScreen />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('discover-grid')).toBeInTheDocument();
+    });
+
+    // The cooking topic chip should be active
+    const topics = screen.getAllByTestId('discover-topic');
+    const cookingChip = topics.find(t => t.textContent?.includes('cooking'));
+    expect(cookingChip).toBeTruthy();
+    expect(cookingChip!.classList).toContain('border-brand');
+
+    // Only cooking posts should be visible
+    const cards = screen.getAllByTestId('discover-card');
+    expect(cards.length).toBe(1);
+  });
+
+  it('restores search query from ?q= on initial render', async () => {
+    (data.readDiscoverFeed as ReturnType<typeof vi.fn>).mockResolvedValue([
+      {
+        author: 'user1',
+        provider: 'api.web10.app',
+        post_id: 'p1',
+        text: 'Hello world post',
+        tags: ['general'],
+        created_at: new Date().toISOString(),
+        likes: 10,
+        comments: 2,
+        reposts: 1,
+        score: 14,
+      },
+      {
+        author: 'user2',
+        provider: 'api.web10.app',
+        post_id: 'p2',
+        text: 'Another post here',
+        tags: ['general'],
+        created_at: new Date().toISOString(),
+        likes: 5,
+        comments: 1,
+        reposts: 0,
+        score: 7,
+      },
+    ]);
+
+    const { default: DiscoverScreen } = await import('@/components/Discover/DiscoverScreen');
+    render(
+      <MemoryRouter initialEntries={['/discover?q=hello']}>
+        <DiscoverScreen />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('discover-search')).toBeInTheDocument();
+    });
+
+    // Search input should have the query
+    expect(screen.getByTestId('discover-search')).toHaveValue('hello');
+
+    // Only matching posts should be visible
+    await waitFor(() => {
+      const cards = screen.getAllByTestId('discover-card');
+      expect(cards.length).toBe(1);
+    });
+  });
+
+  it('restores both ?tag= and ?q= together', async () => {
+    (data.readDiscoverFeed as ReturnType<typeof vi.fn>).mockResolvedValue([
+      {
+        author: 'user1',
+        provider: 'api.web10.app',
+        post_id: 'p1',
+        text: 'Delicious cooking recipe',
+        tags: ['cooking'],
+        created_at: new Date().toISOString(),
+        likes: 10,
+        comments: 2,
+        reposts: 1,
+        score: 14,
+      },
+      {
+        author: 'user2',
+        provider: 'api.web10.app',
+        post_id: 'p2',
+        text: 'Baking is fun too',
+        tags: ['cooking'],
+        created_at: new Date().toISOString(),
+        likes: 5,
+        comments: 1,
+        reposts: 0,
+        score: 7,
+      },
+      {
+        author: 'user3',
+        provider: 'api.web10.app',
+        post_id: 'p3',
+        text: 'Tech news today',
+        tags: ['tech'],
+        created_at: new Date().toISOString(),
+        likes: 20,
+        comments: 5,
+        reposts: 2,
+        score: 28,
+      },
+    ]);
+
+    const { default: DiscoverScreen } = await import('@/components/Discover/DiscoverScreen');
+    render(
+      <MemoryRouter initialEntries={['/discover?tag=cooking&q=delicious']}>
+        <DiscoverScreen />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('discover-grid')).toBeInTheDocument();
+    });
+
+    // Should show only 1 post: cooking tag AND contains "delicious"
+    const cards = screen.getAllByTestId('discover-card');
+    expect(cards.length).toBe(1);
+  });
+
+  it('clicking a topic chip writes ?tag= to URL', async () => {
+    (data.readDiscoverFeed as ReturnType<typeof vi.fn>).mockResolvedValue([
+      {
+        author: 'user1',
+        provider: 'api.web10.app',
+        post_id: 'p1',
+        text: 'Cooking post',
+        tags: ['cooking'],
+        created_at: new Date().toISOString(),
+        likes: 10,
+        comments: 2,
+        reposts: 1,
+        score: 14,
+      },
+      {
+        author: 'user2',
+        provider: 'api.web10.app',
+        post_id: 'p2',
+        text: 'Tech post',
+        tags: ['tech'],
+        created_at: new Date().toISOString(),
+        likes: 5,
+        comments: 1,
+        reposts: 0,
+        score: 7,
+      },
+    ]);
+
+    const { default: DiscoverScreen } = await import('@/components/Discover/DiscoverScreen');
+    render(
+      <MemoryRouter initialEntries={['/discover']}>
+        <DiscoverScreen />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('discover-grid')).toBeInTheDocument();
+    });
+
+    // Click the "cooking" topic chip
+    const topics = screen.getAllByTestId('discover-topic');
+    const cookingChip = topics.find(t => t.textContent?.includes('cooking'));
+    expect(cookingChip).toBeTruthy();
+    fireEvent.click(cookingChip!);
+
+    // Topic chip should now be active
+    await waitFor(() => {
+      expect(cookingChip!.classList).toContain('border-brand');
+    });
+  });
+
+  it('typing in search input filters posts and writes ?q=', async () => {
+    (data.readDiscoverFeed as ReturnType<typeof vi.fn>).mockResolvedValue([
+      {
+        author: 'user1',
+        provider: 'api.web10.app',
+        post_id: 'p1',
+        text: 'Hello world post',
+        tags: ['general'],
+        created_at: new Date().toISOString(),
+        likes: 10,
+        comments: 2,
+        reposts: 1,
+        score: 14,
+      },
+      {
+        author: 'user2',
+        provider: 'api.web10.app',
+        post_id: 'p2',
+        text: 'Another post here',
+        tags: ['general'],
+        created_at: new Date().toISOString(),
+        likes: 5,
+        comments: 1,
+        reposts: 0,
+        score: 7,
+      },
+    ]);
+
+    const { default: DiscoverScreen } = await import('@/components/Discover/DiscoverScreen');
+    render(
+      <MemoryRouter initialEntries={['/discover']}>
+        <DiscoverScreen />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('discover-grid')).toBeInTheDocument();
+    });
+
+    // Initially 2 cards visible
+    expect(screen.getAllByTestId('discover-card').length).toBe(2);
+
+    // Type in search
+    const input = screen.getByTestId('discover-search');
+    fireEvent.change(input, { target: { value: 'hello' } });
+
+    // Should filter to 1 card
+    await waitFor(() => {
+      expect(screen.getAllByTestId('discover-card').length).toBe(1);
+    });
+  });
+
+  it('clearing search removes ?q= and shows all posts', async () => {
+    (data.readDiscoverFeed as ReturnType<typeof vi.fn>).mockResolvedValue([
+      {
+        author: 'user1',
+        provider: 'api.web10.app',
+        post_id: 'p1',
+        text: 'Hello world post',
+        tags: ['general'],
+        created_at: new Date().toISOString(),
+        likes: 10,
+        comments: 2,
+        reposts: 1,
+        score: 14,
+      },
+      {
+        author: 'user2',
+        provider: 'api.web10.app',
+        post_id: 'p2',
+        text: 'Another post here',
+        tags: ['general'],
+        created_at: new Date().toISOString(),
+        likes: 5,
+        comments: 1,
+        reposts: 0,
+        score: 7,
+      },
+    ]);
+
+    const { default: DiscoverScreen } = await import('@/components/Discover/DiscoverScreen');
+    render(
+      <MemoryRouter initialEntries={['/discover?q=hello']}>
+        <DiscoverScreen />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('discover-search')).toHaveValue('hello');
+    });
+
+    // Only 1 card visible with query
+    expect(screen.getAllByTestId('discover-card').length).toBe(1);
+
+    // Click clear button
+    fireEvent.click(screen.getByTestId('discover-search-clear'));
+
+    // Should show all posts again
+    await waitFor(() => {
+      expect(screen.getAllByTestId('discover-card').length).toBe(2);
+    });
+
+    // Search input should be empty
+    expect(screen.getByTestId('discover-search')).toHaveValue('');
   });
 });

--- a/marketing/web10-social/src/__tests__/follow.test.tsx
+++ b/marketing/web10-social/src/__tests__/follow.test.tsx
@@ -194,7 +194,11 @@ describe('Follow button -> followUser call', () => {
     const { followUser } = await import('@/data');
     const { default: DiscoverScreen } = await import('@/components/Discover/DiscoverScreen');
 
-    render(<DiscoverScreen />);
+    render(
+      <MemoryRouter initialEntries={['/discover']}>
+        <DiscoverScreen />
+      </MemoryRouter>,
+    );
 
     await waitFor(() => {
       expect(screen.getAllByTestId('discover-user-card').length).toBeGreaterThan(0);
@@ -214,7 +218,11 @@ describe('Follow button -> followUser call', () => {
   it('discover screen shows suggested users', async () => {
     const { default: DiscoverScreen } = await import('@/components/Discover/DiscoverScreen');
 
-    render(<DiscoverScreen />);
+    render(
+      <MemoryRouter initialEntries={['/discover']}>
+        <DiscoverScreen />
+      </MemoryRouter>,
+    );
 
     await waitFor(() => {
       const cards = screen.getAllByTestId('discover-user-card');
@@ -286,7 +294,11 @@ describe('DiscoverScreen', () => {
   it('renders discover header', async () => {
     const { default: DiscoverScreen } = await import('@/components/Discover/DiscoverScreen');
 
-    render(<DiscoverScreen />);
+    render(
+      <MemoryRouter initialEntries={['/discover']}>
+        <DiscoverScreen />
+      </MemoryRouter>,
+    );
 
     await waitFor(() => {
       expect(screen.getByText('Discover')).toBeInTheDocument();
@@ -299,7 +311,11 @@ describe('DiscoverScreen', () => {
 
     const { default: DiscoverScreen } = await import('@/components/Discover/DiscoverScreen');
 
-    render(<DiscoverScreen />);
+    render(
+      <MemoryRouter initialEntries={['/discover']}>
+        <DiscoverScreen />
+      </MemoryRouter>,
+    );
 
     await waitFor(() => {
       expect(screen.getByTestId('discover-empty')).toBeInTheDocument();

--- a/marketing/web10-social/src/components/Discover/DiscoverScreen.tsx
+++ b/marketing/web10-social/src/components/Discover/DiscoverScreen.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -34,6 +35,8 @@ import {
   UserPlus,
   UserX,
   Loader2,
+  Search,
+  X,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { MARKETING_ORIGIN } from '@/lib/origins';
@@ -542,7 +545,31 @@ export default function DiscoverScreen() {
   const [loading, setLoading] = useState(true);
   const [profileMap, setProfileMap] = useState<Record<string, ProfileRecord>>({});
   const [mediaMap, setMediaMap] = useState<Record<string, MediaRecord[]>>({});
-  const [topic, setTopic] = useState<string>('All');
+
+  // Deep-link: active tag from ?tag= (refresh-safe, shareable)
+  const [searchParams, setSearchParams] = useSearchParams();
+  const urlTag = searchParams.get('tag') || '';
+  const [activeTag, setActiveTag] = useState<string>(urlTag || 'All');
+
+  // Deep-link: search query from ?q= (refresh-safe, shareable)
+  const urlQuery = searchParams.get('q') || '';
+  const [searchQuery, setSearchQuery] = useState<string>(urlQuery);
+
+  // Sync activeTag with ?tag= search param
+  useEffect(() => {
+    const current = searchParams.get('tag') || 'All';
+    if (activeTag !== current) {
+      setActiveTag(current);
+    }
+  }, [searchParams]);
+
+  // Sync searchQuery with ?q= search param
+  useEffect(() => {
+    const current = searchParams.get('q') || '';
+    if (searchQuery !== current) {
+      setSearchQuery(current);
+    }
+  }, [searchParams]);
 
   // Knob state — starts at Balanced preset, knobs re-rank client-side live
   const [knobState, setKnobState] = useState<KnobState>(defaultKnobState());
@@ -725,25 +752,75 @@ export default function DiscoverScreen() {
     [rankedPosts],
   );
 
-  const visiblePosts = useMemo(
-    () => topic === 'All'
-      ? rankedPosts
-      : rankedPosts.filter(p => p.tags?.includes(topic) ?? false),
-    [rankedPosts, topic],
-  );
+  const visiblePosts = useMemo(() => {
+    let filtered = rankedPosts;
+    if (activeTag && activeTag !== 'All') {
+      filtered = filtered.filter(p => p.tags?.includes(activeTag) ?? false);
+    }
+    if (searchQuery.trim()) {
+      const q = searchQuery.toLowerCase();
+      filtered = filtered.filter(p =>
+        (p.text ?? '').toLowerCase().includes(q) ||
+        (p.tags ?? []).some(t => t.toLowerCase().includes(q)) ||
+        (p.author ?? '').toLowerCase().includes(q),
+      );
+    }
+    return filtered;
+  }, [rankedPosts, activeTag, searchQuery]);
 
   const isInitialLoad = loading && posts.length === 0;
   const showSuggested = suggestedLoading || suggested.length > 0;
+
+  function handleSearchChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const val = e.target.value;
+    setSearchQuery(val);
+    const params = new URLSearchParams(searchParams);
+    if (val.trim()) {
+      params.set('q', val.trim());
+    } else {
+      params.delete('q');
+    }
+    setSearchParams(params);
+  }
+
+  function handleSearchClear() {
+    setSearchQuery('');
+    const params = new URLSearchParams(searchParams);
+    params.delete('q');
+    setSearchParams(params);
+  }
 
   return (
     <div className="flex flex-col min-h-full bg-background">
       <div className="md:max-w-xl md:mx-auto">
       {/* Header */}
       <div className="sticky top-0 z-10 bg-background/90 backdrop-blur-md border-b border-border md:static md:border-0 md:bg-transparent md:mb-4">
-        <div className="flex items-center justify-between px-4 py-3 md:px-0">
-          <div className="flex items-center gap-2">
+        <div className="flex items-center justify-between px-4 py-3 md:px-0 gap-3">
+          <div className="flex items-center gap-2 shrink-0">
             <Compass className="h-5 w-5 text-brand-400" strokeWidth={1.75} />
             <h1 className="font-display text-lg font-bold text-foreground">Discover</h1>
+          </div>
+          <div className="relative flex-1 max-w-xs">
+            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
+            <input
+              type="text"
+              value={searchQuery}
+              onChange={handleSearchChange}
+              placeholder="Search posts…"
+              data-testid="discover-search"
+              className="w-full h-8 pl-8 pr-7 rounded-full border border-input bg-surface text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-brand/50 transition-colors duration-150"
+            />
+            {searchQuery && (
+              <button
+                type="button"
+                onClick={handleSearchClear}
+                className="absolute right-1.5 top-1/2 -translate-y-1/2 h-5 w-5 flex items-center justify-center rounded-full hover:bg-elevated transition-colors duration-150"
+                aria-label="Clear search"
+                data-testid="discover-search-clear"
+              >
+                <X className="h-3 w-3 text-muted-foreground" />
+              </button>
+            )}
           </div>
         </div>
       </div>
@@ -799,7 +876,7 @@ export default function DiscoverScreen() {
             aria-label="Filter by topic"
           >
             {topics.map(t => {
-              const active = t === topic;
+              const active = t === activeTag;
               return (
                 <button
                   key={t}
@@ -807,7 +884,16 @@ export default function DiscoverScreen() {
                   role="tab"
                   aria-selected={active}
                   data-testid="discover-topic"
-                  onClick={() => setTopic(t)}
+                  onClick={() => {
+                    setActiveTag(t);
+                    const params = new URLSearchParams(searchParams);
+                    if (t === 'All') {
+                      params.delete('tag');
+                    } else {
+                      params.set('tag', t);
+                    }
+                    setSearchParams(params);
+                  }}
                   className={cn(
                     'shrink-0 rounded-full border px-3 py-1.5 text-sm transition-colors',
                     'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',


### PR DESCRIPTION
Adds deep-link support to the Discover screen so state is restorable via URL:\n\n- **Search input** in the header filters posts by text, tags, or author, writing the query to `?q=`\n- **Topic chips** now write `?tag=` to the URL on click; refreshing restores the active tag\n- Combined filtering works (`?tag=cooking&q=delicious` applies both)\n- Clear button removes `?q=` and restores all posts\n- Wraps all existing Discover tests in `MemoryRouter` and adds 7 new deep-link tests