### PR TITLE
docs: add knowledge-base with web10-v2 architecture docs

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,4 +1,8 @@
 "$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
 
+[env]
+OPENAI_TIMEOUT = "180"
+
+
 [prompts]
 general = "Before starting any plan.txt or lane task, check the lane queues in 'parallel execution.txt' ([✓ x.y.z] = merged, [~] = in flight elsewhere), the [✓] ticks in plan.txt, and the top entries of CHANGELOG.md — the task may already be done; if so, pick the next unticked item in the lane instead. When you finish work, in the same branch: add a CHANGELOG.md line, tick the plan.txt item, and tick your lane item in 'parallel execution.txt'. After creating a PR, do not report it ready yet: first check for merge conflicts (gh pr view --json mergeable,mergeStateStatus) and resolve them, then watch ALL checks including optional ones (gh pr checks --watch — UNSTABLE means an optional check failed and counts as red) and fix failures until every check is green. Full procedure in AGENTS.md."

--- a/knowledge/knowledge-base/web10-v2/api-endpoints.md
+++ b/knowledge/knowledge-base/web10-v2/api-endpoints.md
@@ -1,0 +1,215 @@
+# API Endpoints — The Map
+
+The web10 API is a FastAPI app. Every request carries a JWT token in the body 
+(except anon reads and health checks). The token tells the server who you are, 
+what node you came from, and what you're allowed to do.
+
+Below is every endpoint, grouped by what it does.
+
+---
+
+## Auth — Identity & Tokens
+
+Get in. Stay in. Recover.
+
+| Method | Path | What It Does | Auth |
+|--------|------|-------------|------|
+| POST | `/signup` | Create account, provision collection + default service terms | None |
+| POST | `/web10token` | Mint JWT — password or existing token | None |
+| POST | `/certify` | Verify a token is valid (signature, provider, expiry) | Token |
+| POST | `/recovery_prompt` | Send recovery code to phone | None |
+| POST | `/recovery_bot` | Twilio webhook for RESET body → generates temp password | None |
+| POST | `/change_pass` | Change password (requires old password) | None |
+| POST | `/change_phone` | Change phone number (requires password) | None |
+| POST | `/mobile_login` | Login via SMS code | None |
+| POST | `/send_code` | Send verification code to registered phone | Admin |
+| POST | `/verify_code` | Verify phone code | Admin |
+| POST | `/set_recovery_phone` | Set recovery phone on star record | Token (own) |
+| POST | `/set_email` | Set recovery email, send verification code | Admin |
+| POST | `/get_email` | Return user's own email | Admin |
+| POST | `/verify_email` | Verify email with code | Admin |
+
+**Key code:** `api/app/endpoints/auth.py`, `api/app/services/auth.py`
+
+---
+
+## CRUD — The Core Five
+
+Every user owns a collection. Every collection has services. Every service has 
+a contract. These five endpoints are the entire data layer.
+
+| Method | Path | What It Does | Auth |
+|--------|------|-------------|------|
+| POST | `/{user}/{service}` | Create records | Token + contract |
+| PATCH | `/{user}/{service}` | Read records (query, sort, skip, limit) | Token + contract |
+| PUT | `/{user}/{service}` | Update records | Token + contract |
+| DELETE | `/{user}/{service}` | Delete records | Token + contract |
+| POST | `/{user}/{service}/aggregate` | Run aggregation pipeline (scoped, validated) | Token + contract |
+
+Every CRUD request runs through the same gate:
+
+1. `is_permitted(token, user, service, action)` — check contract
+2. `check(user)` — verify, replenish credits, check space
+3. Execute against `db[user]`
+4. Background tasks: `charge`, `emit_event`, `background_index_post`
+
+**Key code:** `api/app/endpoints/crud.py`, `api/app/services/documentdb.py`
+
+---
+
+## Discovery — Public Board
+
+Cross-user index for public content. Read-only surface, anon-accessible. 
+Backed by `web10.discovery_posts` collection.
+
+| Method | Path | What It Does | Auth |
+|--------|------|-------------|------|
+| PATCH | `/discover/posts` | For-you feed (recent or trending) | Anon OK |
+| PATCH | `/discover/users` | Suggested accounts by engagement | Anon OK |
+| PATCH | `/discover/search` | Full-text search (text + regex fallback) | Anon OK |
+| PATCH | `/discover/topics` | Trending hashtags | Anon OK |
+| PATCH | `/discover/post/{user}/{service}/{id}` | Single post lookup | Anon OK |
+| PATCH | `/discover/app/{web10apps_post_id}` | App product page data | Anon OK |
+
+**How it works:** CRUD writes → background task → `upsert_discovery_post` → 
+discovery index. Reads derive engagement from the public ledger at query time.
+
+**Key code:** `api/app/endpoints/discover.py`, `api/app/services/documentdb.py` (discovery section)
+
+---
+
+## Media — Object Storage
+
+Two-phase upload to S3-compatible storage (MinIO). Metadata lives in user 
+collections (`media` or `public_media` service).
+
+| Method | Path | What It Does | Auth |
+|--------|------|-------------|------|
+| POST | `/{user}/upload` | Request presigned upload URL | Token + media create |
+| POST | `/{user}/upload/confirm` | Confirm upload, write metadata record | Token + service create |
+| POST | `/{user}/read` | Request presigned read URL | Token + service read |
+| POST | `/{user}/list` | List media metadata records | Token + service read |
+| DELETE | `/{user}/delete` | Delete media records | Token + media delete |
+
+**Key code:** `api/app/endpoints/media.py`, `api/app/services/media.py`
+
+---
+
+## Public Ledger — Structured Interactions
+
+Write-open, read-public surface for structured data. Backed by 
+`web10.public` collection. Schema-validated.
+
+| Method | Path | What It Does | Auth |
+|--------|------|-------------|------|
+| POST | `/public/entries` | Create entry (schema-validated) | Token |
+| PATCH | `/public/entries` | Query entries (filter by schema, target, author) | Anon OK |
+| PUT | `/public/entries/{id}` | Update entry | Author only |
+| DELETE | `/public/entries/{id}` | Delete entry | Author only |
+
+Used for: reactions, comments, reposts, follows, app ratings — anything that 
+needs to be public and structured.
+
+**Key code:** `api/app/endpoints/public.py`, `api/app/services/documentdb.py` (public section)
+
+---
+
+## Schemas — Type Definitions
+
+JSON Schema registry. Any user can register schemas; public ledger entries 
+validate against them.
+
+| Method | Path | What It Does | Auth |
+|--------|------|-------------|------|
+| POST | `/schemas/register` | Register new JSON Schema | Token |
+| PATCH | `/schemas/{id}` | Fetch schema | Anon OK |
+| PUT | `/schemas/{id}` | Update schema | Author only |
+| DELETE | `/schemas/{id}` | Delete schema | Author only |
+
+**Key code:** `api/app/endpoints/schemas.py`, `api/app/services/documentdb.py` (schemas section)
+
+---
+
+## Payments — Stripe Integration
+
+Developer compensation and subscription management. Customer and business IDs 
+stored on the star record.
+
+| Method | Path | What It Does | Auth |
+|--------|------|-------------|------|
+| POST | `/dev_pay` | Create subscription checkout session | Token |
+| PATCH | `/dev_pay` | Verify subscription status | Token |
+| DELETE | `/dev_pay` | Cancel subscription | Token |
+| POST | `/manage_business` | Create Stripe Connect business session | Admin |
+| POST | `/business_login` | Stripe Connect login link | Admin |
+
+**Key code:** `api/app/endpoints/payments.py`, `api/app/services/stripe.py`
+
+---
+
+## System — Node Operations
+
+Setup, config, health, stats, app store, moderation. Most are admin-gated.
+
+| Method | Path | What It Does | Auth |
+|--------|------|-------------|------|
+| GET | `/` | Redirect to `/docs` | None |
+| GET | `/setup` | Check if node is configured | None |
+| POST | `/setup` | First-run setup (JWT key, config, admin) | None |
+| POST | `/config` | Get node config (stripped of secrets) | Admin |
+| PATCH | `/config` | Partial config update | Admin |
+| POST | `/am_admin` | Check if caller is admin | Token |
+| GET | `/ready` | Health check (DB ping) | None |
+| POST | `/stats` | Node stats (apps, users, storage) | None |
+| GET | `/pwa_listing` | Fetch PWA manifest from URL | None |
+| POST | `/register_app` | Register app (starts pending) | None |
+| POST | `/apps/admin` | List all apps with review state | Admin |
+| POST | `/apps/approve` | Approve/reject app | Admin |
+| POST | `/apps/rating` | Submit star rating | Token |
+| PATCH | `/apps/ratings/{id}` | Read ratings | Anon OK |
+| POST | `/admin/discovery/remove` | Hide post from discovery board | Admin |
+| POST | `/admin/discovery/restore` | Restore hidden post | Admin |
+| POST | `/admin/discovery/removed` | List hidden posts | Admin |
+| POST | `/admin/discovery/migrate_terms` | Migrate public_posts terms | Admin |
+| POST | `/admin/discovery/backfill` | Backfill discovery index | Admin |
+| POST | `/admin/apps/migrate_v2` | Migrate apps to v2 | Admin |
+
+**Key code:** `api/app/endpoints/system.py`, `api/app/services/config.py`
+
+---
+
+## How Requests Flow
+
+```mermaid
+graph LR
+    R["Client"] -->|"CRUD, public, schemas"| G["is_permitted"]
+    R -->|"media read/upload"| G
+    G -->|"allowed"| UC["User collection"]
+    G -->|"allowed"| SC["System collections"]
+    G -->|"presigned URL"| R
+    R -->|"direct S3"| MB["Media blobs"]
+    
+    style R fill:#f5f5f5,stroke:#333,color:#000
+    style G fill:#e8f5e9,stroke:#2e7d32,color:#000
+    style UC fill:#e3f2fd,stroke:#1565c0,color:#000
+    style SC fill:#fff3e0,stroke:#e65100,color:#000
+    style MB fill:#fce4ec,stroke:#c62828,color:#000
+```
+
+---
+
+## Router Registration Order
+
+`api/app/main.py` registers routers in this order. Specific routes must come 
+before the catch-all CRUD router, which matches `/{user}/{service}`:
+
+1. `auth.router` — identity endpoints
+2. `payments.router` — stripe endpoints
+3. `system.router` — node ops
+4. `media.router` — `{user}/upload`, `{user}/read`, etc.
+5. `discover.router` — `/discover/*`
+6. `schemas.router` — `/schemas/*`
+7. `public.router` — `/public/*`
+8. `crud.router` — `/{user}/{service}` (catch-all)
+
+If CRUD were registered first, it would shadow everything else.

--- a/knowledge/knowledge-base/web10-v2/database-migration.md
+++ b/knowledge/knowledge-base/web10-v2/database-migration.md
@@ -1,0 +1,122 @@
+# Database Migration: MongoDB → FerretDB/DocumentDB
+
+## Why
+
+web10 was built on MongoDB from the start — `pymongo`, the Mongo wire protocol, 
+collections-per-user, service records, whitelists, the whole stack spoke Mongo.
+
+But MongoDB is not fully open source. Starting with Server Side License v2 
+(2023), MongoDB requires commercial licensing for production deployments above 
+a certain threshold. That conflicts with web10's ethos: an open protocol for 
+open data, hosted anywhere, by anyone.
+
+The goal was simple: **swap the database without touching the application code.**
+
+## The Stack
+
+Everything lives in the document store — user data, contracts, star records, 
+service terms. The web10 service reads the contracts from the database to 
+enforce them:
+
+```mermaid
+graph LR
+    R["PATCH /alice/posts"] --> S["web10 service"]
+    S -->|"1. read star record"| STAR["star record (*)"]
+    STAR -->|"2. user exists"| S
+    S -->|"3. read service term"| SVC["services term"]
+    SVC -->|"4. contract"| S
+    S -->|"5. ALLOW / DENY"| DATA["posts, inbox, dms..."]
+    
+    style R fill:#f5f5f5,stroke:#333,color:#000
+    style S fill:#fff9c4,stroke:#f57f17,color:#000
+    style STAR fill:#fff3e0,stroke:#e65100,color:#000
+    style SVC fill:#e8f5e9,stroke:#2e7d32,color:#000
+    style DATA fill:#e3f2fd,stroke:#1565c0,color:#000
+```
+
+Double security: the star record (`*`) is checked first — it proves the user 
+exists and carries their verification status, credits, and space limits. Then 
+the service term record is read from the `services` collection — it carries 
+the whitelist and blacklist for that specific service. Both live in the user's 
+own collection. Both must pass.
+
+The database holds everything. The web10 service is the enforcement layer — 
+it reads the rules from the database and applies them before any data touches 
+the network.
+
+## The Swap
+
+The application code changed nothing. `documentdb.py` still imports `pymongo`, 
+still uses `MongoClient`, still writes `db[user].find_one()`. The only thing 
+that changed was the connection string:
+
+```
+# Before (MongoDB Atlas)
+mongodb+srv://web10:password@cluster0.mongodb.net/myFirstDatabase
+
+# After (FerretDB/DocumentDB)
+mongodb://web10:web10@ferretdb:27017/
+```
+
+The `docker-compose.yml` was updated to include FerretDB + PostgreSQL as the 
+default, with real MongoDB available via `--profile mongo` for compatibility 
+testing:
+
+```yaml
+# Default: open-source stack
+postgres:
+  image: ghcr.io/ferretdb/postgres-documentdb:17
+
+ferretdb:
+  image: ghcr.io/ferretdb/ferretdb:2
+
+# Optional: real MongoDB
+mongo:
+  image: mongo:7
+  profiles: ["mongo"]
+```
+
+## Why It Works
+
+FerretDB implements the MongoDB wire protocol at the network level. This means 
+`pymongo` — or any MongoDB driver in any language — connects to FerretDB 
+exactly as it would to MongoDB. FerretDB translates the wire protocol messages 
+to PostgreSQL queries backed by the documentdb extension.
+
+The web10 codebase uses standard MongoDB operations that FerretDB supports:
+
+- CRUD (`insert_one`, `find`, `find_one_and_update`, `delete_many`)
+- Queries with operators (`$set`, `$inc`, `$match`, `$in`, `$ne`, `$exists`)
+- Aggregation pipelines (`$group`, `$sort`, `$limit`, `$unwind`, `$addFields`, etc.)
+- Text indexes (`$text` search)
+- Capped collections (metering events)
+- Collection-level stats (`collStats`, `dbstats`)
+
+## Benefits
+
+- **Fully open source** — AGPLv3 for FerretDB, PostgreSQL license for the backend
+- **Self-hostable** — no Atlas dependency, runs in docker-compose alongside the app
+- **Same API** — zero application code changes
+- **MongoDB remains supported** — flip `DB_URL` and you're on real Mongo
+- **PostgreSQL durability** — ACID compliance, WAL, proven storage engine
+
+## Trade-offs
+
+- **Feature parity** — FerretDB covers the MongoDB features web10 uses, but not 
+  every MongoDB feature exists. The aggregation pipeline validation in 
+  `documentdb.py` already constrains what stages are allowed, which happens to 
+  align with FerretDB's supported subset.
+- **Performance** — FerretDB is a translation layer. For web10's workload 
+  (small per-user collections, read-heavy discovery queries), the overhead is 
+  negligible. The `total_s3_size()` function even has a 60-second cache to 
+  avoid repeated cross-collection scans.
+- **`collStats`** — FerretDB/DocumentDB returns a PostgreSQL-derived estimate 
+  rather than exact MongoDB stats. This is acceptable for space-gating (the 
+  quota check in `crud.check()`), which only needs an approximate byte count.
+
+## Timeline
+
+1. **Phase 1 (origin):** MongoDB Atlas clusters for development and early production
+2. **Phase 2:** FerretDB added to `docker-compose.yml` as an optional profile
+3. **Phase 3:** FerretDB/DocumentDB promoted to default; MongoDB moved to `--profile mongo`
+4. **Now:** Both backends are supported, FerretDB is the default for local and self-hosted deployments

--- a/knowledge/knowledge-base/web10-v2/the-crud.md
+++ b/knowledge/knowledge-base/web10-v2/the-crud.md
@@ -1,0 +1,237 @@
+# The CRUD — User-Owned Data Buckets
+
+## The Original Idea
+
+Before social feeds, before discovery, before media uploads — there was just **five endpoints**.
+
+The original web10 was a CRUD API. Not a REST API with resource-specific routes, not a GraphQL schema 
+with predefined types. Just five HTTP verbs against a single URL pattern:
+
+```
+POST   /{user}/{service}   — create
+PATCH  /{user}/{service}   — read
+PUT    /{user}/{service}   — update
+DELETE /{user}/{service}   — delete
+POST   /{user}/{service}/aggregate — query
+```
+
+That's it. Five endpoints. One pattern. Every API call in the system routes through this.
+
+## The Insight
+
+The insight was simple: **if you give every user their own data bucket, and let them decide who 
+touches it, you don't need a platform.**
+
+On every other internet platform, the company owns the database. You're a row in their table. 
+They decide who sees your data, they decide what happens to it, they can change the terms 
+overnight. You're a tenant.
+
+On web10, **you are the database**.
+
+## The Architecture
+
+When a user signs up, the system creates a **MongoDB collection named after them**:
+
+```python
+# api/app/services/documentdb.py:293
+user_col = db[username]
+user_col.insert_one(new_user)
+```
+
+That's the user's entire data universe. Every record they own lives in `db["alice"]`, 
+`db["bob"]`, `db["chimdi"]`. The collection name is the username. There is no shared 
+"users" table, no "posts" table, no "messages" table. Just one collection per person.
+
+```mermaid
+graph LR
+    App["Social App"] -->|"PATCH /alice/posts"| CRUD["CRUD\n/{user}/{service}"]
+    CRUD -->|"check contract"| Gate{"is_permitted?"}
+    Gate -->|"ALLOW"| VC["alice\n(virtual collection)"]
+    Gate -->|"DENY"| X["403"]
+    VC --> DB["Document Store\n(MongoDB / FerretDB)"]
+    
+    style App fill:#f5f5f5,stroke:#333,color:#000
+    style CRUD fill:#f5f5f5,stroke:#333,color:#000
+    style Gate fill:#fff9c4,stroke:#f57f17,color:#000
+    style VC fill:#e8f5e9,stroke:#2e7d32,color:#000
+    style DB fill:#e3f2fd,stroke:#1565c0,color:#000
+    style X fill:#ffebee,stroke:#c62828,color:#000
+```
+
+Inside each user's collection, data is organized by **service**. A service is just a string 
+field on every document — `public_posts`, `inbox`, `follows`, `media`, `profile`, `dms`, 
+whatever the user or an app needs. The service name is the data bucket.
+
+## The Contracts
+
+Each service has a **term record** — a contract that says who can do what. The term lives in 
+the user's own collection, under the `services` service:
+
+```python
+# api/app/services/records.py:72-82
+def public_posts_term():
+    return {
+        "service": "public_posts",
+        "whitelist": [
+            {"username": ".*", "provider": ".*", "read": True},
+        ],
+        "blacklist": [],
+    }
+```
+
+This contract says: anyone (`.*`), from any provider (`.*`), can read my public posts. 
+Nobody can write, update, or delete them — only the owner can.
+
+The contracts are stored as records in the user's collection. The user can edit them at any 
+time. The user can delete them. The user is the only one who can change the rules of their 
+own data.
+
+## The Permission Check
+
+Every CRUD request goes through the same gate: `is_permitted()`. This function is the 
+enforcement engine — it reads the contract and decides:
+
+```python
+# api/app/services/auth.py:118-144
+def is_permitted(token: Token, username: str, service: str, action: str) -> bool:
+    # Decode the token to find out who's asking
+    # Certify the token is valid
+    # If the requester owns the data, allow
+    # If the requester is on the whitelist for this action, allow
+    # If the requester is on the blacklist, deny
+```
+
+The flow:
+
+```mermaid
+flowchart TD
+    A["Request arrives\nPOST /bob/public_posts"] --> B["Decode token\nWho is asking?"]
+    B --> C["Certify token\nIs it valid?"]
+    C -->|Invalid| D["DENY"]
+    C -->|Valid| E{"Is requester\nthe owner?"}
+    E -->|Yes| F["ALLOW"]
+    E -->|No| G{"Check contract\nfor this service"}
+    G --> H{"On whitelist\nfor this action?"}
+    H -->|No| D
+    H -->|Yes| I{"On blacklist?"}
+    I -->|Yes| D
+    I -->|No| F
+```
+
+The contract lookup uses regex matching — `.*` means everyone, `alice` means only Alice, 
+`family` could be an alias group. The provider field lets you grant access to specific 
+nodes. The action field (`create`, `read`, `update`, `delete`) lets you grant exactly 
+what you want:
+
+```python
+# api/app/services/documentdb.py:608-612
+def is_listed(e):
+    list_hit = (bool(re.fullmatch(e["username"], username))) and \
+               (bool(re.fullmatch(e["provider"], provider)))
+    action_permitted = action in e and e[action]
+    all_permitted = "all" in e and e["all"]
+    return list_hit and (action_permitted or all_permitted)
+```
+
+## The Freedom
+
+This is where the idea becomes real:
+
+**The platform cannot read your data unless you whitelist it.** The node operator is not 
+special — they're just another user on the whitelist. If you don't grant them access, 
+they can't see your records.
+
+**The platform cannot sell your data because they don't have it.** Your data lives in 
+your collection. Access is granted by contract, not by employment.
+
+**The platform cannot change the terms because you own the terms.** The service records 
+live in your collection. Only you can edit them. If a platform wants to change how your 
+data is accessed, they have to ask you to change your contract.
+
+**You can leave and take your data because it's yours.** Export your collection, move it 
+to another node, the contracts travel with the records. Your data isn't locked in a 
+proprietary format — it's JSON documents in a collection.
+
+## How Apps Work
+
+An app doesn't own your data. An app is just a client that talks to your CRUD endpoints. 
+When you install an app, the app creates service term records in your collection — 
+contracts that grant the app access to specific services. You can see every contract. 
+You can edit every contract. You can revoke every contract.
+
+```mermaid
+sequenceDiagram
+    participant App as Social App
+    participant API as web10 API
+    participant DB as alice's data
+
+    App->>API: PATCH /alice/public_posts
+    API->>API: check contract
+    API->>DB: allowed — return posts
+    API-->>App: posts data
+
+    App->>API: POST /alice/dms
+    API->>API: check contract
+    API-->>App: DENY — no access
+```
+
+## The Original CRUD Endpoints
+
+The five endpoints haven't changed. They're still in `api/app/endpoints/crud.py`, 
+still five functions, still the same URL pattern. Everything that was added — discovery, 
+media, payments, schemas — sits alongside them, never replaces them:
+
+```python
+# api/app/endpoints/crud.py — the original five
+@router.post("/{user}/{service}")      # create
+@router.patch("/{user}/{service})     # read
+@router.put("/{user}/{service})       # update
+@router.delete("/{user}/{service})    # delete
+@router.post("/{user}/{service}/aggregate")  # query
+```
+
+Every request hits the same gate:
+
+```python
+# api/app/endpoints/crud.py:57
+if not is_permitted(token, user, service, "create"):
+    raise exceptions.CRUD
+```
+
+The permission check is the first thing that runs. Before the database is touched, 
+before any business logic executes — the contract is checked. If the contract says no, 
+the request dies.
+
+## The Vision
+
+The original README said it plainly:
+
+> Users of the internet solely use the internet as clients through their browser.
+> web10.0 is a protocol for supplying internet users with their own personal APIs 
+> allowing them to use the internet in a new way.
+
+The CRUD is that personal API. Five endpoints. One collection. Contracts you control. 
+Data you own.
+
+If every user on the internet had their own data bucket with their own rules, the 
+platforms would have nothing to sell. No attention to auction. No data to mine. 
+No leverage to hold over creators.
+
+The internet would be free because the users would own it.
+
+## What Was Added
+
+The CRUD is still the foundation. Everything else is built on top:
+
+- **Discovery** — a cross-user index for public content, fed by background tasks on CRUD writes
+- **Media** — S3-compatible object storage with presigned URLs, metadata stored in user collections
+- **Public Ledger** — a shared collection for structured interactions (reactions, comments, follows)
+- **Schemas** — JSON Schema validation for structured data in the public ledger
+- **App Store** — registration, review, and rating of web10 apps
+- **Payments** — Stripe integration for subscriptions and developer compensation
+
+None of these change the CRUD. They all use it. A media record lives in your `media` 
+service. A reaction lives in the public ledger, but the engagement count is derived 
+from it at read time. Discovery is a projection, not the source of truth.
+
+The CRUD is the source of truth. Everything else is a view.

--- a/knowledge/knowledge-base/web10-v3/personal-vs-discoverable.md
+++ b/knowledge/knowledge-base/web10-v3/personal-vs-discoverable.md
@@ -1,0 +1,104 @@
+# Personal Data vs Discoverable Data
+
+## Two Kinds of Data, Two Kinds of Needs
+
+web10 has to serve two fundamentally different needs:
+
+**Personal data** — the user's private bucket. Posts, messages, media, follows, settings. The user owns it, controls it, can delete it, can take it with them. This is the sovereignty story.
+
+**Discoverable data** — the public surface. A trending feed, engagement counts, follower counts, search results, suggested accounts. This is the growth story. An influencer needs people to find them. A platform needs content to surface.
+
+In v2, these are built as separate systems that happen to overlap. The overlap is where everything breaks.
+
+## Personal Data — The User Collection
+
+Every user gets a collection. Everything they own lives there. Service terms control access. The CRUD endpoints are the gate.
+
+```
+alice/
+  ├── star record (*)          — identity, verification, credits
+  ├── services                 — contracts for each service
+  ├── public_posts             — public posts (anon-read whitelisted)
+  ├── private_posts            — private posts (owner-only)
+  ├── staging_posts            — drafts (owner-only)
+  ├── inbox                    — delivered content (fan-out writes)
+  ├── follows                  — who alice follows
+  ├── reactions                — alice's reactions
+  ├── comments                 — alice's comments
+  ├── dms                      — direct messages
+  ├── media                    — private media metadata
+  └── public_media             — public media metadata
+```
+
+This works perfectly for ownership. Alice controls every record. She can change the terms. She can export and leave. The platform can't touch her data without a contract.
+
+**The problem:** nothing is discoverable by default. Every collection is a walled garden. To find Alice's content, you need to know her username, hit her CRUD endpoint, and hope her contract allows it. That's fine for DMs, terrible for a trending feed.
+
+## Discoverable Data — The System Collections
+
+To make content findable, v2 added system collections — cross-user surfaces that live outside any single user's control:
+
+```
+web10/
+  ├── discovery_posts          — public post index (text, tags, media refs)
+  ├── public                   — structured interactions (reactions, comments, follows)
+  ├── schemas                  — JSON schema registry
+  ├── apps                     — app store registrations
+  └── metering_events          — per-request metering
+```
+
+The discovery index is a **projection** — a subset of each user's public posts, stripped down to what's needed for display (text, tags, author, created_at). Engagement counts are derived at read time from the public ledger.
+
+The public ledger is a **mirror** — every reaction, comment, and follow gets copied here so it can be read by anyone, including anon.
+
+**The problem:** these are separate data surfaces that the client is responsible for keeping in sync. The double-write problem exists because personal data and discoverable data live in different places and the client has to write to both.
+
+## The Tension
+
+| | Personal Data | Discoverable Data |
+|---|---|---|
+| **Owner** | The user | The system |
+| **Access** | Contract-gated | Public (anon-read) |
+| **Write** | CRUD endpoint | Projection hooks + ledger mirrors |
+| **Read** | `PATCH /{user}/{service}` | `PATCH /discover/*`, `PATCH /public/entries` |
+| **Sync** | Source of truth | Derived, must stay current |
+| **Delete** | User deletes, gone | Projection must be cleaned up |
+
+The tension is: **the user must own their data, but the system must be able to project it.**
+
+In v2, the compromise is "the system projects from the user's data via server-side hooks." That works for posts (discovery index). It doesn't work for reactions, comments, and follows — those still need the client to write the ledger mirror.
+
+## Why It's Like This
+
+The public ledger exists because of invariant I3: you can't read another user's collection directly for engagement counts. If Alice wants to know how many people reacted to her post, the system can't aggregate across every user's `reactions` collection — that would be a cross-collection read. So reactions must be written to a shared surface the system can query.
+
+The discovery index exists for the same reason: a trending feed can't scan every user's `public_posts` collection. It needs a single index to sort and paginate.
+
+Both are necessary. But both create a sync problem when the client is responsible for the mirror.
+
+## What v3 Should Do
+
+Marry the two together. Not merge them — keep personal data personal, keep discoverable data public — but make the projection automatic and server-side for everything, not just posts.
+
+**The principle:** every CRUD write that should be discoverable triggers a server-side projection. The client never writes to a system collection directly. The client writes to their own collection. The server handles the rest.
+
+```
+Client → POST /alice/reactions → Server
+                                  → CRUD write (source of truth)
+                                  → server-side hook: mirror to web10.public
+                                  → engagement count updated
+```
+
+Same for comments. Same for follows. Same for everything that needs to be public.
+
+**The result:** one client call. One source of truth. The projection is a server-side guarantee, not a client-side hope. The personal data stays personal. The discoverable data stays discoverable. They're married by the hook, not by the client.
+
+## The Deeper Question
+
+There's a deeper architectural question underneath this: **should the system collections even exist?**
+
+The discovery index and public ledger are projections because the database model (one collection per user) makes cross-user queries impossible. But what if the data model supported both personal ownership and cross-user discovery natively?
+
+That's a v3 question. The v2 answer is "server-side hooks." The v3 answer might be "a data model that doesn't require two surfaces."
+
+Until then, the hooks are the bridge. Make them comprehensive, make them reliable, and make the client never think about sync again.

--- a/knowledge/knowledge-base/web10-v3/social-double-write.md
+++ b/knowledge/knowledge-base/web10-v3/social-double-write.md
@@ -1,0 +1,90 @@
+# web10-social: The Double-Write Problem
+
+## The Core Issue
+
+web10-social has to talk to two separate data surfaces for the same action. Not for posts — those are fine. For **reactions, comments, and follows**, the client writes to the user's CRUD collection AND manually mirrors to the public ledger. The mirror is fire-and-forget with no retry. If it fails, the data is silently out of sync.
+
+## What Works — Posts
+
+Post creation is clean. The client writes once, the server handles the rest:
+
+```
+Client → POST /alice/public_posts → Server
+                                    → CRUD write (awaited)
+                                    → background_index_post (server-side hook)
+                                    → discovery index upsert
+```
+
+The discovery index is a server-side projection. The client never touches it. This is the right pattern.
+
+**Code:** `marketing/web10-social/src/data/posts.ts:37-41`
+
+```ts
+export async function createPost(post) {
+  const wapi = getWapi();
+  const service = post.visibility === 'public' ? 'public_posts' : 'private_posts';
+  return wapi.create<PostRecord>(service, post);
+}
+```
+
+One call. One write. Server handles indexing.
+
+## What's Broken — Reactions, Comments, Follows
+
+These three actions do a **client-side double write**. The CRUD record is awaited. The ledger mirror is fire-and-forget:
+
+**Reactions** — `src/data/reactions.ts:43-70`
+
+```ts
+const record = await wapi.create<ReactionRecord>('reactions', reaction);  // CRUD
+createPublicEntry({ ... }).catch((e) => {  // ledger — fire-and-forget
+  console.error('ledger mirror failed (reaction create):', e);
+});
+```
+
+**Comments** — `src/data/comments.ts:58-85` — same pattern. Update is worse: CRUD update, then ledger delete, then ledger create (three calls). Delete is four calls (read, query ledger, delete ledger, delete CRUD).
+
+**Follows** — `src/data/follows.ts:118-186` — triple write: CRUD, ledger mirror, plus inbox backfill from the discovery API.
+
+## Why The Ledger Exists
+
+The public ledger (`web10.public`) is the only cross-user read surface. Because of invariant I3, you can't read another user's collection directly for engagement counts. The ledger is the single write-open surface where anyone can record structured interactions, and anyone (including anon) can read them.
+
+The follower count reads from the ledger, not the `follows` collection. The engagement score on the discovery board derives from the ledger. The marketing-ui FeedPreview reads the ledger.
+
+**The ledger IS the source of truth for public engagement.** But the client is responsible for keeping it in sync.
+
+## The Problems
+
+**1. Fire-and-forget mirrors.** Every ledger write uses `.catch(() => { ... })` with no retry. If the network blips, the CRUD record exists but the engagement count is wrong. No reconciliation mechanism exists. The next page load shows stale counts.
+
+**2. Read-then-write races.** `toggleReaction()` reads existing reactions, then creates or deletes. Two simultaneous toggles can both read "not reacted" and both create. Same for `followUser()` — both can read "not following" and both create.
+
+**3. Delete is a read-then-delete.** `deleteComment()` reads the comment to find its `post_id`, queries the ledger, deletes ledger entries, then deletes the CRUD record. If the comment was already deleted between read and delete, the ledger cleanup operates on stale data.
+
+**4. Fan-out is O(followers) on the client.** Post creation fans out to every follower's inbox from the browser — `Promise.allSettled` over the follower list. At demo scale this works. At 10,000 followers it hangs the tab.
+
+**5. Two feed read paths.** The friends feed pulls directly from each followee's `public_posts` (one read per person you follow). The discover feed reads the discovery index. They're different data, different queries, different code paths.
+
+## The Double-Write Map
+
+| Action | Client Writes | Sync Risk |
+|--------|-------------|-----------|
+| Create post | 1 (CRUD only, server indexes) | None |
+| Delete post | 1 (CRUD only, server un-indexes) | None |
+| Create reaction | 2 (CRUD + ledger, fire-and-forget) | **High** |
+| Create comment | 2 (CRUD + ledger, fire-and-forget) | **High** |
+| Update comment | 3 (CRUD update + ledger delete + ledger create) | **High** |
+| Delete comment | 4 (read + ledger query + ledger delete + CRUD delete) | **Medium** |
+| Follow | 3 (CRUD + ledger + inbox backfill) | **High** |
+| Unfollow | 2 (CRUD update + ledger delete) | **Medium** |
+
+## What v3 Should Do
+
+The pattern that works for posts — **server-side hooks** — should apply everywhere. When a reaction is created via CRUD, the server should automatically write the ledger entry. When a follow is created, the server should write the ledger entry. The client makes one call. The server handles the rest.
+
+The hooks already exist for posts (`_index_post_create`, `_index_post_delete` in `crud.py`). The same mechanism should handle reactions, comments, and follows. The ledger mirror should be a server-side concern, not a client-side chore.
+
+The fan-out should move server-side too. Post creation should trigger a background task that writes to followers' inboxes — not a client-side `Promise.allSettled` over the follower list.
+
+The result: every action is one client call to CRUD. The server handles all projections. The client never manages sync between two data surfaces again.


### PR DESCRIPTION
Three docs in `knowledge/knowledge-base/web10-v2/` with mermaid diagrams:

- **the-crud.md** — the original five CRUD endpoints, user-owned collections, service contracts, and the permission gate that protects every request.
- **database-migration.md** — how web10 moved from MongoDB Atlas to FerretDB/DocumentDB with zero application code changes.
- **api-endpoints.md** — complete endpoint map across all eight categories (auth, CRUD, discovery, media, payments, public ledger, schemas, system).