### PR TITLE
docs: web10 v3 architecture — ClickHouse + MinIO, layered permissions, groups

### DIFF
--- a/knowledge/knowledge-base/web10-v3/archive/clickhouse-mongodb-direct-query.md
+++ b/knowledge/knowledge-base/web10-v3/archive/clickhouse-mongodb-direct-query.md
@@ -1,0 +1,138 @@
+# ClickHouse + MongoDB: Direct Query via `mongodb()`
+
+## The Idea
+
+ClickHouse has a `mongodb()` table function that queries MongoDB directly. No data migration, no ETL pipeline, no projection layer. ClickHouse reads MongoDB collections in-flight and can join them with ClickHouse tables in a single query.
+
+```sql
+SELECT
+    ch_orders.order_id,
+    ch_orders.amount,
+    mongo_users.email,
+    mongo_users.country
+FROM local_clickhouse_orders AS ch_orders
+LEFT JOIN mongodb(
+    'mongodb://user:password@mongo-host:27017/shop_db',
+    'users',
+    'id String, email String, country String'
+) AS mongo_users
+ON ch_orders.user_id = mongo_users.id;
+```
+
+For web10, this means ClickHouse can query user collections directly from MongoDB while still providing OLAP capabilities for the public layer.
+
+## How It Works
+
+ClickHouse connects to MongoDB as a remote data source. The `mongodb()` function takes:
+- Connection string
+- Collection name
+- Schema definition (ClickHouse types)
+
+```sql
+-- Query a user's posts directly from MongoDB
+SELECT * FROM mongodb('mongodb://...', 'alice.public_posts',
+    'post_id String, text String, tags Array(String), created_at DateTime')
+WHERE created_at > now() - INTERVAL 7 DAY;
+
+-- Join ClickHouse ledger with MongoDB user data
+SELECT
+    l.interaction_type,
+    l.actor_key,
+    u.email,
+    u.display_name
+FROM public_ledger AS l
+LEFT JOIN mongodb('mongodb://...', 'web10.star',
+    'user_key String, email String, display_name String') AS u
+ON l.actor_key = u.user_key;
+```
+
+## The Architecture
+
+```
+Client → API → MongoDB (writes, source of truth)
+              ↓
+         ClickHouse (queries MongoDB directly for reads)
+              ↓
+         Response to client
+```
+
+No projection. No mirror. No double-write. ClickHouse reads what it needs from MongoDB at query time.
+
+## Advantages Over S3 Projection
+
+**1. No sync problem.** The data lives in one place. ClickHouse reads the latest state from MongoDB on every query. No stale projections, no reconciliation, no tombstone cleanup.
+
+**2. No ETL pipeline.** The S3 approach required batch writes, compaction, and file management. `mongodb()` eliminates all of that — ClickHouse reads MongoDB collections directly.
+
+**3. Real-time consistency.** A write to MongoDB is immediately visible to ClickHouse queries. The S3 approach had a delay between write and file flush.
+
+**4. Simpler stack.** MongoDB + ClickHouse vs. MongoDB + S3 + ClickHouse + batch writer. Fewer moving parts.
+
+**5. Schema flexibility preserved.** MongoDB's schemaless documents are accessed through ClickHouse's typed schema definition. New fields in MongoDB can be added to the ClickHouse schema definition without migrating existing data.
+
+## Disadvantages vs S3
+
+**1. Query latency.** ClickHouse reads from MongoDB over the network on every query. S3 Parquet files can be cached and scanned in parallel. For heavy analytical workloads, S3 will be faster.
+
+**2. MongoDB load.** Every ClickHouse query adds read load to MongoDB. S3 offloads this entirely. At very high query volumes, MongoDB becomes the bottleneck.
+
+**3. No columnar compression.** MongoDB stores documents row-by-row. ClickHouse reads full documents even if it only needs a few fields. S3 Parquet is columnar — only requested columns are read.
+
+**4. No materialized views on MongoDB data.** ClickHouse can create materialized views on its own tables, but not on `mongodb()` sources. Pre-computed aggregations require a local ClickHouse table (which brings back the sync problem).
+
+**5. Connection management.** ClickHouse maintains connections to MongoDB. Connection pooling, authentication, and network reliability become operational concerns.
+
+## The Fit for web10
+
+| Workload | mongodb() | S3 Parquet |
+|---|---|---|
+| Discovery feed | Good | Better |
+| Engagement counts | Good | Better |
+| User profile reads | Good | Good |
+| Search | Adequate | Better |
+| Analytics | Adequate | Better |
+| Write throughput | N/A (read-only) | N/A (batch) |
+| Real-time consistency | **Excellent** | Poor |
+| Operational complexity | **Low** | High |
+| MongoDB read load | Added | None |
+
+## When to Use `mongodb()`
+
+**Use it when:**
+- You need real-time consistency between MongoDB and analytical queries
+- Query volume is moderate (not competing with MongoDB for reads)
+- You want to eliminate ETL complexity
+- The workload is a mix of CRUD and analytics
+
+**Don't use it when:**
+- You need heavy analytical workloads (billions of rows, complex aggregations)
+- MongoDB is already at read capacity
+- You need materialized views or pre-computed aggregations
+- Columnar scan performance is critical
+
+## The Hybrid: Best of Both
+
+For web10, the optimal approach combines both:
+
+```
+Writes:  Client → API → MongoDB (source of truth)
+Reads (CRUD): API → MongoDB directly
+Reads (OLAP): API → ClickHouse → mongodb() → MongoDB
+Hot paths: API → ClickHouse local tables (materialized from MongoDB)
+```
+
+The `mongodb()` table function handles most analytical queries. For the hottest paths (trending feed, engagement counts), materialized views in ClickHouse provide sub-millisecond response.
+
+## Migration Path
+
+1. Deploy ClickHouse alongside MongoDB
+2. Replace MongoDB ledger queries with `mongodb()` calls in ClickHouse
+3. For hot paths, add materialized views that refresh from MongoDB
+4. Gradually migrate discovery queries from MongoDB to ClickHouse
+5. Keep MongoDB as the write path and source of truth
+
+## Summary
+
+ClickHouse's `mongodb()` table function eliminates the need for a projection layer. It reads MongoDB directly, providing real-time consistency without ETL complexity. For web10, this means the public layer can leverage ClickHouse's analytical power while MongoDB remains the source of truth.
+
+The trade-off is query latency and MongoDB read load. For moderate workloads, `mongodb()` is the simpler, more maintainable approach. For heavy analytical workloads, S3 Parquet projections provide better performance at the cost of complexity.

--- a/knowledge/knowledge-base/web10-v3/archive/clickhouse-permissions-mongo-storage.md
+++ b/knowledge/knowledge-base/web10-v3/archive/clickhouse-permissions-mongo-storage.md
@@ -1,0 +1,247 @@
+# ClickHouse Permissions + MongoDB Storage: The Flattened Model
+
+## The Current Problem
+
+MongoDB has one database per user: `alice.public_posts`, `bob.public_posts`. Access control is structural — you can't query Bob's collection because it's a separate database. Cross-user queries are impossible, which is why the discovery index and public ledger exist.
+
+The consequence: double-write. Every public action writes to the user's collection AND a system collection. The client manages sync. The sync breaks.
+
+## The Idea
+
+Flatten MongoDB. One collection (or a few). Just IDs and raw data. No per-user isolation at the database level.
+
+Move the permissions layer to ClickHouse. Every record has a permissions entry — who can see it, under what terms. ClickHouse queries join MongoDB data with permissions. If you don't have permission, the row is filtered out at query time.
+
+```
+MongoDB (dumb storage):  { _id: "post-abc", body: { text: "hello", tags: [...] }, author: "alice" }
+ClickHouse (permissions): { record_id: "post-abc", author: "alice", visibility: "public", terms: "..." }
+```
+
+The dev does CRUD. Writes the raw data to MongoDB. Writes the permissions metadata to ClickHouse. That's it.
+
+## How It Works
+
+### The MongoDB Layer — Dumb Storage
+
+One collection. Flat. No per-user databases. No access control at the storage layer.
+
+```
+web10_data/
+  posts:
+    { _id: "post-abc", author: "alice", body: { text: "...", tags: [...] }, created_at: ... }
+    { _id: "post-def", author: "bob", body: { text: "...", tags: [...] }, created_at: ... }
+  reactions:
+    { _id: "react-1", actor: "alice", target: "post-def", type: "like", created_at: ... }
+  comments:
+    { _id: "comment-1", actor: "alice", target: "post-def", text: "...", created_at: ... }
+  follows:
+    { _id: "follow-1", follower: "alice", following: "bob", created_at: ... }
+```
+
+That's it. Just IDs and raw BSON. No schema enforcement. No access control. The dev writes to it like a key-value store.
+
+### The ClickHouse Layer — Permissions + Analytics
+
+Structured tables for permissions, visibility, and aggregation:
+
+```sql
+-- Permissions: who can see what
+CREATE TABLE record_permissions (
+    record_id String,
+    record_type String,  -- 'post', 'reaction', 'comment'
+    author_key String,
+    visibility String,   -- 'public', 'followers', 'private', 'token'
+    terms String,        -- JSON: who has access, under what conditions
+    created_at DateTime64(3),
+    deleted UInt8 DEFAULT 0
+) ENGINE = MergeTree()
+ORDER BY (record_type, author_key, record_id);
+
+-- Follows graph: who follows whom
+CREATE TABLE follows_graph (
+    follower_key String,
+    following_key String,
+    created_at DateTime64(3),
+    deleted UInt8 DEFAULT 0
+) ENGINE = MergeTree()
+ORDER BY (follower_key, following_key);
+
+-- Tokens: who has been granted access to what
+CREATE TABLE access_tokens (
+    token_id String,
+    record_id String,
+    granted_to String,
+    expires_at DateTime64(3),
+    revoked UInt8 DEFAULT 0
+) ENGINE = MergeTree()
+ORDER BY (record_id, granted_to);
+
+-- Engagement: aggregated from reactions
+CREATE TABLE engagement (
+    record_id String,
+    reaction_count UInt32,
+    comment_count UInt32,
+    score Float64,
+    updated_at DateTime64(3)
+) ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY record_id;
+```
+
+### The Query — Join + Filter
+
+Every read goes through ClickHouse. It joins MongoDB data with permissions and filters by the requester's access:
+
+```sql
+-- Alice's feed: posts from people she follows that she's allowed to see
+SELECT mongo.body, perm.author_key, eng.score
+FROM mongodb('mongodb://...', 'web10_data.posts',
+    '_id String, author String, body String, created_at DateTime') AS mongo
+JOIN record_permissions AS perm ON mongo._id = perm.record_id
+LEFT JOIN engagement AS eng ON mongo._id = eng.record_id
+JOIN follows_graph AS fg ON perm.author_key = fg.following_key
+WHERE fg.follower_key = 'alice'
+  AND perm.deleted = 0
+  AND (
+    perm.visibility = 'public'
+    OR perm.visibility = 'followers'
+    OR EXISTS (
+      SELECT 1 FROM access_tokens
+      WHERE record_id = mongo._id AND granted_to = 'alice' AND revoked = 0
+    )
+  )
+ORDER BY mongo.created_at DESC
+LIMIT 50;
+```
+
+The query returns exactly what Alice is allowed to see. Nothing more. Nothing less. The permissions are enforced at the query layer, not the storage layer.
+
+### The Write — CRUD + Permissions
+
+The dev writes to MongoDB (the data) and ClickHouse (the permissions). One API call, two writes:
+
+```
+Client → POST /alice/posts → API
+                                  → MongoDB INSERT: { _id: "post-abc", author: "alice", body: {...} }
+                                  → ClickHouse INSERT: { record_id: "post-abc", author: "alice", visibility: "public", terms: {...} }
+```
+
+The MongoDB write is the data. The ClickHouse write is the permissions. Both are fast. Both are awaited. If either fails, the whole operation fails.
+
+## The Advantages
+
+**1. No double-write for discovery.** The discovery index disappears. ClickHouse queries MongoDB directly and filters by permissions. There's one copy of the data. No mirror. No sync problem.
+
+**2. Cross-user queries are trivial.** MongoDB is flat. ClickHouse can query all users in one SELECT. The permissions layer filters what's visible. No system collections. No ledger.
+
+**3. Targeted discovery.** Every user's discovery feed is a ClickHouse query with their specific permission filters. "Show me posts from people I follow where visibility is public or followers." The query returns exactly what they're allowed to see. No over-fetching, no client-side filtering.
+
+**4. MongoDB is simple.** The dev just writes BSON. No per-user databases to manage. No collection-per-user pattern. No cross-collection queries. It's a key-value store for documents.
+
+**5. ClickHouse owns the complex stuff.** Permissions, visibility, terms, engagement scoring, trending, search — all structured in ClickHouse where they belong. ClickHouse is the query engine for "what can this user see?"
+
+**6. Sovereignty.** User data in MongoDB is just files (BSON). Export is dumping the collection and filtering by author. Portable. Simple.
+
+**7. No FerretDB.** MongoDB is just dumb storage. Any MongoDB-compatible backend works. FerretDB's limitations don't matter because we're not doing complex queries against it — ClickHouse handles the queries.
+
+## The Disadvantages
+
+**1. Every read goes through ClickHouse.** Even a single post lookup: `GET /alice/posts/abc` goes through ClickHouse → `mongodb()` → MongoDB. Added latency vs. direct MongoDB reads. Mitigation: cache hot reads. Or keep the CRUD API for simple lookups and use ClickHouse only for cross-user queries.
+
+**2. ClickHouse is the single point of failure for reads.** If ClickHouse is down, no one can read anything. Even the owner can't read their own posts. Mitigation: ClickHouse is highly available. Multiple nodes, replication.
+
+**3. Permission evaluation at query time.** Every query evaluates permissions for every row. At scale, this is expensive. Mitigation: materialized views for common permission patterns. Pre-computed "visible to X" indexes.
+
+**4. MongoDB has no access control.** If someone gets direct MongoDB access, they can read everything. The permissions are only enforced by ClickHouse. Mitigation: MongoDB is behind the API. Direct access requires infrastructure compromise. Defense in depth.
+
+**5. Write complexity.** The dev writes to two systems. MongoDB for data, ClickHouse for permissions. If the MongoDB write succeeds but ClickHouse fails, the data exists without permissions. Mitigation: transactional write — both succeed or both fail. Or: ClickHouse write is the primary, MongoDB is the backup.
+
+**6. Schema drift.** MongoDB is schemaless. ClickHouse has a schema. If the MongoDB document gains a field, the ClickHouse `mongodb()` schema definition needs updating. Mitigation: ClickHouse schema is the source of truth. The API enforces it on writes.
+
+## The Hybrid CRUD
+
+The practical approach: not every read goes through ClickHouse.
+
+```
+Simple CRUD (single user, single record): API → MongoDB directly
+  - GET /alice/posts/abc
+  - PATCH /alice/posts/abc
+  - DELETE /alice/posts/abc
+
+Cross-user queries (discovery, feed, search): API → ClickHouse → mongodb()
+  - GET /discover
+  - GET /alice/feed
+  - GET /search?q=hello
+  - GET /trending
+```
+
+The CRUD API reads MongoDB directly for single-user operations. ClickHouse handles everything that crosses user boundaries. The permissions layer in ClickHouse is consulted for cross-user queries. For single-user CRUD, the API checks the token and authorizes against the record's author — simple, fast, no ClickHouse needed.
+
+## The Write Model
+
+The dev's experience:
+
+```python
+# Create a post — one API call
+def create_post(author, body, visibility):
+    post_id = str(uuid4())
+
+    # MongoDB: the data
+    mongo.db.posts.insert_one({
+        "_id": post_id,
+        "author": author,
+        "body": body,
+        "created_at": now(),
+    })
+
+    # ClickHouse: the permissions
+    clickhouse.execute("""
+        INSERT INTO record_permissions
+        VALUES (%s, 'post', %s, %s, %s, %s, 0)
+    """, (post_id, author, visibility, json.dumps(terms), now()))
+
+    return post_id
+```
+
+The dev writes to MongoDB (the data) and ClickHouse (the permissions). The API handles both. The dev doesn't think about sync, mirrors, or projections.
+
+## What About the Ledger?
+
+The public ledger disappears. Reactions, comments, and follows are just records in MongoDB with permissions in ClickHouse. Engagement counts are materialized views in ClickHouse:
+
+```sql
+CREATE MATERIALIZED VIEW reaction_counts
+TO engagement
+AS SELECT
+    target AS record_id,
+    count() AS reaction_count,
+    0 AS comment_count,
+    count() * 1.0 AS score,
+    now() AS updated_at
+FROM mongodb('mongodb://...', 'web10_data.reactions',
+    '_id String, actor String, target String, type String, created_at DateTime')
+WHERE type = 'like'
+GROUP BY target;
+```
+
+The materialized view aggregates reactions from MongoDB into ClickHouse. Engagement counts are pre-computed. No ledger mirror. No client-side sync.
+
+## The Verdict
+
+This is the v3 answer to the double-write problem. Not "server-side hooks to a mirror." Not "S3 projections." The answer is: **one storage, one permissions layer, queries join them.**
+
+MongoDB is the dumb storage. ClickHouse is the smart query engine. The permissions live where the queries happen. The data lives where writes are fast. They're joined at query time.
+
+The double-write problem disappears because there's no mirror. The discovery index disappears because ClickHouse queries across users. The ledger disappears because engagement is a materialized view.
+
+One collection. One permissions table. One query engine. The rest is SQL.
+
+## Migration Path
+
+1. Flatten MongoDB: migrate from per-user databases to a flat collection
+2. Deploy ClickHouse with permissions tables
+3. Backfill permissions from existing terms records and visibility settings
+4. Migrate cross-user queries (discovery, feed, search) to ClickHouse
+5. Keep CRUD API for single-user operations
+6. Deprecate the discovery index and public ledger
+
+The migration is additive. The flat collection coexists with per-user databases during transition. ClickHouse queries the flat collection. The old system collections are deprecated as ClickHouse replaces them.

--- a/knowledge/knowledge-base/web10-v3/archive/clickhouse-public-layer.md
+++ b/knowledge/knowledge-base/web10-v3/archive/clickhouse-public-layer.md
@@ -1,0 +1,160 @@
+# ClickHouse for the Public Layer
+
+## The Problem
+
+The public layer — discovery index, public ledger, engagement counts — is the read surface everyone hits. Anon users, marketing-ui, the trending feed, suggested accounts, search. Every query scans across users. Every query aggregates.
+
+MongoDB is terrible at this. It was built for single-document CRUD with indexed lookups. Cross-user aggregation means MapReduce, $lookup pipelines, or application-side accumulation. All of them choke at scale because MongoDB stores documents row-by-row with no column compression. A query like "top 50 posts by engagement in the last hour" means scanning every post, computing engagement from the ledger, sorting, and returning. That's a full collection scan with no vectorized execution.
+
+The double-write docs already explain why the client-side mirror breaks. Even with server-side hooks, the read surface itself is the bottleneck.
+
+## Why ClickHouse
+
+ClickHouse is an OLAP columnar database. It was built for exactly this: high-throughput writes, complex aggregations, sub-second response on billions of rows. It stores data column-by-column with compression (LZ4, ZSTD), executes queries vectorized, and merges data in the background.
+
+The public layer is OLAP. It's not "find user X's post." It's "show me the top posts right now." It's "how many reactions did this post get?" It's "which tags are trending?" These are aggregations over many rows. ClickHouse is the tool for aggregations over many rows.
+
+## The Fit
+
+| Requirement | MongoDB | ClickHouse |
+|---|---|---|
+| Cross-user aggregation | Full scan, MapReduce, or app-side | Native GROUP BY, materialized views |
+| Write throughput | ~10k docs/sec single node | ~1M rows/sec single node |
+| Read latency (aggregates) | Seconds to minutes | Milliseconds |
+| Storage efficiency | Row-based, no compression | Columnar, 5-10x compression |
+| Time-series queries | Weak (no native partitioning) | Strong (native partitioning, TTL) |
+| Full-text search | Atlas-only, weak | Native tokenization, TF-IDF |
+| Single-record CRUD | Native | Weak (no row-level updates) |
+
+The trade-off is clear: ClickHouse is not a CRUD database. You don't update a single row. You insert. You delete by partition. This is actually the right model for the public layer — it's an append-only projection. When a post is deleted, you insert a tombstone or delete by partition key.
+
+## The Architecture
+
+The public layer stays a projection. It doesn't replace MongoDB. It sits beside it:
+
+```
+Client → POST /alice/reactions → API (crud.py)
+                                      → MongoDB write (source of truth)
+                                      → ClickHouse INSERT (public projection)
+```
+
+The server-side hook that was already proposed for reactions, comments, and follows writes to ClickHouse instead of (or in addition to) the MongoDB ledger. The read path changes:
+
+```
+Before:  GET /discover → API → MongoDB $lookup pipeline → slow
+After:   GET /discover → API → ClickHouse SELECT → fast
+```
+
+## What Goes Into ClickHouse
+
+### discovery_posts
+The post index for the trending feed. Append-only. When a post is deleted, insert a `deleted=true` flag.
+
+```sql
+CREATE TABLE discovery_posts (
+    post_id String,
+    author_key String,
+    author_name String,
+    text String,
+    tags Array(String),
+    visibility String,
+    created_at DateTime64(3),
+    deleted UInt8 DEFAULT 0,
+    engagement_score Float64
+) ENGINE = MergeTree()
+ORDER BY (created_at, post_id)
+TTL created_at + INTERVAL 90 DAY;
+```
+
+The `engagement_score` is a materialized view that updates from the reactions table. The TTL handles data retention — posts older than 90 days fall off the trending feed naturally.
+
+### public_ledger
+Structured interactions. Reactions, comments, follows. The source of truth for engagement counts.
+
+```sql
+CREATE TABLE public_ledger (
+    entry_id String,
+    actor_key String,
+    target_key String,
+    target_post_id String,
+    interaction_type String,  -- 'reaction', 'comment', 'follow'
+    payload String,           -- JSON for flexible schema
+    created_at DateTime64(3),
+    deleted UInt8 DEFAULT 0
+) ENGINE = MergeTree()
+ORDER BY (interaction_type, target_post_id, created_at);
+```
+
+Queries like "engagement count for post X" become `SELECT count() FROM public_ledger WHERE target_post_id = 'X' AND deleted = 0` — sub-millisecond on millions of rows.
+
+### metering_events
+Per-request metering. Already high-volume, already append-only. Perfect ClickHouse fit.
+
+```sql
+CREATE TABLE metering_events (
+    event_id String,
+    user_key String,
+    service String,
+    operation String,
+    bytes UInt64,
+    duration_ms UInt32,
+    created_at DateTime64(3)
+) ENGINE = MergeTree()
+ORDER BY (user_key, created_at)
+TTL created_at + INTERVAL 30 DAY;
+```
+
+## The Advantages
+
+**1. Sub-second discovery.** The trending feed, top posts, suggested accounts — all become trivial SELECT queries. No MapReduce. No $lookup chains. Just `SELECT * FROM discovery_posts WHERE deleted = 0 ORDER BY engagement_score DESC LIMIT 50`.
+
+**2. Real-time engagement.** Engagement counts update as reactions stream in. Materialized views can aggregate reactions per post automatically. No more "read the ledger, count manually" on every page load.
+
+**3. Scale without pain.** ClickHouse handles millions of inserts per second on a single node. The public layer is the bottleneck at scale because every user's action writes to it. Columnar storage means the storage cost doesn't grow linearly with data volume.
+
+**4. Time-series analytics.** Trending tags, hourly activity, user growth — all native. Partition by date, aggregate by window, no application-side time bucketing.
+
+**5. Full-text search.** ClickHouse has an inverted index for search. The discovery index can support text search natively — no Elasticsearch needed for the first cut.
+
+**6. Data retention.** TTL policies handle cleanup automatically. Posts older than 90 days drop off the trending feed. Metering events older than 30 days are gone. No manual cleanup jobs.
+
+**7. Analytics for free.** The same table that serves the trending feed can answer "how many unique users reacted today" or "what's the median post length." No separate analytics pipeline.
+
+## Search
+
+ClickHouse has an inverted index for full-text search. The discovery index can support text search natively — keyword matching, phrase search, relevance ranking. For the discovery feed, trending tags, and post search, it eliminates the need for a separate search service.
+
+At very large scale or when you need advanced features (fuzzy matching, synonyms, multi-language stemming), Elasticsearch or Meilisearch is still the heavier hammer. But for v3, ClickHouse's inverted index covers the search surface without adding another service.
+
+## What Doesn't Go Into ClickHouse
+
+ClickHouse is not a replacement for the user collections. Personal data stays in MongoDB:
+
+- `alice/public_posts` — CRUD, contract-gated, per-user
+- `alice/inbox` — fan-out writes, per-user reads
+- `alice/dms` — private, per-user
+- `alice/follows` — source of truth for who alice follows
+- `alice/reactions` — source of truth for alice's reactions
+
+The user collections need row-level updates, contract checks, and per-user access control. ClickHouse can't do any of that efficiently. It's a projection target, not a source of truth.
+
+## Migration Path
+
+This is additive. No migration needed:
+
+1. Deploy ClickHouse alongside MongoDB (new docker-compose service)
+2. Add the INSERT hooks to `crud.py` — server-side projections write to both
+3. Flip the read path: discovery queries hit ClickHouse instead of MongoDB
+4. The old MongoDB ledger can be deprecated once ClickHouse is the sole read source
+
+The risk is low because ClickHouse starts as a warm cache. The MongoDB ledger stays the source of truth until ClickHouse is proven reliable. Then you flip the reads and drop the ledger writes.
+
+## The Cost
+
+ClickHouse is open source (Apache 2.0). One node handles the workload of many MongoDB nodes for this use case. The storage cost is lower because of columnar compression. The operational cost is one more service in docker-compose, but it's a single binary with no dependencies.
+
+The engineering cost is writing the hooks and the read-path queries. The hooks are the same server-side projections already planned for v3. The only difference is the target is ClickHouse instead of a MongoDB collection.
+
+## Summary
+
+The public layer is OLAP. MongoDB is OLTP. ClickHouse is OLAP. Using ClickHouse for the public layer means the read surface — discovery, trending, engagement, analytics — works at scale without fighting the database. Personal data stays in MongoDB where it belongs. The server-side hooks bridge them. One client call. Two writes. Each to the right database.

--- a/knowledge/knowledge-base/web10-v3/archive/clickhouse-s3-user-collections.md
+++ b/knowledge/knowledge-base/web10-v3/archive/clickhouse-s3-user-collections.md
@@ -1,0 +1,143 @@
+# ClickHouse + S3: User Collections as Files
+
+## The Idea
+
+ClickHouse can query S3 directly. Not as a pipeline — as the storage layer. The `S3` table engine reads Parquet files from S3 paths without loading them into ClickHouse's own disks. What if user collections lived in S3 instead of MongoDB?
+
+```
+Current:  alice/public_posts → MongoDB collection
+Idea:     alice/public_posts → s3://web10-data/alice/public_posts/*.parquet
+```
+
+ClickHouse queries the S3 path. The data never leaves S3. No MongoDB. No FerretDB. Just files and a query engine.
+
+## How It Would Work
+
+Each user collection becomes an S3 prefix. Records are Parquet files, partitioned by time:
+
+```
+s3://web10-data/
+  alice/
+    public_posts/
+      year=2026/month=08/part-001.parquet
+      year=2026/month=08/part-002.parquet
+    reactions/
+      year=2026/month=08/part-001.parquet
+    comments/
+      year=2026/month=08/part-001.parquet
+    follows/
+      year=2026/part-001.parquet
+  bob/
+    public_posts/
+      year=2026/month=08/part-001.parquet
+```
+
+ClickHouse defines a virtual table over the S3 prefix:
+
+```sql
+CREATE TABLE alice_posts
+ENGINE = S3('s3://web10-data/alice/public_posts/*.parquet', 'Parquet');
+```
+
+Or a global view across all users:
+
+```sql
+SELECT * FROM s3('s3://web10-data/*/public_posts/*.parquet', 'Parquet')
+WHERE created_at > now() - INTERVAL 1 HOUR
+ORDER BY engagement_score DESC
+LIMIT 50;
+```
+
+## The Advantages
+
+**1. No MongoDB.** One fewer service. No FerretDB translation layer. No document database at all. The stack becomes: ClickHouse + S3 + API. Simpler to run, simpler to understand.
+
+**2. Sovereignty.** User data is files, not rows in a database. Alice can copy her S3 prefix to another bucket. She can move to another node by pointing it at her files. The data is portable by definition — not because of an export feature, because it's just files.
+
+**3. Cross-user queries are native.** MongoDB makes cross-user queries painful because each user has their own collection. S3 has no collection boundary — it's a flat namespace with prefixes. ClickHouse can query all users in one SELECT. No discovery index needed. No projection layer. The user data IS the public layer.
+
+**4. Storage cost.** Parquet compresses 5-10x vs BSON. S3 is cheap. At scale, storage matters. A user with 10,000 posts takes ~50MB in MongoDB, ~5MB in Parquet on S3.
+
+**5. ClickHouse features on everything.** Inverted index for search. Materialized views for aggregation. TTL for retention. These work on S3-backed tables. The discovery features (trending, search, suggestions) work directly on user data — no mirror, no sync.
+
+**6. No double-write.** The personal-vs-discoverable tension disappears. There's one copy of the data. ClickHouse reads it for personal queries and public queries. No ledger mirror. No projection hooks. No sync problem.
+
+**7. Media and metadata together.** Currently media blobs live in MinIO and metadata lives in MongoDB. With this model, everything is S3. Media blobs in one prefix, metadata as Parquet in another. One storage system.
+
+**8. Horizontal scale.** S3 scales infinitely. ClickHouse scales horizontally. No MongoDB replica set limits. No sharding strategy to design.
+
+## The Disadvantages
+
+**1. No atomic updates.** MongoDB's `find_one_and_update` is atomic. S3 + Parquet is not. To update a record: read the file, modify the row, write a new file, replace the old one. Between read and write, another request can modify the same file. Last write wins. For social data this is often acceptable — reactions are idempotent, posts are append-only. But it's a real limitation.
+
+**2. No row-level deletes.** Parquet files are immutable. To delete a row: rewrite the file without it, or add a tombstone flag. MongoDB deletes a document in microseconds. S3 requires a file rewrite. Tombstones work but the old data stays on disk until compaction.
+
+**3. Write latency.** Writing a Parquet file to S3 is slower than writing to MongoDB. Serialization, compression, network round-trip. MongoDB writes are in-memory with WAL. For high-frequency operations (reactions, likes), S3 write latency adds up. Mitigation: batch writes. Accumulate records in memory, flush to S3 every N seconds or N records.
+
+**4. Query latency.** ClickHouse reading from S3 is slower than reading from local disk. Every query hits the network. For read-heavy operations (feed, profile, search), S3 latency matters. Mitigation: ClickHouse can cache hot data locally. Or use a materialized view that copies frequently queried data to local disk.
+
+**5. Schema rigidity.** Parquet has a schema. Adding a field means either: writing new files with the new schema (now you have two schemas), or making the schema wide enough for every possible field. MongoDB is schemaless — every document can have different fields. For social data with evolving features, schema flexibility matters. Mitigation: use a superset schema with nullable columns. Or use a JSON column for flexible fields.
+
+**6. Small files problem.** If every write creates a Parquet file, you get millions of tiny files. S3 doesn't like that — listing is slow, metadata operations are expensive. Mitigation: batch writes. Accumulate records, flush as larger files. Or use a compaction process that merges small files periodically.
+
+**7. Per-user access control.** MongoDB collections are naturally isolated — Alice's collection is separate from Bob's. S3 prefixes can be isolated with IAM policies, but ClickHouse querying across prefixes needs access to all of them. The API layer must enforce access control — ClickHouse can't gate reads per-user. Mitigation: the API validates the token, checks the terms record, and only constructs queries for data the user can access. This is already how the API works — it's not a new problem.
+
+**8. No secondary indexes.** Parquet has column statistics (min/max) that ClickHouse uses for pruning, but no secondary indexes. A query like `SELECT * WHERE post_id = 'xyz'` scans every file in the prefix. MongoDB has an index on `_id` — it's instant. Mitigation: partition by post_id hash. Or use a local ClickHouse table as an index that maps IDs to S3 file locations.
+
+**9. No geospatial indexes.** MongoDB has geospatial indexes for location queries. ClickHouse has geospatial functions but no native geospatial index. For location-based features, this is a limitation.
+
+**10. No change streams.** MongoDB change streams let you react to data changes in real-time. S3 has no equivalent. To detect changes: poll S3 for new files, or use S3 event notifications. Less elegant, more complex.
+
+## The Hybrid — Best of Both
+
+The honest answer: this isn't all-or-nothing. The public layer benefits from S3 + ClickHouse. The personal layer benefits from MongoDB.
+
+```
+Personal data (CRUD-heavy):  MongoDB
+  - Single-record updates
+  - Atomic operations
+  - Per-user isolation
+  - Schema flexibility
+
+Public data (query-heavy):   S3 + ClickHouse
+  - Cross-user aggregation
+  - Search
+  - Trending
+  - Analytics
+```
+
+The bridge is the server-side hook. When a user creates a post, the API writes to MongoDB (personal) AND to S3 (public). One client call, two writes. The writes are different shapes — MongoDB gets the full document, S3 gets the projected public fields.
+
+This is the double-write from the other doc. But with S3 as the target, the double-write has a purpose: personal data stays in the right database, public data lands in the right storage.
+
+## What About Replacing MongoDB Entirely?
+
+Technically possible. Operationally painful.
+
+Every CRUD operation becomes a file read + file write. Atomic operations require application-level locking. Schema evolution requires migration scripts. Deletes require tombstones and compaction.
+
+The benefit: one storage system. The cost: reimplementing every database feature in application code.
+
+The trade-off only makes sense if the benefit (sovereignty, simplicity, cost) outweighs the cost (complexity, latency, lost features). For web10, the sovereignty story is central. But the current model already supports data export. Making the storage format portable doesn't make the data more sovereign — the API contracts do.
+
+## The Verdict
+
+**S3 + ClickHouse for the public layer:** yes. The advantages (cross-user queries, search, analytics, cost) outweigh the disadvantages (write latency, no updates). The public layer is append-heavy and query-heavy — perfect for S3 Parquet.
+
+**S3 + ClickHouse for personal data:** no. The disadvantages (no atomic updates, no row-level deletes, schema rigidity, write latency) outweigh the advantages. Personal data is CRUD-heavy — MongoDB is the right tool.
+
+**The hybrid:** keep MongoDB for personal data, move the public ledger to S3 + ClickHouse. Server-side hooks bridge them. No double-write problem — the writes go to different systems for different purposes.
+
+## The Deeper Question
+
+The real question isn't "S3 or MongoDB?" It's "what does the data model look like?"
+
+The current model: one collection per user, system collections for public data. This model creates the double-write problem because personal and public data live in different places.
+
+An alternative model: all data in one place, with access control at the query layer. Personal data is just data with restricted access. Public data is data with open access. No separate collections. No mirrors.
+
+S3 + ClickHouse makes this model possible. One S3 bucket. ClickHouse enforces access control via the API layer. Personal and public are not different storage — they're different query permissions.
+
+That's a v3 question. The v2 answer is "server-side hooks." The v3 answer might be "one storage, query-time access control."
+
+Until then: MongoDB for personal, S3 + ClickHouse for public. The hooks bridge them.

--- a/knowledge/knowledge-base/web10-v3/archive/clickhouse-s3-virtual-collections.md
+++ b/knowledge/knowledge-base/web10-v3/archive/clickhouse-s3-virtual-collections.md
@@ -1,0 +1,124 @@
+# ClickHouse + S3: Virtual User Collections
+
+## The Idea
+
+ClickHouse can query S3 directly. The S3 table engine reads Parquet files from S3 paths without loading them into ClickHouse storage. What if user collections lived in S3 instead of MongoDB — each user's data as Parquet files, ClickHouse querying them as virtual collections?
+
+```
+Current:  alice/public_posts → MongoDB collection → CRUD endpoint
+Idea:     alice/public_posts → s3://web10/alice/public_posts/*.parquet → ClickHouse S3 table
+```
+
+## How It Would Work
+
+Each user collection becomes an S3 prefix. Records are written as individual Parquet files (or batched into larger files):
+
+```
+s3://web10/
+  alice/
+    public_posts/
+      2026-08-01_001.parquet   — 500 records
+      2026-08-02_001.parquet   — 300 records
+    reactions/
+      2026-08-01_001.parquet
+    comments/
+      2026-08-01_001.parquet
+  bob/
+    public_posts/
+      2026-08-01_001.parquet
+```
+
+ClickHouse defines a table that reads from the S3 prefix:
+
+```sql
+CREATE TABLE alice_public_posts (
+    post_id String,
+    text String,
+    tags Array(String),
+    created_at DateTime64(3),
+    deleted UInt8
+) ENGINE = S3('s3://web10/alice/public_posts/*.parquet', 'Parquet');
+```
+
+A global view joins all users:
+
+```sql
+CREATE VIEW all_public_posts AS
+SELECT * FROM s3('s3://web10/*/public_posts/*.parquet', 'Parquet');
+```
+
+## The Pros
+
+**1. No MongoDB.** One fewer service. No FerretDB translation layer. No MongoDB wire protocol overhead. The stack becomes: ClickHouse + S3 + API.
+
+**2. Sovereignty.** User data is files in S3, not rows in a database. Alice can export her data by downloading her S3 prefix. She can move it to another node by copying the prefix. The data model is portable by default — not an export feature, just files.
+
+**3. Storage cost.** S3 is cheap. Parquet is compressed. User data that costs $X in MongoDB costs $X/5 in S3 Parquet. At scale, storage is not free.
+
+**4. Cross-user queries.** ClickHouse can query across all user prefixes in one SELECT. `SELECT * FROM s3('s3://web10/*/public_posts/*.parquet') WHERE created_at > now() - INTERVAL 1 HOUR` — trending feed without a separate discovery index. The user collections ARE the discovery index.
+
+**5. No double-write for the public layer.** The current problem is: personal data in MongoDB, public data in a separate ledger. If user data lives in S3 and ClickHouse queries it directly, there's no mirror. The personal data IS the public data. ClickHouse just reads across users.
+
+**6. Append-only is natural.** Social data is mostly append-only. Posts, reactions, comments — you create them, you rarely update them. Parquet is append-only. Each write is a new file. Perfect match.
+
+**7. Analytics for free.** The same S3 files that serve the CRUD API can answer any analytical question. "How many posts did Alice write this month?" "What's the median post length across all users?" No separate analytics pipeline.
+
+## The Cons
+
+**1. Single-record updates.** Parquet files are immutable. To update a record, you rewrite the file. `PATCH /alice/reactions/123` means: read the Parquet file, find the record, modify it, write a new Parquet file, replace the old one. That's expensive. MongoDB does this in microseconds.
+
+**2. Atomic find-and-update.** MongoDB's `find_one_and_update` is atomic. S3 has no transactions. To do find-and-update on S3, you need application-level locking: read the file, check the condition, write the new file, hope no one else wrote between read and write. Race condition city.
+
+**3. Per-user access control.** MongoDB collections are naturally isolated — Alice's collection is separate from Bob's. S3 prefixes can be isolated with IAM policies, but ClickHouse querying `s3://web10/*/public_posts/*.parquet` needs access to all prefixes. The API layer must enforce access control — ClickHouse can't gate reads per-user.
+
+**4. Schema evolution.** Parquet has a schema. If a post gains a field, you either write a new file with the new schema (now you have files with different schemas) or you make the schema wide enough for every possible field. MongoDB is schemaless — every document can have different fields.
+
+**5. Delete semantics.** Deleting a single record from Parquet means rewriting the file. Or you add a `deleted` flag (tombstone) and accept that the old file stays on disk. MongoDB deletes are instant — the document is gone.
+
+**6. Write latency.** Writing a Parquet file to S3 is slower than writing a MongoDB document. You're serializing, compressing, uploading. MongoDB writes are in-memory with fsync to disk. For a high-write workload like reactions, S3 write latency matters.
+
+**7. Query latency.** ClickHouse reading from S3 is slower than reading from local disk. Every query hits the network. For a trending feed that's called on every page load, S3 latency adds up. ClickHouse can cache, but cache invalidation is the other hard problem.
+
+**8. Indexing.** Parquet has column statistics (min/max) that ClickHouse uses for pruning, but it doesn't have secondary indexes. A query like `SELECT * FROM alice_public_posts WHERE post_id = 'xyz'` scans every Parquet file in the prefix looking for that ID. MongoDB has an index on `_id` — it's instant.
+
+**9. Small files problem.** If each write creates a Parquet file, you end up with millions of tiny files. S3 doesn't like that — listing is slow, metadata operations are expensive. You need to batch writes (which adds latency) or use a compaction process (which adds complexity).
+
+## The Verdict
+
+**For the public layer: yes.** ClickHouse querying S3 is the right model for discovery, trending, and analytics. The data is append-heavy, cross-user queries are the norm, and updates are rare. The S3 table engine works well here.
+
+**For personal data: no.** User collections need single-record CRUD, atomic operations, per-user access control, and schema flexibility. MongoDB (or a document database) is the right tool. The sovereignty story — "user data is files" — is compelling but the operational cost of Parquet CRUD is too high.
+
+## The Hybrid
+
+The sweet spot is a hybrid: personal data in MongoDB, public projections in S3 + ClickHouse.
+
+```
+Client → POST /alice/reactions → API
+                                      → MongoDB write (source of truth, CRUD)
+                                      → S3 Parquet write (public projection)
+```
+
+The S3 write is the same server-side hook proposed in the double-write doc. The difference is the target: S3 Parquet instead of a MongoDB collection. ClickHouse queries the S3 files for discovery, trending, and analytics.
+
+The advantage over the MongoDB ledger: no separate data surface to keep in sync. The S3 files ARE the projection. ClickHouse reads them directly. No intermediate MongoDB collection.
+
+The advantage over MongoDB for the public layer: columnar storage, inverted index for search, materialized views for aggregation, TTL for retention. All native.
+
+## What This Means for v3
+
+1. **Keep MongoDB for personal data.** User collections stay where they are. CRUD, contracts, access control — MongoDB handles it.
+
+2. **Move the public ledger to S3.** Server-side hooks write Parquet files to S3. ClickHouse queries them. No MongoDB ledger collection.
+
+3. **Discovery index becomes a ClickHouse view.** No separate index — just a view over `s3://web10/*/public_posts/*.parquet` with engagement scores from the ledger.
+
+4. **Search uses ClickHouse inverted index.** No Elasticsearch. Native full-text search on the S3 files.
+
+5. **The double-write problem is still there.** The server-side hook writes to MongoDB AND S3. But it's server-side, not client-side. Reliable, not fire-and-forget.
+
+## Summary
+
+ClickHouse + S3 eliminates the public ledger as a separate data surface. User data projections live in S3 as Parquet files. ClickHouse queries them directly. No MongoDB collection to mirror. No sync problem.
+
+But personal data stays in MongoDB. CRUD, atomicity, access control — S3 Parquet can't replace that. The hybrid is the answer: MongoDB for personal, S3 + ClickHouse for public. One server-side hook bridges them.

--- a/knowledge/knowledge-base/web10-v3/archive/per-record-visibility.md
+++ b/knowledge/knowledge-base/web10-v3/archive/per-record-visibility.md
@@ -1,0 +1,267 @@
+# Per-Record Visibility: Groups, Tokens, and Discovery
+
+## The Current Problem
+
+Visibility is per-**collection**, not per-record. `public_posts` has `whitelist: [".*"]` — anyone can read everything in it. `private_posts` has `whitelist: []` — only the owner. A post is either public or private. No middle ground.
+
+There's no way to post to a group. No "followers only." No "people with this token." The collection IS the permission.
+
+## The Question
+
+Should groups be separate collections (`group-a-posts`)? That's the old model. It's what created the double-write problem. Each group needs its own collection, its own term record, its own discovery index. N groups = N collections. It doesn't scale.
+
+**The answer: per-record permissions.** Every post carries its own visibility. ClickHouse filters at query time.
+
+## How It Works
+
+Each post has a `visibility` column and a `visibility_scope` column:
+
+```sql
+CREATE TABLE posts (
+    post_id String,
+    author_key String,
+    body String,              -- JSON: full post content
+    visibility String,         -- 'public', 'private', 'followers', 'group', 'token'
+    visibility_scope String,   -- the scope: group_id, token_id, etc.
+    tags Array(String),
+    created_at DateTime64(3),
+    updated_at DateTime64(3),
+    deleted UInt8 DEFAULT 0
+) ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY (author_key, post_id);
+
+CREATE TABLE group_members (
+    group_id String,
+    member_key String,
+    joined_at DateTime64(3),
+    deleted UInt8 DEFAULT 0
+) ENGINE = MergeTree()
+ORDER BY (group_id, member_key);
+
+CREATE TABLE follows (
+    follower_key String,
+    following_key String,
+    created_at DateTime64(3),
+    deleted UInt8 DEFAULT 0
+) ENGINE = MergeTree()
+ORDER BY (follower_key, following_key);
+
+CREATE TABLE access_tokens (
+    token_id String,
+    record_id String,
+    granted_to String,
+    expires_at DateTime64(3),
+    revoked UInt8 DEFAULT 0
+) ENGINE = MergeTree()
+ORDER BY (record_id, granted_to);
+```
+
+The dev posts to a group:
+
+```ts
+await createPost({
+  text: "hello team",
+  visibility: "group",
+  visibility_scope: "web10-dev-team",
+  tags: ["internal"]
+});
+```
+
+The dev posts publicly:
+
+```ts
+await createPost({
+  text: "check this out",
+  visibility: "public",
+  tags: ["web10"]
+});
+```
+
+The dev posts to followers only:
+
+```ts
+await createPost({
+  text: "behind the scenes",
+  visibility: "followers"
+});
+```
+
+## The Discover Query
+
+When Alice hits discover, ClickHouse returns only what she's allowed to see:
+
+```sql
+SELECT post_id, author_key, body, tags, created_at
+FROM posts
+WHERE deleted = 0
+  AND created_at > now() - INTERVAL 30 DAY
+  AND (
+    -- Public posts: everyone sees them
+    visibility = 'public'
+
+    OR
+
+    -- Followers-only: Alice sees them if she follows the author
+    (visibility = 'followers'
+     AND author_key IN (
+       SELECT following_key FROM follows
+       WHERE follower_key = 'alice' AND deleted = 0
+     ))
+
+    OR
+
+    -- Group posts: Alice sees them if she's a member
+    (visibility = 'group'
+     AND visibility_scope IN (
+       SELECT group_id FROM group_members
+       WHERE member_key = 'alice' AND deleted = 0
+     ))
+
+    OR
+
+    -- Token posts: Alice sees them if she has a valid token
+    (visibility = 'token'
+     AND EXISTS (
+       SELECT 1 FROM access_tokens
+       WHERE record_id = post_id
+         AND granted_to = 'alice'
+         AND revoked = 0
+         AND (expires_at IS NULL OR expires_at > now())
+     ))
+
+    OR
+
+    -- Private: Alice sees her own posts
+    (visibility = 'private' AND author_key = 'alice')
+  )
+ORDER BY created_at DESC
+LIMIT 50;
+```
+
+One query. All permissions evaluated at query time. No over-fetching. No client-side filtering. Alice sees exactly what she's allowed to see.
+
+## The Feed Query
+
+Alice's friends feed — posts from people she follows, filtered by visibility:
+
+```sql
+SELECT post_id, author_key, body, tags, created_at
+FROM posts
+WHERE deleted = 0
+  AND author_key IN (
+    SELECT following_key FROM follows
+    WHERE follower_key = 'alice' AND deleted = 0
+  )
+  AND (
+    visibility = 'public'
+    OR visibility = 'followers'
+    OR (visibility = 'group'
+        AND visibility_scope IN (
+          SELECT group_id FROM group_members
+          WHERE member_key = 'alice' AND deleted = 0
+        ))
+    OR (visibility = 'private' AND author_key = 'alice')
+  )
+ORDER BY created_at DESC
+LIMIT 50;
+```
+
+## The Profile Query
+
+Bob views Alice's profile. He sees only her public posts and group posts where he's a member:
+
+```sql
+SELECT post_id, body, tags, created_at
+FROM posts
+WHERE deleted = 0
+  AND author_key = 'alice'
+  AND (
+    visibility = 'public'
+    OR (visibility = 'group'
+        AND visibility_scope IN (
+          SELECT group_id FROM group_members
+          WHERE member_key = 'bob' AND deleted = 0
+        ))
+    OR (visibility = 'token'
+        AND EXISTS (
+          SELECT 1 FROM access_tokens
+          WHERE record_id = post_id AND granted_to = 'bob' AND revoked = 0
+        ))
+  )
+ORDER BY created_at DESC;
+```
+
+## Why Per-Record, Not Per-Collection
+
+| | Per-Collection (current) | Per-Record (ClickHouse) |
+|---|---|---|
+| Post to a group | Need a new collection | `visibility: "group"` |
+| Post to followers | Need a new collection | `visibility: "followers"` |
+| Post with a token | Not possible | `visibility: "token"` |
+| Change visibility after posting | Move to another collection | `INSERT` new row with new visibility |
+| Discovery query | Separate index per collection | One query, filters by visibility |
+| N groups | N collections, N term records | One table, N group_members rows |
+
+Per-record permissions are flexible. Per-collection permissions require infrastructure for every new visibility type.
+
+## The Developer Experience
+
+The dev doesn't think about collections. They don't think about term records. They don't think about whitelists. They just set visibility on the post:
+
+```ts
+// Public post
+await createPost({ text: "hello", visibility: "public" });
+
+// Followers only
+await createPost({ text: "behind the scenes", visibility: "followers" });
+
+// Group post
+await createPost({ text: "team update", visibility: "group", visibility_scope: "my-team" });
+
+// Token-gated post
+await createPost({ text: "early access", visibility: "token", visibility_scope: "token-abc-123" });
+
+// Private
+await createPost({ text: "private note", visibility: "private" });
+```
+
+The API writes the row to ClickHouse. The discover query filters by permissions. That's it.
+
+## Groups
+
+Groups are just a membership table. No collections. No term records. No infrastructure:
+
+```sql
+INSERT INTO group_members VALUES ('my-team', 'alice', now(), 0);
+INSERT INTO group_members VALUES ('my-team', 'bob', now(), 0);
+INSERT INTO group_members VALUES ('my-team', 'charlie', now(), 0);
+```
+
+Alice posts to `my-team`. Bob and Charlie see it on discover because they're members. Dave doesn't because he's not. The query handles it.
+
+## The Write Flow
+
+```
+Client → POST /alice/posts → API
+                                  → ClickHouse INSERT (the post, with visibility)
+```
+
+One write. One table. The visibility is on the record. No collection routing. No term record checks. No discovery index mirror.
+
+If the post is to a group, the API also inserts into `group_members` if the group doesn't exist (or it already exists from group creation). The post itself is just one row with `visibility: "group"` and `visibility_scope: "group-id"`.
+
+## What Happens to the Old Model
+
+The collection-based visibility (`public_posts`, `private_posts`) disappears. There's one `posts` table. The `visibility` column replaces the collection. The `visibility_scope` column replaces the need for separate group collections.
+
+The term records (`whitelist`, `blacklist`) disappear for posts. They're replaced by the `visibility` column. The same for reactions, comments, follows — per-record permissions replace per-collection permissions.
+
+The services collection (which stored term records) can be repurposed for app-level permissions (can this app create posts on behalf of the user). But content-level permissions are per-record.
+
+## Summary
+
+Per-record visibility in ClickHouse replaces the collection-based model. Every post carries its own permissions. The discover query filters by what the user can see. Groups are a membership table. Tokens are a grants table. Follows are a follows table. One query handles all of it.
+
+The dev sets `visibility` on the post. The API writes one row. ClickHouse filters at query time. No collections. No term records. No double-write. No discovery index mirror.
+
+This is the WordPress for YouTube vibe. One table for posts. A `visibility` column for permissions. The query does the rest.

--- a/knowledge/knowledge-base/web10-v3/archive/simple-architecture.md
+++ b/knowledge/knowledge-base/web10-v3/archive/simple-architecture.md
@@ -1,0 +1,199 @@
+# Simple Architecture: MongoDB + ClickHouse
+
+## The Goal
+
+WordPress for YouTube vibes. Simple to deploy. Simple to operate. The dev doesn't think about databases — they just write content and it works.
+
+## Two Databases. That's It.
+
+```
+MongoDB      — full documents. The body of everything.
+ClickHouse   — the discovery index. Everything needed for queries, stored locally.
+```
+
+No Postgres. No CDC pipeline. No Kafka. No federated joins at query time.
+
+## What Goes Where
+
+### MongoDB — The Documents
+
+The full, rich payload. Everything the user wrote.
+
+```
+posts:
+  { _id: "post-abc", author: "alice", body: { text: "hello", media: [...] }, created_at: ... }
+reactions:
+  { _id: "react-1", actor: "alice", target: "post-abc", type: "like", created_at: ... }
+comments:
+  { _id: "comment-1", actor: "alice", target: "post-abc", text: "nice", created_at: ... }
+```
+
+MongoDB is the source of truth for the content. When the dev reads a single post, they read from MongoDB by ID. Fast. Simple.
+
+### ClickHouse — The Index
+
+Everything needed to answer discovery queries, stored locally. No joins to external databases at query time.
+
+```sql
+CREATE TABLE discovery_posts (
+    post_id String,
+    author_key String,
+    text String,              -- copy for search (inverted index)
+    tags Array(String),
+    visibility String,         -- permissions baked in
+    created_at DateTime64(3),
+    engagement_score Float64,
+    deleted UInt8 DEFAULT 0
+) ENGINE = MergeTree()
+ORDER BY (created_at, post_id);
+
+CREATE TABLE follows_graph (
+    follower_key String,
+    following_key String,
+    created_at DateTime64(3),
+    deleted UInt8 DEFAULT 0
+) ENGINE = MergeTree()
+ORDER BY (follower_key, following_key);
+
+CREATE TABLE engagement (
+    record_id String,
+    reaction_count UInt32,
+    score Float64,
+    updated_at DateTime64(3)
+) ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY record_id;
+```
+
+The key: **everything ClickHouse needs for a query lives in ClickHouse.** The `visibility` column is in the table. The follows graph is in the table. No Postgres lookup. No MongoDB join. The query is local, fast, vectorized.
+
+## The Developer Experience
+
+The dev makes one call. The API handles the rest.
+
+```ts
+// The dev writes this:
+await createPost({
+  text: "hello world",
+  tags: ["web10"],
+  visibility: "public"
+});
+
+// The API handles this (the dev never sees it):
+// → MongoDB: insert full document
+// → ClickHouse: insert index row + visibility
+```
+
+That's it. The dev doesn't know there are two databases. They don't care. They just CRUD with visibility settings.
+
+## The Read Flow
+
+```
+Discovery query (feed, trending, search):
+  → ClickHouse returns post IDs (local query, fast)
+  → API batch-fetches full documents from MongoDB by ID
+  → Return to client
+
+Single post read:
+  → MongoDB fetch by ID (direct, no ClickHouse needed)
+  → Return to client
+```
+
+ClickHouse never joins to MongoDB at query time. It returns IDs. The API fetches the bodies. This is the pattern that doesn't melt databases.
+
+## Why Not Three Databases?
+
+Adding Postgres for permissions means:
+- A third service to deploy and maintain
+- A CDC pipeline to keep it in sync with ClickHouse
+- Federated joins or application-level orchestration for every query
+- More things that can break
+
+The permissions are simple enough to live in ClickHouse. `visibility` is a column. Revoking is inserting a `deleted=true` row. Follows are a table. These are all append-only writes — ClickHouse handles them perfectly.
+
+ClickHouse is OLAP, not OLTP. But the permissions workload is mostly inserts (create permission) and reads (filter by visibility). The updates are rare and can be handled as append-only (insert a new row, mark the old one deleted). This is the model ClickHouse is built for.
+
+## Why Not Federated Joins?
+
+The `mongodb()` and `postgresql()` table functions are great for ETL and backfills. They're terrible for production queries:
+
+- Every query opens network connections to external databases
+- ClickHouse loses its columnar speed advantage waiting on network I/O
+- Under load, it floods MongoDB and Postgres with parallel connections
+
+The rule: `mongodb()` and `postgresql()` are for data migrations, not API pathways.
+
+## The Write Model
+
+The API writes to both databases synchronously. If either fails, the whole operation fails.
+
+```python
+def create_post(author, body, visibility):
+    post_id = str(uuid4())
+
+    # MongoDB: the full document
+    mongo.db.posts.insert_one({
+        "_id": post_id,
+        "author": author,
+        "body": body,
+        "created_at": now(),
+    })
+
+    # ClickHouse: the index row (with permissions baked in)
+    clickhouse.execute("""
+        INSERT INTO discovery_posts
+        VALUES (%s, %s, %s, %s, %s, %s, 0.0, 0)
+    """, (post_id, author, body['text'], body['tags'], visibility, now()))
+
+    return post_id
+```
+
+Both writes are fast. Both are awaited. No background sync. No CDC. No eventual consistency.
+
+For engagement updates (reactions streaming in), a background queue batches inserts into ClickHouse. This is the one place where async is acceptable — engagement counts can be eventual.
+
+## The Discovery Query
+
+Alice's feed — posts from people she follows, filtered by visibility:
+
+```sql
+SELECT dp.post_id, dp.author_key, dp.text, dp.tags, dp.engagement_score
+FROM discovery_posts dp
+JOIN follows_graph fg ON dp.author_key = fg.following_key
+WHERE fg.follower_key = 'alice'
+  AND dp.deleted = 0
+  AND fg.deleted = 0
+  AND (
+    dp.visibility = 'public'
+    OR dp.visibility = 'followers'
+  )
+ORDER BY dp.created_at DESC
+LIMIT 50;
+```
+
+Everything is local. Everything is fast. No network hops. No external joins. ClickHouse returns 50 post IDs with enough metadata to render the feed. The API fetches the full bodies from MongoDB for any posts that need it.
+
+## The Double-Write Problem
+
+Solved. One copy of the data (MongoDB). One index for discovery (ClickHouse). The server writes both. The client never manages sync. No ledger mirror. No projection layer. No double-write.
+
+The "double-write" is just the API writing to two databases in one call. It's not a problem — it's the architecture. The dev doesn't see it.
+
+## Deployment
+
+Two services in docker-compose:
+
+```yaml
+services:
+  mongo:       # or ferretdb + postgres-documentdb
+  clickhouse:  # single binary, no dependencies
+  api:         # orchestrates both
+  minio:       # media blobs
+```
+
+Four services. That's the whole stack. No Kafka. No Debezium. No Postgres. No CDC pipeline.
+
+## Summary
+
+MongoDB stores the documents. ClickHouse stores the index with permissions baked in. The API orchestrates writes. The dev just calls `createPost()` and doesn't think about it.
+
+Two databases. No CDC. No federated joins. No Kafka. Simple to deploy. Simple to operate. Fast queries. The WordPress for YouTube vibe.

--- a/knowledge/knowledge-base/web10-v3/archive/three-tier-architecture.md
+++ b/knowledge/knowledge-base/web10-v3/archive/three-tier-architecture.md
@@ -1,0 +1,286 @@
+# Three-Tier Architecture: MongoDB Storage + Postgres Permissions + ClickHouse Analytics
+
+## The Problem
+
+The previous doc proposed ClickHouse for both permissions and analytics. ClickHouse is OLAP — great for aggregations, bad for single-record CRUD. The permissions layer needs fast point writes (create permission, revoke token, update visibility) and fast point lookups (does user X have access to record Y?). That's OLTP.
+
+Postgres and YugabyteDB are OLTP. They're fast for point writes and lookups. They can't query MongoDB directly like ClickHouse can. So the architecture needs three tiers.
+
+## The Three Tiers
+
+```
+MongoDB (dumb storage):     Raw data. IDs and BSON. No access control.
+Postgres/Yugabyte (OLTP):   Permissions. Who can see what. Fast point reads/writes.
+ClickHouse (OLAP):          Analytics. Discovery, trending, engagement, search.
+```
+
+Each tier does what it's built for. No compromise.
+
+## The MongoDB Layer — Dumb Storage
+
+Same as before. One flat collection. Just IDs and raw data.
+
+```
+web10_data/
+  posts:
+    { _id: "post-abc", author: "alice", body: { text: "...", tags: [...] }, created_at: ... }
+  reactions:
+    { _id: "react-1", actor: "alice", target: "post-def", type: "like", created_at: ... }
+  comments:
+    { _id: "comment-1", actor: "alice", target: "post-def", text: "...", created_at: ... }
+```
+
+## The Postgres Layer — Permissions (OLTP)
+
+Fast point reads and writes. Every record has a permissions row. The API checks Postgres before serving any data.
+
+```sql
+-- Permissions: who can see what
+CREATE TABLE record_permissions (
+    record_id TEXT PRIMARY KEY,
+    record_type TEXT NOT NULL,  -- 'post', 'reaction', 'comment'
+    author_key TEXT NOT NULL,
+    visibility TEXT NOT NULL,   -- 'public', 'followers', 'private', 'token'
+    terms JSONB,                -- access conditions
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    deleted BOOLEAN DEFAULT FALSE
+);
+
+-- Index for permission checks
+CREATE INDEX idx_permissions_author ON record_permissions(author_key);
+CREATE INDEX idx_permissions_visibility ON record_permissions(visibility);
+
+-- Follows graph
+CREATE TABLE follows (
+    follower_key TEXT NOT NULL,
+    following_key TEXT NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    deleted BOOLEAN DEFAULT FALSE,
+    PRIMARY KEY (follower_key, following_key)
+);
+
+CREATE INDEX idx_follows_following ON follows(following_key);
+
+-- Access tokens
+CREATE TABLE access_tokens (
+    token_id TEXT PRIMARY KEY,
+    record_id TEXT NOT NULL,
+    granted_to TEXT NOT NULL,
+    expires_at TIMESTAMPTZ,
+    revoked BOOLEAN DEFAULT FALSE
+);
+
+CREATE INDEX idx_tokens_record ON access_tokens(record_id);
+CREATE INDEX idx_tokens_granted ON access_tokens(granted_to);
+```
+
+The API checks permissions before serving data:
+
+```python
+def can_user_see(user_key, record_id):
+    perm = db.execute("""
+        SELECT visibility FROM record_permissions WHERE record_id = $1
+    """, record_id).fetchone()
+
+    if perm.visibility == 'public':
+        return True
+    if perm.visibility == 'followers':
+        return db.execute("""
+            SELECT 1 FROM follows WHERE follower_key = $1 AND following_key = $2
+        """, user_key, perm.author_key).fetchone() is not None
+    if perm.visibility == 'token':
+        return db.execute("""
+            SELECT 1 FROM access_tokens
+            WHERE record_id = $1 AND granted_to = $2 AND revoked = FALSE
+        """, record_id, user_key).fetchone() is not None
+    return False
+```
+
+Sub-millisecond. Indexed. ACID. This is what Postgres does.
+
+## The ClickHouse Layer — Analytics (OLAP)
+
+Discovery, trending, engagement, search. Cross-user aggregation. This is where ClickHouse shines.
+
+```sql
+-- Post index for discovery
+CREATE TABLE discovery_posts (
+    post_id String,
+    author_key String,
+    text String,
+    tags Array(String),
+    visibility String,
+    created_at DateTime64(3),
+    engagement_score Float64,
+    deleted UInt8 DEFAULT 0
+) ENGINE = MergeTree()
+ORDER BY (created_at, post_id);
+
+-- Engagement aggregation
+CREATE TABLE engagement (
+    record_id String,
+    reaction_count UInt32,
+    comment_count UInt32,
+    score Float64,
+    updated_at DateTime64(3)
+) ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY record_id;
+
+-- Follows graph for feed computation
+CREATE TABLE follows_graph (
+    follower_key String,
+    following_key String,
+    created_at DateTime64(3),
+    deleted UInt8 DEFAULT 0
+) ENGINE = MergeTree()
+ORDER BY (follower_key, following_key);
+```
+
+ClickHouse queries for discovery:
+
+```sql
+-- Alice's feed: posts from people she follows
+SELECT dp.post_id, dp.text, dp.tags, dp.engagement_score
+FROM discovery_posts dp
+JOIN follows_graph fg ON dp.author_key = fg.following_key
+WHERE fg.follower_key = 'alice'
+  AND dp.deleted = 0
+  AND dp.visibility IN ('public', 'followers')
+ORDER BY dp.created_at DESC
+LIMIT 50;
+```
+
+The ClickHouse query returns candidate records. The API checks Postgres for permissions before serving each one.
+
+## The Write Flow
+
+One API call, three writes:
+
+```
+Client → POST /alice/posts → API
+                                  → MongoDB INSERT (raw data)
+                                  → Postgres INSERT (permissions)
+                                  → ClickHouse INSERT (discovery index)
+```
+
+MongoDB: the data. Postgres: who can see it. ClickHouse: discovery and analytics.
+
+```python
+def create_post(author, body, visibility):
+    post_id = str(uuid4())
+
+    # MongoDB: the data
+    mongo.db.posts.insert_one({
+        "_id": post_id,
+        "author": author,
+        "body": body,
+        "created_at": now(),
+    })
+
+    # Postgres: the permissions
+    postgres.execute("""
+        INSERT INTO record_permissions (record_id, record_type, author_key, visibility, terms)
+        VALUES ($1, 'post', $2, $3, $4)
+    """, post_id, author, visibility, json.dumps(terms))
+
+    # ClickHouse: the discovery index
+    clickhouse.execute("""
+        INSERT INTO discovery_posts VALUES (%s, %s, %s, %s, %s, %s, 0.0, 0)
+    """, (post_id, author, body['text'], body['tags'], visibility, now()))
+
+    return post_id
+```
+
+## The Read Flow
+
+Two paths:
+
+```
+CRUD read (single user):     API → Postgres (check permission) → MongoDB (get data)
+Discovery read (cross-user): API → ClickHouse (get candidates) → Postgres (check each) → MongoDB (get data)
+```
+
+For a single post: `GET /alice/posts/abc` → Postgres check → MongoDB fetch. Fast. No ClickHouse needed.
+
+For a feed: `GET /alice/feed` → ClickHouse returns 50 candidates → Postgres checks each → MongoDB fetches the allowed ones. The ClickHouse query is fast. The Postgres checks are fast (indexed). The MongoDB fetches are fast (by ID).
+
+## Why Not ClickHouse for Permissions?
+
+ClickHouse is OLAP. It's built for:
+- High-throughput batch inserts
+- Complex aggregations over millions of rows
+- Columnar compression and vectorized execution
+
+It's NOT built for:
+- Single-row inserts (high latency, no WAL)
+- Single-row updates (requires mutation, background process)
+- Single-row deletes (requires mutation, background process)
+- Point lookups (no secondary indexes, scans partitions)
+
+The permissions layer needs all four of those. Postgres does them natively. ClickHouse doesn't.
+
+## Why Not Postgres for Analytics?
+
+Postgres can do cross-user queries. It can join tables and aggregate. But at scale:
+
+- Postgres scans rows. ClickHouse scans columns. For "top 50 posts by engagement," Postgres reads every column of every row. ClickHouse reads only the columns it needs.
+- Postgres has no inverted index for full-text search. ClickHouse does.
+- Postgres materialized views refresh manually. ClickHouse materialized views update automatically on insert.
+- Postgres struggles with billions of rows. ClickHouse is built for it.
+
+## Why Not ClickHouse mongodb() for Permissions?
+
+The `mongodb()` table function lets ClickHouse query MongoDB directly. But it's still OLAP — it reads MongoDB collections in batch, not for point lookups. A permission check like "does user X have access to record Y?" becomes a full collection scan in ClickHouse. Postgres does it with an index in microseconds.
+
+## The Trade-offs
+
+| Operation | MongoDB | Postgres | ClickHouse |
+|---|---|---|---|
+| Single-row INSERT | Fast | Fast | Slow (batch only) |
+| Single-row UPDATE | Fast | Fast | Slow (mutation) |
+| Single-row DELETE | Fast | Fast | Slow (mutation) |
+| Point lookup (by ID) | Fast (indexed) | Fast (indexed) | Slow (partition scan) |
+| Cross-user aggregation | Slow (MapReduce) | OK (joins) | Fast (vectorized) |
+| Full-text search | Weak | OK (tsvector) | Fast (inverted index) |
+| Materialized views | No | Manual | Automatic |
+| Time-series queries | Weak | OK | Fast (partitioning, TTL) |
+
+## The Verdict
+
+**MongoDB for storage.** Dumb. Flat. Just IDs and BSON. No access control. No complex queries. The dev writes to it like a key-value store.
+
+**Postgres for permissions.** Fast point reads and writes. Indexed lookups. ACID. The API checks Postgres before serving any data. "Does user X have access to record Y?" is a single indexed query.
+
+**ClickHouse for analytics.** Discovery, trending, engagement, search. Cross-user aggregation. Inverted index for search. Materialized views for pre-computed scores. The API queries ClickHouse for candidate records, then checks Postgres for permissions.
+
+Three tiers. Each does what it's built for. No compromise.
+
+## The Double-Write Problem
+
+The previous docs identified the double-write as the core problem: personal data in one place, public data in another, client manages sync. This three-tier model solves it differently:
+
+- There's one copy of the data (MongoDB)
+- Permissions are in Postgres (fast, reliable, ACID)
+- Discovery is in ClickHouse (fast, analytical)
+- The server writes all three. The client never manages sync.
+
+The server-side hook is the bridge. One API call, three writes. All awaited. All reliable. The client makes one call. The server handles the rest.
+
+## Migration Path
+
+1. Flatten MongoDB: migrate from per-user databases to a flat collection
+2. Deploy Postgres with permissions tables
+3. Backfill permissions from existing terms records and visibility settings
+4. Deploy ClickHouse with discovery tables
+5. Backfill discovery from existing posts
+6. Migrate CRUD reads: API checks Postgres, reads MongoDB
+7. Migrate discovery reads: API queries ClickHouse, checks Postgres, reads MongoDB
+8. Deprecate the discovery index and public ledger
+
+## Summary
+
+MongoDB stores the data. Postgres controls access. ClickHouse powers discovery. Three tiers, each doing what it's built for. The API orchestrates them. The client never thinks about sync.
+
+The double-write problem disappears because there's one copy of the data. The permissions problem is solved by Postgres — fast, indexed, ACID. The discovery problem is solved by ClickHouse — fast aggregation, search, analytics.
+
+One storage. One permissions layer. One analytics engine. The API joins them.

--- a/knowledge/knowledge-base/web10-v3/discovery-is-crud.md
+++ b/knowledge/knowledge-base/web10-v3/discovery-is-crud.md
@@ -1,0 +1,161 @@
+# Discovery Is CRUD: No Separate Endpoints
+
+## The Problem
+
+`/public` and `/discover` are separate endpoints from CRUD. The discovery index is a separate data surface. The public ledger is a separate data surface. The client writes to CRUD and mirrors to the ledger. The server indexes to the discovery table. Three surfaces. Sync problems. Double-write.
+
+The discovery index exists because MongoDB can't query across users. ClickHouse can. The discovery index is a MongoDB workaround, not a platform feature.
+
+## The Solution
+
+Discovery is a CRUD parameter. One endpoint. One data surface. No mirrors. No sync.
+
+```
+GET /alice/posts?discover=true    → posts Alice can see (public + followers + groups)
+GET /alice/posts?discover=false   → only Alice's own posts
+GET /alice/posts                  → default: Alice's own posts (private)
+```
+
+The `discover` flag tells the API to apply cross-user visibility filtering. Without it, the API returns only the authenticated user's own data. With it, the API returns data from other users where the authenticated user has permission.
+
+## How It Works
+
+The CRUD endpoint handles everything. ClickHouse filters by permissions at query time:
+
+```sql
+-- discover=false: only the user's own posts
+SELECT * FROM posts
+WHERE author_key = 'alice' AND deleted = 0
+ORDER BY created_at DESC;
+
+-- discover=true: posts Alice can see (cross-user, permission-filtered)
+SELECT * FROM posts
+WHERE deleted = 0
+  AND (
+    -- Public posts from anyone
+    visibility = 'public'
+    AND collection_visibility = 'public'
+
+    OR
+
+    -- Followers-only: Alice sees them if she follows the author
+    (visibility = 'followers'
+     AND author_key IN (
+       SELECT following_key FROM follows
+       WHERE follower_key = 'alice' AND deleted = 0
+     ))
+
+    OR
+
+    -- Group posts: Alice sees them if she's a member
+    (visibility = 'group'
+     AND visibility_scope IN (
+       SELECT group_id FROM group_members
+       WHERE member_key = 'alice' AND deleted = 0
+     ))
+
+    OR
+
+    -- Alice's own posts (always visible)
+    author_key = 'alice'
+  )
+ORDER BY created_at DESC
+LIMIT 50;
+```
+
+## The Post-Level `discoverable` Flag
+
+Every post has a `discoverable` flag. The author controls it:
+
+```ts
+// Public and discoverable (default for public posts)
+await createPost({ text: "hello world", visibility: "public", discoverable: true });
+
+// Public but not discoverable (visible by direct link, not in feeds)
+await createPost({ text: "private link post", visibility: "public", discoverable: false });
+
+// Followers-only (discoverable within followers)
+await createPost({ text: "behind the scenes", visibility: "followers", discoverable: true });
+```
+
+The `discoverable` flag is per-record. The author sets it. The API respects it. If `discoverable: false`, the post is excluded from `discover=true` queries but still visible to the author and anyone with a direct link.
+
+```sql
+-- discover=true also filters by discoverable flag
+SELECT * FROM posts
+WHERE deleted = 0
+  AND discoverable = 1
+  AND (visibility checks...)
+```
+
+## What Disappears
+
+- `/discover` endpoint — replaced by `?discover=true` on CRUD
+- `/public` endpoint — replaced by `?discover=true&visibility=public`
+- Discovery index table — replaced by ClickHouse filtering on the posts table
+- Public ledger — replaced by ClickHouse aggregation on the reactions table
+- Server-side indexing hooks — replaced by a single insert into the posts table
+- Client-side ledger mirrors — replaced by the API writing once
+
+## The API Surface
+
+```
+# CRUD endpoints (everything)
+GET  /{user}/posts                    → user's own posts
+GET  /{user}/posts?discover=true      → discoverable posts the user can see
+GET  /{user}/posts?discover=true&sort=trending  → trending posts
+GET  /{user}/posts?discover=true&tags=web10     → posts with tag
+GET  /{user}/posts/{id}              → single post (by ID, if permitted)
+
+POST /{user}/posts                   → create a post
+PATCH /{user}/posts/{id}             → update a post
+DELETE /{user}/posts/{id}            → delete a post (tombstone)
+
+# Same pattern for reactions, comments, follows
+GET  /{user}/reactions?discover=true → reactions the user can see
+GET  /{user}/comments?discover=true  → comments the user can see
+```
+
+One endpoint per resource. The `discover` flag controls cross-user visibility. The `sort` and `tags` parameters control ordering and filtering. ClickHouse handles the rest.
+
+## Why This Is Better
+
+**1. No double-write.** One insert. One table. No discovery index mirror. No public ledger mirror. The API writes once. ClickHouse queries it.
+
+**2. No sync problem.** The data is in one place. ClickHouse filters at query time. No stale projections. No reconciliation. No tombstone cleanup for the index.
+
+**3. Simpler API.** One endpoint per resource. The `discover` flag is a boolean. The client doesn't think about which endpoint to hit. It just sets the flag.
+
+**4. Simpler stack.** No discovery index table. No public ledger table. No server-side hooks. No client-side mirrors. One table for posts. One table for reactions. One table for comments.
+
+**5. Real-time.** No delay between write and discovery. The post is discoverable immediately because it's in the same table ClickHouse queries.
+
+**6. The author controls it.** The `discoverable` flag is per-record. The author decides. The API respects it. No platform override. No shadow-banning. No algorithmic suppression.
+
+## The Developer Experience
+
+```ts
+// Read my posts
+const myPosts = await readPosts({ username: 'alice' });
+
+// Read discoverable posts (feed)
+const feed = await readPosts({ username: 'alice', discover: true });
+
+// Read trending posts
+const trending = await readPosts({ discover: true, sort: 'trending' });
+
+// Read posts with a tag
+const tagged = await readPosts({ discover: true, tags: ['web10'] });
+
+// Create a discoverable post
+await createPost({ text: "hello", visibility: "public", discoverable: true });
+
+// Create a non-discoverable post (visible by link only)
+await createPost({ text: "secret", visibility: "public", discoverable: false });
+```
+
+The dev doesn't think about endpoints. They don't think about the discovery index. They don't think about the ledger. They just set `discover: true` and it works.
+
+## Summary
+
+`/discover` and `/public` disappear. Discovery is a CRUD parameter. One endpoint. One table. No mirrors. No sync. The `discover` flag controls cross-user visibility. The `discoverable` flag controls whether the author wants to be found. ClickHouse filters at query time. The API writes once. The client sets a boolean. That's it.

--- a/knowledge/knowledge-base/web10-v3/groups-platform-primitive.md
+++ b/knowledge/knowledge-base/web10-v3/groups-platform-primitive.md
@@ -1,0 +1,176 @@
+# Groups: A Platform Primitive
+
+## The Idea
+
+Groups are not just a visibility type. They are a fundamental platform feature. Users create groups, add members, manage admins, and post to them. Groups are the building block for communities, teams, and circles.
+
+Groups are a CRUD endpoint. The platform manages them. The user controls them.
+
+## The Schema
+
+```sql
+CREATE TABLE groups (
+    group_id String,
+    name String,
+    description String,
+    admin_key String,          -- the creator/admin
+    created_at DateTime64(3),
+    updated_at DateTime64(3),
+    deleted UInt8 DEFAULT 0
+) ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY group_id;
+
+CREATE TABLE group_members (
+    group_id String,
+    member_key String,
+    role String,               -- 'admin', 'member'
+    joined_at DateTime64(3),
+    updated_at DateTime64(3),
+    deleted UInt8 DEFAULT 0
+) ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY (group_id, member_key);
+```
+
+## The API
+
+```
+# Group CRUD
+POST   /groups                          → create a group
+GET    /groups/{id}                     → get a group
+PATCH  /groups/{id}                     → update a group (name, description)
+DELETE /groups/{id}                     → delete a group (tombstone)
+
+# Membership
+POST   /groups/{id}/members             → add a member
+GET    /groups/{id}/members             → list members
+PATCH  /groups/{id}/members/{user}      → update role (promote to admin)
+DELETE /groups/{id}/members/{user}      → remove a member
+
+# Posts to a group
+POST   /{user}/posts?group={group_id}   → create a post visible to group members
+GET    /{user}/posts?group={group_id}   → read posts in this group
+```
+
+## Creating a Group
+
+```ts
+const group = await createGroup({
+  name: "Web10 Dev Team",
+  description: "Internal team discussions"
+});
+// Returns: { group_id: "grp-abc", name: "Web10 Dev Team", admin_key: "alice" }
+```
+
+The creator is the admin. The admin can add members and promote other admins.
+
+## Adding Members
+
+```ts
+await addMember({
+  group_id: "grp-abc",
+  member_key: "bob",
+  role: "member"
+});
+
+await addMember({
+  group_id: "grp-abc",
+  member_key: "charlie",
+  role: "admin"  // promote to admin
+});
+```
+
+The member receives a notification. They can see posts in the group on discover. They can post to the group.
+
+## Posting to a Group
+
+```ts
+await createPost({
+  text: "team update: v3 architecture locked",
+  visibility: "group",
+  visibility_scope: "grp-abc",
+  discoverable: true  // discoverable within the group
+});
+```
+
+The post is visible to all group members on `discover=true`. It is not visible to non-members. The `discoverable` flag controls whether it appears in the group feed or only by direct link.
+
+## Group Discovery Query
+
+When Alice hits discover, group posts are included if she's a member:
+
+```sql
+SELECT * FROM posts
+WHERE deleted = 0
+  AND (
+    visibility = 'public'
+    OR (visibility = 'followers' AND author_key IN (SELECT following_key FROM follows WHERE follower_key = 'alice'))
+    OR (visibility = 'group'
+        AND visibility_scope IN (
+          SELECT group_id FROM group_members
+          WHERE member_key = 'alice' AND deleted = 0
+        ))
+    OR author_key = 'alice'
+  );
+```
+
+## Group Permissions
+
+| Action | Who Can Do It |
+|---|---|
+| Create group | Any user |
+| Add member | Admin or member (depending on group settings) |
+| Remove member | Admin only |
+| Promote to admin | Admin only |
+| Delete group | Admin only |
+| Post to group | Any member |
+| See group posts | Any member (if discoverable) |
+
+## Group Settings
+
+Groups can have settings that control membership:
+
+```json
+{
+  "group_id": "grp-abc",
+  "name": "Web10 Dev Team",
+  "join_policy": "invite-only",  // "open", "invite-only", "approval"
+  "post_policy": "members-only", // "members-only", "admins-only"
+  "discoverable": true           // group posts appear in member feeds
+}
+```
+
+- `join_policy: "open"` — anyone can join
+- `join_policy: "invite-only"` — only admins can add members
+- `join_policy: "approval"` — members request to join, admins approve
+
+- `post_policy: "members-only"` — any member can post
+- `post_policy: "admins-only"` — only admins can post
+
+## Why Groups Are Fundamental
+
+Groups are not a feature. They are the building block for:
+
+- **Teams** — internal collaboration, project discussions
+- **Communities** — interest-based groups, hobby circles
+- **Circles** — close friends, family, trusted contacts
+- **Audiences** — newsletter subscribers, beta testers
+- **Moderation** — admin-controlled spaces with rules
+
+Groups replace the need for separate collection types. Instead of `public_posts`, `private_posts`, `group-posts`, the user creates groups and posts to them. The visibility is per-group. The membership is managed by the platform.
+
+## The Privacy Panel Integration
+
+The privacy panel shows groups the user is a member of:
+
+```
+Groups:
+  Web10 Dev Team (admin) → 5 members, 120 posts
+  Personal Circle (member) → 3 members, 45 posts
+  Public Community (member) → 1200 members, 5000 posts
+```
+
+The user can leave groups, manage membership, and control which groups their posts appear in.
+
+## Summary
+
+Groups are a platform primitive. CRUD endpoint. Membership management. Admin controls. Post visibility. The building block for communities, teams, and circles. No separate collections. No term records. One table for groups. One table for membership. The API handles the rest.

--- a/knowledge/knowledge-base/web10-v3/layered-permissions.md
+++ b/knowledge/knowledge-base/web10-v3/layered-permissions.md
@@ -1,0 +1,158 @@
+# Layered Permissions: Collection Ceiling, Post-Level Narrowing
+
+## The Model
+
+The collection is the ceiling. The post can only narrow, never widen. The strictest permission wins.
+
+This is the Unix file permission model: directory permission is the ceiling, file permission can only narrow. The user's privacy panel manages collections. Individual posts can only be more private.
+
+## How It Works
+
+Each collection has a default visibility set by the user's privacy panel. Each post inherits that default. The post can override to be stricter — never less strict.
+
+```
+Collection: public_posts (whitelist: ".*") → anyone can read
+Post-level: visibility = "followers" → only followers see it
+Result: followers-only (stricter wins)
+
+Collection: private_posts (whitelist: []) → owner only
+Post-level: visibility = "public" → IGNORED
+Result: owner-only (collection ceiling)
+
+Collection: group-posts (whitelist: group members)
+Post-level: visibility = "followers" → only followers who are also members
+Result: intersection (stricter wins)
+```
+
+## The ClickHouse Schema
+
+```sql
+CREATE TABLE posts (
+    post_id String,
+    author_key String,
+    collection_name String,  -- 'public_posts', 'private_posts', 'group-posts'
+    body String,             -- JSON: full post content
+    visibility String,       -- post-level: 'public', 'private', 'followers', 'group'
+    visibility_scope String, -- group_id, if group
+    tags Array(String),
+    created_at DateTime64(3),
+    updated_at DateTime64(3),
+    deleted UInt8 DEFAULT 0
+) ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY (author_key, post_id);
+
+-- Collection-level permissions (the ceiling)
+CREATE TABLE collection_permissions (
+    author_key String,
+    collection_name String,
+    visibility String,       -- 'public', 'private', 'followers', 'group'
+    visibility_scope String, -- group_id, if group
+    whitelist String,        -- JSON: who can access this collection
+    blacklist String,        -- JSON: who is blocked
+    updated_at DateTime64(3),
+    deleted UInt8 DEFAULT 0
+) ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY (author_key, collection_name);
+```
+
+When a post is created, it inherits the collection's visibility. The dev can narrow it:
+
+```ts
+// Inherits collection default (public_posts → public)
+await createPost({ text: "hello world", collection: "public_posts" });
+
+// Narrows to followers-only (collection allows it, post is stricter)
+await createPost({ text: "behind the scenes", collection: "public_posts", visibility: "followers" });
+
+// Tries to widen (private_posts → public) — REJECTED
+await createPost({ text: "going viral", collection: "private_posts", visibility: "public" });
+// API rejects: post visibility "public" exceeds collection ceiling "private"
+```
+
+## The Privacy Panel
+
+The user's UI shows collections and their default permissions. This is the primary way to manage data privacy:
+
+```
+alice/
+  public_posts/    → visibility: public (whitelist: ".*")
+  private_posts/   → visibility: private (whitelist: [])
+  group-posts/     → visibility: group (group: "web10-dev")
+  followers-posts/ → visibility: followers
+```
+
+The user manages these at the collection level. 99% of posts inherit the collection default. The per-record `visibility` column handles the 1% exception.
+
+Posts that deviate from the collection default are shown in the data viewer as exceptions. The user can see them, understand them, and restore them to the collection default.
+
+## The Query: Both Checks Must Pass
+
+Every discover query enforces both layers:
+
+```sql
+SELECT p.post_id, p.author_key, p.body, p.tags, p.created_at
+FROM posts p
+JOIN collection_permissions cp
+  ON p.author_key = cp.author_key AND p.collection_name = cp.collection_name
+WHERE p.deleted = 0
+  AND cp.deleted = 0
+  -- Collection-level check (the ceiling)
+  AND collection_visible_to(cp, 'alice')
+  -- Post-level check (stricter, can only narrow)
+  AND post_visible_to(p, 'alice')
+ORDER BY p.created_at DESC
+LIMIT 50;
+```
+
+The `collection_visible_to()` function checks if the collection allows the user. The `post_visible_to()` function checks if the post allows the user. Both must return true. The strictest permission is always enforced.
+
+## The Validation: API Enforces the Ceiling
+
+When a post is created, the API checks that the post-level visibility doesn't exceed the collection ceiling:
+
+```python
+def create_post(author, collection, body, visibility=None):
+    # Get the collection's default visibility
+    collection_perm = get_collection_permission(author, collection)
+
+    # Use collection default if no post-level visibility specified
+    effective_visibility = visibility or collection_perm.visibility
+
+    # Enforce the ceiling: post can only be stricter
+    if is_wider(effective_visibility, collection_perm.visibility):
+        raise PermissionError(
+            f"Post visibility '{effective_visibility}' exceeds "
+            f"collection ceiling '{collection_perm.visibility}'"
+        )
+
+    # Insert the post with the effective visibility
+    clickhouse.execute("""
+        INSERT INTO posts VALUES (%s, %s, %s, %s, %s, %s, %s, now(), now(), 0)
+    """, (str(uuid4()), author, collection, json.dumps(body),
+          effective_visibility, '', body.get('tags', []), ))
+```
+
+The `is_wider()` function compares visibility levels:
+
+```
+public > followers > group > private
+```
+
+A post in a `followers` collection can be `followers` or `private`. It cannot be `public`.
+
+## The Sovereignty Story
+
+The user's privacy panel is the source of truth for their data. Collections set the default. Posts can only narrow. The user manages the 99% at collection level. The per-record column handles the 1% exception.
+
+This is the WordPress for YouTube vibe. The user manages privacy like file permissions. The directory is the ceiling. The file can only be more private. The strictest permission wins.
+
+The data viewer shows posts that deviate from the collection default. The user can understand them and restore them. The system is transparent. The user is in control.
+
+## Summary
+
+- **Collection is the ceiling.** The user's privacy panel manages collections.
+- **Post can only narrow.** Individual posts can be more private, never less.
+- **Strictest wins.** Both collection and post checks must pass.
+- **API enforces it.** The API rejects posts that exceed the collection ceiling.
+- **99% collection, 1% post.** Most posts inherit the default. Exceptions are rare.
+- **Transparent.** The data viewer shows deviations. The user understands and controls.

--- a/knowledge/knowledge-base/web10-v3/why-not-just-clickhouse.md
+++ b/knowledge/knowledge-base/web10-v3/why-not-just-clickhouse.md
@@ -1,0 +1,146 @@
+# Why Not Just ClickHouse + MinIO?
+
+## The Question
+
+If ClickHouse handles discovery, permissions, and analytics — and MinIO handles media blobs — what does MongoDB actually give us? Can we just delete it from the stack?
+
+```
+Current:  MongoDB + ClickHouse + MinIO + API
+Idea:     ClickHouse + MinIO + API
+```
+
+## What ClickHouse Would Need to Do
+
+Everything. Posts, reactions, comments, follows, permissions, engagement. All stored in ClickHouse tables. Deletes are tombstones. Updates are new rows with higher version numbers.
+
+```sql
+CREATE TABLE posts (
+    post_id String,
+    author_key String,
+    body String,          -- JSON: the full post content
+    visibility String,
+    created_at DateTime64(3),
+    updated_at DateTime64(3),
+    deleted UInt8 DEFAULT 0
+) ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY (author_key, post_id);
+
+CREATE TABLE reactions (
+    reaction_id String,
+    actor_key String,
+    target_post_id String,
+    type String,
+    created_at DateTime64(3),
+    deleted UInt8 DEFAULT 0
+) ENGINE = MergeTree()
+ORDER BY (target_post_id, created_at);
+```
+
+MinIO stores the media blobs. ClickHouse stores the metadata. That's it.
+
+## Where It Works
+
+**Append-only writes.** Posts, reactions, comments, follows — you create them, you rarely change them. ClickHouse is built for this. Millions of inserts per second. Perfect.
+
+**Tombstone deletes.** You don't delete a row. You insert a new row with `deleted = 1`. ClickHouse handles this naturally. The data stays on disk until TTL cleans it up. Fine.
+
+**Updates.** You don't update a row. You insert a new row with a higher `updated_at`. `ReplacingMergeTree` keeps the latest version. Editing a post is an insert, not an update. Works.
+
+**Discovery, trending, search.** ClickHouse is built for this. Local queries, vectorized execution, inverted index. No MongoDB needed.
+
+**Permissions.** `visibility` is a column. Filter at query time. No Postgres needed. No separate permissions layer needed.
+
+**Media.** MinIO stores blobs. ClickHouse stores metadata (URL, size, type). ClickHouse can query MinIO directly for metadata if needed. Works.
+
+## Where It Hurts
+
+**Schema evolution.** ClickHouse has a schema. Adding a field means `ALTER TABLE posts ADD COLUMN new_field String`. At scale, ALTER TABLE is a heavy operation — it rewrites data parts. MongoDB is schemaless — every document can have different fields. For a social network where features change weekly, schema rigidity is real pain.
+
+**Mitigation:** store the body as JSON. ClickHouse has `JSON` type and `extractJSONString()` functions. The schema is wide (post_id, author, body JSON, visibility, created_at). New fields go into the JSON blob. No ALTER TABLE needed.
+
+**Point lookups.** `GET /alice/posts/abc` — fetching a single post by ID. ClickHouse has no secondary index on `post_id`. It scans partitions. For a hot path (every page load fetches posts), this is slow.
+
+**Mitigation:** API-level caching. Redis cache for hot posts. Or a small local ClickHouse table with a primary key on `post_id` that's kept in memory. Or accept that ClickHouse point lookups are ~10ms, not ~1ms, and that's fine for a feed.
+
+**Atomic operations.** MongoDB's `find_one_and_update` is atomic. "Increment reaction count if the user hasn't reacted yet." ClickHouse has no atomic counters. You insert a reaction row. The count is computed at query time (`COUNT(*) WHERE target_post_id = 'X'`).
+
+**Mitigation:** this is actually fine. The count is a materialized view in ClickHouse. It updates on insert. No atomic counter needed. The reaction is an insert. The count is an aggregation. This is the OLAP model.
+
+**Write latency for single rows.** ClickHouse is optimized for batch inserts. A single `INSERT INTO posts VALUES (...)` works but it's slower than MongoDB's in-memory write. At scale, you batch inserts anyway.
+
+**Mitigation:** batch inserts in the API. Accumulate writes, flush every 100ms or 100 records. Accept eventual consistency for the index. The MongoDB write is synchronous (source of truth). The ClickHouse write is async (index). If ClickHouse is behind by 100ms, the feed is 100ms stale. Acceptable.
+
+**Complex nested data.** A post can have rich media, nested comments, threaded replies, reactions with metadata. MongoDB stores this as nested BSON naturally. ClickHouse needs flat tables or JSON columns.
+
+**Mitigation:** JSON columns. ClickHouse's JSON type handles nested data. You query it with `extractJSONString()`. It's not as elegant as MongoDB's dot notation, but it works.
+
+## The Honest Comparison
+
+| Concern | MongoDB | ClickHouse Only |
+|---|---|---|
+| Append-only writes | Fast | **Faster** (1M rows/sec) |
+| Single-row updates | **Fast** (atomic) | Slow (insert + merge) |
+| Point lookups | **Fast** (indexed) | Slow (partition scan) |
+| Schema flexibility | **Schemaless** | Rigid (JSON workaround) |
+| Cross-user queries | Slow (MapReduce) | **Fast** (vectorized) |
+| Full-text search | Weak | **Fast** (inverted index) |
+| Aggregations | Slow | **Fast** (materialized views) |
+| Operational complexity | One service | One service |
+| Storage cost | Higher | **Lower** (columnar) |
+
+## The Verdict
+
+**For the public layer: ClickHouse only.** No MongoDB needed. Discovery, trending, engagement, search — ClickHouse does it all faster and cheaper.
+
+**For personal data: it depends.**
+
+If personal data is mostly append-only (posts, reactions, comments) and point lookups can be cached, ClickHouse can handle it. The JSON column workaround solves schema flexibility. The materialized view workaround solves atomic counters. The cache workaround solves point lookup latency.
+
+The cost: every workaround is application complexity. MongoDB does these things natively. ClickHouse requires you to design around its limitations.
+
+**The WordPress for YouTube answer: ClickHouse + MinIO only.**
+
+Why? Because WordPress doesn't use three databases. It uses one. MySQL handles everything — posts, comments, users, permissions. It's not optimal for anything. It's good enough for everything.
+
+ClickHouse + MinIO is the same idea. One database for structured data. One object store for blobs. The API handles the rest. No MongoDB. No Postgres. No CDC. No Kafka.
+
+The trade-offs (schema rigidity, point lookup latency, no atomic updates) are acceptable for a social network. Most social operations are append-only. Most reads are discovery queries. Most writes are creates, not updates.
+
+## The Architecture
+
+```
+ClickHouse:
+  posts (with JSON body)
+  reactions
+  comments
+  follows
+  engagement (materialized view)
+  discovery_posts (materialized view)
+
+MinIO:
+  media blobs
+  presigned URLs
+
+API:
+  orchestrates ClickHouse + MinIO
+  caches hot point lookups
+  batches inserts
+```
+
+Two services. That's the stack.
+
+## Migration from MongoDB
+
+1. Deploy ClickHouse + MinIO
+2. Migrate MongoDB data to ClickHouse tables (one-time backfill)
+3. Switch writes to ClickHouse
+4. Keep MongoDB as read-only backup for 30 days
+5. Delete MongoDB
+
+## The Risk
+
+ClickHouse is not MongoDB. If you need atomic updates, schemaless documents, or sub-millisecond point lookups, you'll feel the pain. The workarounds (JSON columns, materialized views, caching) add complexity.
+
+But for "WordPress for YouTube" vibes, that complexity is the point. You accept the limitations of the tool to keep the stack simple. WordPress works with MySQL even though MySQL isn't optimal for everything. It's good enough.
+
+ClickHouse + MinIO is good enough for a social network. The rest is optimization for later.


### PR DESCRIPTION
Explores the web10 v3 architecture from first principles: ClickHouse + MinIO as the entire stack (no MongoDB, no Postgres, no CDC). Layered permissions model (collection ceiling + post-level narrowing, strictest wins). Discovery as a CRUD parameter (`?discover=true`) instead of separate endpoints. Groups as a cross-app platform primitive — one membership, infinite apps.

Also archives 8 superseded architecture explorations (three-tier, S3 Parquet, federated joins, per-record-only permissions) that were dead ends.