### PR TITLE
docs: web10 v3 architecture — groups, service contracts, cross-app sharing, federation

### DIFF
--- a/knowledge/knowledge-base/web10-social-v3/README.md
+++ b/knowledge/knowledge-base/web10-social-v3/README.md
@@ -1,0 +1,56 @@
+# web10 Social v3
+
+The social app is the proof. If a full-featured social platform maps cleanly to the v3 protocol, the protocol is right.
+
+**The v3 primitives:**
+- One `posts` table — everything is a post
+- `ref` type — links posts together (reactions, comments, replies)
+- Groups — policy containers for people, not data
+- Service contracts — which websites can access your data
+- Groups define discovery — one query, no fan-out
+
+**The screens:** Each doc below shows how a social app screen maps to the protocol. No dedicated social endpoints. No special tables. Just CRUD + groups + refs.
+
+## Screens
+
+| Screen | Doc | Status |
+|---|---|---|
+| Your Profile | `your-profile.md` | ✓ |
+| Another Person's Profile | `other-profile.md` | ✓ |
+| Public Discover | `discover.md` | ✓ |
+| Your Feed | `feed.md` | ✓ |
+| Your Messages | `messages.md` | ✓ |
+| Groups Tab | `groups-tab.md` | ✓ |
+| Post Detail | `post-detail.md` | ✓ |
+| Create Post | `create-post.md` | ✓ |
+| Search | `search.md` | ✓ |
+| Notifications | `notifications.md` | ✓ |
+| Settings / Privacy | `settings.md` | ✓ |
+
+## The Proof
+
+If every screen above reduces to:
+1. A CRUD call to `/{user}/{service}`
+2. A groups call to `/groups`
+3. A `ref` in the JSON body
+
+Then the protocol is simpler than v2. If any screen needs a dedicated endpoint, a special table, or a workaround — the protocol has a gap.
+
+**Result: zero gaps.** Every screen is CRUD + groups + refs. No dedicated social endpoints. No special tables. No mirrors. No fan-out.
+
+| v2 Social | v3 Social |
+|---|---|
+| `/reactions` endpoint | posts table, `reactions` collection |
+| `/comments` endpoint | posts table, `comments` collection |
+| `/follows` endpoint | group membership |
+| `/discover` endpoint | `?discover=true` on CRUD |
+| Discovery index mirror | posts table IS the index |
+| Client-side double-write | server writes once |
+| Public ledger | posts with `ref` type |
+| Dedicated notifications | lightweight app-owned table |
+
+The protocol exists to enable the platform to be the very best. The social app is the proof.
+
+## Summary
+
+The social app is the acid test. 11 screens. Zero dedicated endpoints. Zero special tables. Every screen is CRUD + groups + refs. The protocol is simpler than v2. The foundation holds.

--- a/knowledge/knowledge-base/web10-social-v3/README.md
+++ b/knowledge/knowledge-base/web10-social-v3/README.md
@@ -3,8 +3,8 @@
 The social app is the proof. If a full-featured social platform maps cleanly to the v3 protocol, the protocol is right.
 
 **The v3 primitives:**
-- One `posts` table — everything is a post
-- `ref` type — links posts together (reactions, comments, replies)
+- One `documents` table — everything is a document
+- `ref` type — links documents together (reactions, comments, replies)
 - Groups — policy containers for people, not data
 - Service contracts — which websites can access your data
 - Groups define discovery — one query, no fan-out
@@ -40,13 +40,13 @@ Then the protocol is simpler than v2. If any screen needs a dedicated endpoint, 
 
 | v2 Social | v3 Social |
 |---|---|
-| `/reactions` endpoint | posts table, `reactions` collection |
-| `/comments` endpoint | posts table, `comments` collection |
+| `/reactions` endpoint | documents table, `reactions` collection |
+| `/comments` endpoint | documents table, `comments` collection |
 | `/follows` endpoint | group membership |
 | `/discover` endpoint | `?discover=true` on CRUD |
-| Discovery index mirror | posts table IS the index |
+| Discovery index mirror | documents table IS the index |
 | Client-side double-write | server writes once |
-| Public ledger | posts with `ref` type |
+| Public ledger | documents with `ref` type |
 | Dedicated notifications | lightweight app-owned table |
 
 The protocol exists to enable the platform to be the very best. The social app is the proof.

--- a/knowledge/knowledge-base/web10-social-v3/create-post.md
+++ b/knowledge/knowledge-base/web10-social-v3/create-post.md
@@ -1,0 +1,104 @@
+# Create Post
+
+Compose and publish a post. Pick groups. Add media. Write content.
+
+## What the Screen Shows
+
+```
+New Post
+─────────────────────
+[jacoby149 avatar]
+
+Type something...
+
+─────────────────────
+📷 Add media    👥 Pick groups
+
+Groups:
+  [jacoby149.public] ✓
+  [web10-dev]        ✓
+
+[POST]
+```
+
+## Protocol Mapping
+
+**Compose:** Client-side. No protocol involvement until publish.
+
+**Media upload:**
+```
+User selects image
+  → GET /jacoby149/upload
+  → API: presigned MinIO PUT URL (valid 5 mins)
+  → Client: direct upload to MinIO
+  → Client: "I uploaded it, key is jacoby149/media/img-abc.jpg"
+```
+
+**Group picker:** Groups the user belongs to (as member or admin).
+```
+GET /groups?member=jacoby149
+→ [jacoby149.public, jacoby149.close-friends, web10-dev, jazz-collectors, ...]
+```
+The app filters to groups where posting makes sense. Shows group name and member count.
+
+**Publish:**
+```
+User taps POST
+  → POST /jacoby149/posts
+     { "text": {"type": "text", "value": "just shipped the new groups feature"},
+       "media": [{"type": "minio", "value": "jacoby149/media/img-abc.jpg"}],
+       "tags": ["web10", "groups"],
+       "groups": ["jacoby149.public", "web10-dev"],
+       "discoverable": true }
+  → API: INSERT INTO posts
+  → API: INSERT INTO post_groups (one row per group)
+  → WebSocket: push to subscribers in both groups
+```
+
+One insert into posts. N inserts into post_groups. Done.
+
+## The Write Flow
+
+```
+Client → POST /jacoby149/posts { body, groups: [...] }
+  API → INSERT INTO posts (post_id, author_key, 'posts', body_json, discoverable, tags, ...)
+  API → INSERT INTO post_groups (post_id, 'jacoby149.public', 'read', ...)
+  API → INSERT INTO post_groups (post_id, 'web10-dev', 'read', ...)
+  API → Redis: update group:jacoby149.public:recent, group:web10-dev:recent
+  API → WebSocket: PUBLISH to both group channels
+  API → 201 Created { post_id }
+```
+
+One table write. N group attachments. Cache update. Push notification. Done.
+
+## Media in the Post
+
+The media lives in the JSON body:
+```json
+{
+  "text": {"type": "text", "value": "check this out"},
+  "media": [
+    {"type": "minio", "value": "jacoby149/media/img-abc.jpg"},
+    {"type": "minio", "value": "jacoby149/media/vid-xyz.mp4"}
+  ]
+}
+```
+
+On read, the API scans for minio types and converts to presigned URLs. No separate media table. The JSON body holds the references.
+
+## Draft Posts
+
+Client-side only. No protocol involvement. The app stores drafts locally (localStorage, IndexedDB). On publish, the draft becomes a real post.
+
+## TODO
+
+- [ ] Group picker UI — search groups, show member counts, filter by join policy
+- [ ] Media upload — presigned URL flow, progress indicator, retry
+- [ ] Character limit — client-side validation, no protocol limit (JSON is freeform)
+- [ ] Tag input — client-side, stored in tags array
+- [ ] Scheduled posts — TTL on a `drafts` collection, background job publishes at time (future)
+- [ ] Post preview — render JSON body as the user types
+
+## Proof
+
+Create post is one CRUD call. Groups are an attachment. Media is a minio ref in the JSON body. Tags are an array. No dedicated compose endpoint. No media table. No validation schema. The protocol handles it.

--- a/knowledge/knowledge-base/web10-social-v3/create-post.md
+++ b/knowledge/knowledge-base/web10-social-v3/create-post.md
@@ -50,23 +50,23 @@ User taps POST
        "tags": ["web10", "groups"],
        "groups": ["jacoby149.public", "web10-dev"],
        "discoverable": true }
-  → API: INSERT INTO posts
-  → API: INSERT INTO post_groups (one row per group)
+  → API: INSERT INTO documents
+  → API: INSERT INTO doc_groups (one row per group)
   → WebSocket: push to subscribers in both groups
 ```
 
-One insert into posts. N inserts into post_groups. Done.
+One insert into documents. N inserts into doc_groups. Done.
 
 ## The Write Flow
 
 ```
 Client → POST /jacoby149/posts { body, groups: [...] }
-  API → INSERT INTO posts (post_id, author_key, 'posts', body_json, discoverable, tags, ...)
-  API → INSERT INTO post_groups (post_id, 'jacoby149.public', 'read', ...)
-  API → INSERT INTO post_groups (post_id, 'web10-dev', 'read', ...)
+  API → INSERT INTO documents (doc_id, author_key, 'posts', body_json, discoverable, tags, ...)
+  API → INSERT INTO doc_groups (doc_id, 'jacoby149.public', 'read', ...)
+  API → INSERT INTO doc_groups (doc_id, 'web10-dev', 'read', ...)
   API → Redis: update group:jacoby149.public:recent, group:web10-dev:recent
   API → WebSocket: PUBLISH to both group channels
-  API → 201 Created { post_id }
+  API → 201 Created { doc_id }
 ```
 
 One table write. N group attachments. Cache update. Push notification. Done.

--- a/knowledge/knowledge-base/web10-social-v3/discover.md
+++ b/knowledge/knowledge-base/web10-social-v3/discover.md
@@ -1,0 +1,103 @@
+# Public Discover
+
+The discover page. Posts from all groups you're a member of, sorted by time or engagement.
+
+## What the Screen Shows
+
+```
+Discover
+─────────────────────
+[jacoby149] posted 2h ago in [web10-dev]
+  "just shipped the new groups feature"
+  [❤️ 42] [💬 8]
+
+[alice] posted 3h ago in [jazz-collectors]
+  "this album is fire"
+  [🎵 attachment]
+  [❤️ 15] [💬 3]
+
+[bob] posted 5h ago in [alice.followers]
+  "behind the scenes"
+  [❤️ 120] [💬 24]
+```
+
+## Protocol Mapping
+
+**Discover query:** The same query from overview.md, but broader — all groups, not one.
+```sql
+SELECT p.post_id, p.author_key, p.body, p.tags, p.created_at,
+       pg.group_id
+FROM posts p
+JOIN post_groups pg ON p.post_id = pg.post_id
+JOIN group_members gm ON pg.group_id = gm.group_id
+WHERE p.deleted = 0
+  AND p.discoverable = 1
+  AND gm.member_key = 'jacoby149'
+  AND gm.deleted = 0
+  AND NOT EXISTS (
+    SELECT 1 FROM user_blacklist
+    WHERE user_key = p.author_key AND blocked_key = 'jacoby149'
+  )
+ORDER BY p.created_at DESC
+LIMIT 50;
+```
+
+One query. All groups. Filtered by membership. Blacklisted authors excluded.
+
+**Sorted by engagement:** Count reactions (posts with ref type pointing to this post).
+```sql
+SELECT p.post_id, p.author_key, p.body, p.created_at,
+       (SELECT count() FROM posts r
+        WHERE r.deleted = 0
+          AND r.collection_name = 'reactions'
+          AND hasToken(r.body, p.post_id)
+       ) AS reaction_count
+FROM posts p
+JOIN post_groups pg ON p.post_id = pg.post_id
+JOIN group_members gm ON pg.group_id = gm.group_id
+WHERE p.deleted = 0
+  AND p.discoverable = 1
+  AND gm.member_key = 'jacoby149'
+  AND gm.deleted = 0
+ORDER BY reaction_count DESC, p.created_at DESC
+LIMIT 50;
+```
+
+Subquery on posts table. No dedicated reactions table. The `hasToken` function scans the JSON body for the ref value.
+
+**Group label:** The `post_groups` join returns the group_id. Resolve to group name from `group_contracts`.
+
+## The Data Flow
+
+```
+User opens /discover
+  → GET /discover?sort=newest    (or ?sort=trending)
+  → ClickHouse: discover query with group membership filter
+  → parallel: resolve author avatars (GET /{author}/profile for each unique author)
+  → parallel: resolve group names (batch query group_contracts)
+  → render
+```
+
+One heavy query. Parallel lookups for avatars and group names. Cache avatars in Redis.
+
+## Engagement Count Optimization
+
+The subquery on every row is expensive. Options:
+1. **Redis cache** — on reaction write, increment `post:{post_id}:reactions` counter. Read from Redis, fallback to query.
+2. **ClickHouse JSON path index** — index the `ref` field in the body JSON for faster `hasToken` lookups.
+3. **Aggregation table** — a lightweight table that the API writes to on reaction insert: `post_engagement(post_id, count)`. Not a materialized view — just a counter the API maintains.
+
+Option 3 is simplest. The API already knows about the write. Increment a counter. No materialized view needed.
+
+## TODO
+
+- [ ] Sort toggle — newest vs. trending
+- [ ] Pagination — keyset on created_at (cursor-based, not OFFSET)
+- [ ] Author avatar caching — Redis, TTL 5m
+- [ ] Group name caching — Redis, TTL 1h (groups don't change often)
+- [ ] Engagement counter table — `post_engagement(post_id, reaction_count, comment_count)`
+- [ ] Filter by group — `?group=jazz-collectors` to narrow discover
+
+## Proof
+
+Discover is one query. One table. Group membership is the filter. Engagement is a count of posts with refs. No dedicated reactions table. No discovery index. No mirrors. The protocol handles it.

--- a/knowledge/knowledge-base/web10-social-v3/discover.md
+++ b/knowledge/knowledge-base/web10-social-v3/discover.md
@@ -25,10 +25,10 @@ Discover
 
 **Discover query:** The same query from overview.md, but broader — all groups, not one.
 ```sql
-SELECT p.post_id, p.author_key, p.body, p.tags, p.created_at,
+SELECT p.doc_id, p.author_key, p.body, p.tags, p.created_at,
        pg.group_id
-FROM posts p
-JOIN post_groups pg ON p.post_id = pg.post_id
+FROM documents p
+JOIN doc_groups pg ON p.doc_id = pg.doc_id
 JOIN group_members gm ON pg.group_id = gm.group_id
 WHERE p.deleted = 0
   AND p.discoverable = 1
@@ -44,16 +44,16 @@ LIMIT 50;
 
 One query. All groups. Filtered by membership. Blacklisted authors excluded.
 
-**Sorted by engagement:** Count reactions (posts with ref type pointing to this post).
+**Sorted by engagement:** Count reactions (documents with ref type pointing to this post).
 ```sql
-SELECT p.post_id, p.author_key, p.body, p.created_at,
-       (SELECT count() FROM posts r
+SELECT p.doc_id, p.author_key, p.body, p.created_at,
+       (SELECT count() FROM documents r
         WHERE r.deleted = 0
           AND r.collection_name = 'reactions'
-          AND hasToken(r.body, p.post_id)
+          AND hasToken(r.body, p.doc_id)
        ) AS reaction_count
-FROM posts p
-JOIN post_groups pg ON p.post_id = pg.post_id
+FROM documents p
+JOIN doc_groups pg ON p.doc_id = pg.doc_id
 JOIN group_members gm ON pg.group_id = gm.group_id
 WHERE p.deleted = 0
   AND p.discoverable = 1
@@ -63,9 +63,9 @@ ORDER BY reaction_count DESC, p.created_at DESC
 LIMIT 50;
 ```
 
-Subquery on posts table. No dedicated reactions table. The `hasToken` function scans the JSON body for the ref value.
+Subquery on documents table. No dedicated reactions table. The `hasToken` function scans the JSON body for the ref value.
 
-**Group label:** The `post_groups` join returns the group_id. Resolve to group name from `group_contracts`.
+**Group label:** The `doc_groups` join returns the group_id. Resolve to group name from `group_contracts`.
 
 ## The Data Flow
 
@@ -83,9 +83,9 @@ One heavy query. Parallel lookups for avatars and group names. Cache avatars in 
 ## Engagement Count Optimization
 
 The subquery on every row is expensive. Options:
-1. **Redis cache** — on reaction write, increment `post:{post_id}:reactions` counter. Read from Redis, fallback to query.
+1. **Redis cache** — on reaction write, increment `post:{doc_id}:reactions` counter. Read from Redis, fallback to query.
 2. **ClickHouse JSON path index** — index the `ref` field in the body JSON for faster `hasToken` lookups.
-3. **Aggregation table** — a lightweight table that the API writes to on reaction insert: `post_engagement(post_id, count)`. Not a materialized view — just a counter the API maintains.
+3. **Aggregation table** — a lightweight table that the API writes to on reaction insert: `post_engagement(doc_id, count)`. Not a materialized view — just a counter the API maintains.
 
 Option 3 is simplest. The API already knows about the write. Increment a counter. No materialized view needed.
 
@@ -95,9 +95,9 @@ Option 3 is simplest. The API already knows about the write. Increment a counter
 - [ ] Pagination — keyset on created_at (cursor-based, not OFFSET)
 - [ ] Author avatar caching — Redis, TTL 5m
 - [ ] Group name caching — Redis, TTL 1h (groups don't change often)
-- [ ] Engagement counter table — `post_engagement(post_id, reaction_count, comment_count)`
+- [ ] Engagement counter table — `post_engagement(doc_id, reaction_count, comment_count)`
 - [ ] Filter by group — `?group=jazz-collectors` to narrow discover
 
 ## Proof
 
-Discover is one query. One table. Group membership is the filter. Engagement is a count of posts with refs. No dedicated reactions table. No discovery index. No mirrors. The protocol handles it.
+Discover is one query. One table. Group membership is the filter. Engagement is a count of documents with refs. No dedicated reactions table. No discovery index. No mirrors. The protocol handles it.

--- a/knowledge/knowledge-base/web10-social-v3/feed.md
+++ b/knowledge/knowledge-base/web10-social-v3/feed.md
@@ -19,12 +19,12 @@ Feed
 
 ## Protocol Mapping
 
-**The feed is discover filtered to your followers groups.** You follow people → you're a member of their `username.followers` groups → their posts attached to that group appear in your feed.
+**The feed is discover filtered to your followers groups.** You follow people → you're a member of their `username.followers` groups → their documents attached to that group appear in your feed.
 
 ```sql
-SELECT p.post_id, p.author_key, p.body, p.created_at
-FROM posts p
-JOIN post_groups pg ON p.post_id = pg.post_id
+SELECT p.doc_id, p.author_key, p.body, p.created_at
+FROM documents p
+JOIN doc_groups pg ON p.doc_id = pg.doc_id
 JOIN group_members gm ON pg.group_id = gm.group_id
 WHERE p.deleted = 0
   AND p.discoverable = 1

--- a/knowledge/knowledge-base/web10-social-v3/feed.md
+++ b/knowledge/knowledge-base/web10-social-v3/feed.md
@@ -1,0 +1,84 @@
+# Your Feed
+
+Your personal feed. Posts from people you follow, sorted chronologically.
+
+## What the Screen Shows
+
+```
+Feed
+─────────────────────
+[alice] posted 1h ago
+  "morning coffee run"
+  [📷 attachment]
+  [❤️ 12] [💬 2]
+
+[bob] posted 3h ago
+  "working on something cool"
+  [❤️ 5] [💬 0]
+```
+
+## Protocol Mapping
+
+**The feed is discover filtered to your followers groups.** You follow people → you're a member of their `username.followers` groups → their posts attached to that group appear in your feed.
+
+```sql
+SELECT p.post_id, p.author_key, p.body, p.created_at
+FROM posts p
+JOIN post_groups pg ON p.post_id = pg.post_id
+JOIN group_members gm ON pg.group_id = gm.group_id
+WHERE p.deleted = 0
+  AND p.discoverable = 1
+  AND gm.member_key = 'jacoby149'
+  AND gm.deleted = 0
+  AND pg.group_id LIKE '%.followers'    -- only followers groups, not jazz-collectors
+  AND NOT EXISTS (
+    SELECT 1 FROM user_blacklist
+    WHERE user_key = p.author_key AND blocked_key = 'jacoby149'
+  )
+ORDER BY p.created_at DESC
+LIMIT 50;
+```
+
+The `LIKE '%.followers'` filter narrows to follow relationships. Your feed is discover with a group filter. Same query, different scope.
+
+**Alternative:** The app tracks which users you follow in a local list. Build the group_ids explicitly:
+```sql
+-- jacoby149 follows alice, bob, charlie
+WHERE pg.group_id IN ('alice.followers', 'bob.followers', 'charlie.followers')
+```
+Faster than LIKE. The app maintains the follow list as a convenience.
+
+## The Data Flow
+
+```
+User opens /feed
+  → GET /feed
+  → ClickHouse: discover query filtered to *.followers groups
+  → parallel: resolve author avatars
+  → render
+```
+
+Same discover query, narrower filter. The protocol doesn't need a "feed" concept — it's discover with a group filter.
+
+## Feed vs Discover
+
+| Feed | Discover |
+|---|---|
+| `*.followers` groups only | All groups you're a member of |
+| Chronological | Chronological or trending |
+| People you follow | All shared content |
+| Personal | Broad |
+
+Same query. Different WHERE clause. The groups define the difference.
+
+## TODO
+
+- [ ] Follow list caching — app maintains list of followed users for faster queries
+- [ ] Mute feature — per-author exclusion (extend user_blacklist or add mute table)
+- [ ] "See post" from feed → post detail screen (ref to post-detail.md)
+- [ ] Infinite scroll — keyset pagination on created_at
+- [ ] WebSocket push — new posts from followed users arrive in real-time (see real-time-feeds.md)
+
+## Proof
+
+Your feed is a discover query with a group filter. No feed table. No fan-out on write. No "compute feed" job. One query at read time. The groups define what's in your feed. The protocol handles it.

--- a/knowledge/knowledge-base/web10-social-v3/groups-tab.md
+++ b/knowledge/knowledge-base/web10-social-v3/groups-tab.md
@@ -115,24 +115,24 @@ Members (12):
   ...
 
 Your posts in this group: 24
-  [Opt out all posts]
+  [Opt out all documents]
 ```
 
-**Opt out all posts:** Bulk tombstone your post_groups entries for this group.
+**Opt out all documents:** Bulk tombstone your doc_groups entries for this group.
 ```sql
-INSERT INTO post_groups
-SELECT post_id, group_id, permission, created_at, now(), 1
-FROM post_groups
+INSERT INTO doc_groups
+SELECT doc_id, group_id, permission, created_at, now(), 1
+FROM doc_groups
 WHERE group_id = 'jacoby149.close-friends'
   AND deleted = 0
-  -- need author_key, which isn't in post_groups — join with posts
+  -- need author_key, which isn't in doc_groups — join with documents
 ```
 Actually, need to join with posts to filter by author:
 ```sql
-INSERT INTO post_groups (post_id, group_id, permission, created_at, updated_at, deleted)
-SELECT pg.post_id, pg.group_id, pg.permission, pg.created_at, now(), 1
-FROM post_groups pg
-JOIN posts p ON pg.post_id = p.post_id
+INSERT INTO doc_groups (doc_id, group_id, permission, created_at, updated_at, deleted)
+SELECT pg.doc_id, pg.group_id, pg.permission, pg.created_at, now(), 1
+FROM doc_groups pg
+JOIN documents p ON pg.doc_id = p.doc_id
 WHERE pg.group_id = 'jacoby149.close-friends'
   AND p.author_key = 'jacoby149'
   AND pg.deleted = 0;
@@ -142,7 +142,7 @@ WHERE pg.group_id = 'jacoby149.close-friends'
 
 - [ ] Group management screen — members list, add/remove, change join policy
 - [ ] Member search — find users to invite to a group
-- [ ] Opt out all posts — bulk tombstone with author filter
+- [ ] Opt out all documents — bulk tombstone with author filter
 - [ ] Create group flow — INSERT into group_contracts, auto-add admin as member
 - [ ] Join request notifications — notify admin on new request (see notifications.md)
 

--- a/knowledge/knowledge-base/web10-social-v3/groups-tab.md
+++ b/knowledge/knowledge-base/web10-social-v3/groups-tab.md
@@ -1,0 +1,151 @@
+# Groups Tab
+
+Manage your groups. See groups you admin, groups you belong to, pending join requests.
+
+## What the Screen Shows
+
+```
+Groups
+─────────────────────
+You Admin (2)
+─────────────────────
+jacoby149.public          [open]    1,203 members  [Manage]
+jacoby149.close-friends   [invite]  12 members     [Manage]
+
+You Belong To (3)
+─────────────────────
+jazz-collectors           [request] admin: dave     [View] [Leave]
+web10-dev                 [open]    admin: charlie  [View] [Leave]
+alice.followers           [request] admin: alice    [Unfollow]
+
+Pending Requests (1)
+─────────────────────
+bob wants to join jacoby149.close-friends  [Approve] [Deny]
+```
+
+## Protocol Mapping
+
+**Groups you admin:**
+```sql
+SELECT group_id, name, join_policy
+FROM group_contracts
+WHERE admin_key = 'jacoby149' AND deleted = 0;
+```
+
+**Member counts:**
+```sql
+SELECT group_id, count() AS members
+FROM group_members
+WHERE deleted = 0
+GROUP BY group_id;
+```
+
+**Groups you belong to (not admin):**
+```sql
+SELECT gm.group_id, gc.name, gc.admin_key, gc.join_policy
+FROM group_members gm
+JOIN group_contracts gc ON gm.group_id = gc.group_id
+WHERE gm.member_key = 'jacoby149'
+  AND gm.deleted = 0
+  AND gc.deleted = 0
+  AND gc.admin_key != 'jacoby149';
+```
+
+**Pending join requests:**
+```sql
+SELECT gjr.group_id, gjr.requester_key, gjr.requested_at, gc.name
+FROM group_join_requests gjr
+JOIN group_contracts gc ON gjr.group_id = gc.group_id
+WHERE gjr.status = 'pending'
+  AND gc.admin_key = 'jacoby149'
+  AND gjr.deleted = 0;
+```
+
+**Approve a request:**
+```sql
+-- Update request status
+INSERT INTO group_join_requests
+SELECT group_id, requester_key, 'approved', requested_at, now(), updated_at, deleted
+FROM group_join_requests
+WHERE group_id = 'jacoby149.close-friends' AND requester_key = 'bob';
+
+-- Add to group members
+INSERT INTO group_members VALUES ('jacoby149.close-friends', 'bob', 'member', now(), now(), 0);
+```
+
+**Leave a group:**
+```sql
+INSERT INTO group_members
+SELECT group_id, member_key, role, joined_at, now(), 1
+FROM group_members
+WHERE group_id = 'jazz-collectors' AND member_key = 'jacoby149';
+```
+Tombstone the membership. You're out.
+
+**Block sharing (without leaving):**
+```sql
+INSERT INTO user_group_sharing VALUES ('jacoby149', 'jazz-collectors', 0, now(), now(), 0);
+```
+Your posts are hidden from the group. You still see their posts. Reversible.
+
+## The Data Flow
+
+```
+User opens /groups
+  → query: groups you admin          (group_contracts)
+  → query: member counts             (group_members, GROUP BY)
+  → query: groups you belong to      (group_members JOIN group_contracts)
+  → query: pending requests          (group_join_requests)
+  → parallel: all four queries
+  → render
+```
+
+Four parallel queries. No joins between them. Clean.
+
+## Group Management Screen
+
+```
+jacoby149.close-friends
+─────────────────────
+Join policy: invite only  [Change]
+Members (12):
+  jacoby149  [admin]
+  alice      [member]  [Remove]
+  bob        [member]  [Remove]
+  ...
+
+Your posts in this group: 24
+  [Opt out all posts]
+```
+
+**Opt out all posts:** Bulk tombstone your post_groups entries for this group.
+```sql
+INSERT INTO post_groups
+SELECT post_id, group_id, permission, created_at, now(), 1
+FROM post_groups
+WHERE group_id = 'jacoby149.close-friends'
+  AND deleted = 0
+  -- need author_key, which isn't in post_groups — join with posts
+```
+Actually, need to join with posts to filter by author:
+```sql
+INSERT INTO post_groups (post_id, group_id, permission, created_at, updated_at, deleted)
+SELECT pg.post_id, pg.group_id, pg.permission, pg.created_at, now(), 1
+FROM post_groups pg
+JOIN posts p ON pg.post_id = p.post_id
+WHERE pg.group_id = 'jacoby149.close-friends'
+  AND p.author_key = 'jacoby149'
+  AND pg.deleted = 0;
+```
+
+## TODO
+
+- [ ] Group management screen — members list, add/remove, change join policy
+- [ ] Member search — find users to invite to a group
+- [ ] Opt out all posts — bulk tombstone with author filter
+- [ ] Create group flow — INSERT into group_contracts, auto-add admin as member
+- [ ] Join request notifications — notify admin on new request (see notifications.md)
+
+## Proof
+
+Groups are managed through contract and membership tables. No dedicated social groups endpoint. No special permissions. CRUD on group_contracts and group_members. The protocol handles it.

--- a/knowledge/knowledge-base/web10-social-v3/messages.md
+++ b/knowledge/knowledge-base/web10-social-v3/messages.md
@@ -25,9 +25,9 @@ Inbox (3)          Sent (12)
 
 **Inbox:** Posts attached to your inbox group. Sender owns the post. You discover it.
 ```sql
-SELECT p.post_id, p.author_key, p.body, p.created_at
-FROM posts p
-JOIN post_groups pg ON p.post_id = pg.post_id
+SELECT p.doc_id, p.author_key, p.body, p.created_at
+FROM documents p
+JOIN doc_groups pg ON p.doc_id = pg.doc_id
 WHERE p.deleted = 0
   AND pg.group_id = 'jacoby149.inbox'
   AND pg.deleted = 0
@@ -37,10 +37,10 @@ ORDER BY p.created_at DESC;
 
 **Sent:** Your posts attached to someone's inbox group.
 ```sql
-SELECT p.post_id, p.body, p.created_at,
+SELECT p.doc_id, p.body, p.created_at,
        pg.group_id                    -- the group name tells you who it's for
-FROM posts p
-JOIN post_groups pg ON p.post_id = pg.post_id
+FROM documents p
+JOIN doc_groups pg ON p.doc_id = pg.doc_id
 WHERE p.deleted = 0
   AND p.author_key = 'jacoby149'
   AND p.collection_name = 'outbox'
@@ -50,9 +50,9 @@ ORDER BY p.created_at DESC;
 **DM thread:** A group with two members. Both sides' posts appear.
 ```sql
 -- alice-and-bob DM
-SELECT p.post_id, p.author_key, p.body, p.created_at
-FROM posts p
-JOIN post_groups pg ON p.post_id = pg.post_id
+SELECT p.doc_id, p.author_key, p.body, p.created_at
+FROM documents p
+JOIN doc_groups pg ON p.doc_id = pg.doc_id
 WHERE p.deleted = 0
   AND pg.group_id = 'alice-and-bob'
   AND pg.deleted = 0
@@ -67,26 +67,26 @@ Same group. Different collections. One query returns both.
 ```sql
 CREATE TABLE message_read (
     user_key String,       -- who read it
-    post_id String,        -- which message
+    doc_id String,        -- which message
     read_at DateTime64(3)
 ) ENGINE = MergeTree()
-ORDER BY (user_key, post_id);
+ORDER BY (user_key, doc_id);
 ```
 
-Unread = inbox posts minus read posts.
+Unread = inbox documents minus read documents.
 
 ## The Data Flow
 
 ```
 User opens /messages
-  → GET /messages/inbox       (posts in jacoby149.inbox group)
+  → GET /messages/inbox       (documents in jacoby149.inbox group)
   → GET /messages/sent        (jacoby149's posts in outbox collection)
   → parallel: resolve sender avatars
   → parallel: check read status
   → render
 
 User opens a DM thread
-  → GET /groups/alice-and-bob/posts  (all posts in the group, chronological)
+  → GET /groups/alice-and-bob/posts  (all documents in the group, chronological)
   → mark messages as read
   → render
 ```
@@ -98,8 +98,8 @@ User types message, taps send to alice
   → POST /jacoby149/outbox
      { "text": {"type": "text", "value": "hey"},
        "groups": ["alice.inbox"] }
-  → API: INSERT INTO posts (jacoby149's collection)
-  → API: INSERT INTO post_groups (alice.inbox)
+  → API: INSERT INTO documents (jacoby149's collection)
+  → API: INSERT INTO doc_groups (alice.inbox)
   → alice discovers it next time she checks her inbox
 ```
 
@@ -110,10 +110,10 @@ One insert. One group attachment. No fan-out. Alice sees it when she queries.
 - [ ] Read receipts — message_read table, mark on thread open
 - [ ] Typing indicators — WebSocket signal, ephemeral (not stored)
 - [ ] DM creation flow — create group with two members, invite the other person
-- [ ] Message attachment — media in JSON body (minio type), same as posts
+- [ ] Message attachment — media in JSON body (minio type), same as documents
 - [ ] Unread badge — counter in Redis, increment on inbox write, decrement on read
-- [ ] Search messages — filter posts by group_id and text search on body
+- [ ] Search messages — filter documents by group_id and text search on body
 
 ## Proof
 
-Messages are posts with group attachments. Inbox is a group. Sent is your collection. DMs are a two-person group. No dedicated mail table. No dedicated DM table. No fan-out on send. The protocol handles it.
+Messages are documents with group attachments. Inbox is a group. Sent is your collection. DMs are a two-person group. No dedicated mail table. No dedicated DM table. No fan-out on send. The protocol handles it.

--- a/knowledge/knowledge-base/web10-social-v3/messages.md
+++ b/knowledge/knowledge-base/web10-social-v3/messages.md
@@ -1,0 +1,119 @@
+# Your Messages
+
+Inbox and sent mail. DMs and group messages. All the same model.
+
+## What the Screen Shows
+
+```
+Messages
+─────────────────────
+Inbox (3)          Sent (12)
+
+[alice] 2h ago
+  "hey, how's the project going?"
+
+[bob] 5h ago
+  "check this out"
+  [📷 attachment]
+
+[alice-and-bob DM] 1d ago
+  alice: "sounds good"
+  bob: "let's do it"
+```
+
+## Protocol Mapping
+
+**Inbox:** Posts attached to your inbox group. Sender owns the post. You discover it.
+```sql
+SELECT p.post_id, p.author_key, p.body, p.created_at
+FROM posts p
+JOIN post_groups pg ON p.post_id = pg.post_id
+WHERE p.deleted = 0
+  AND pg.group_id = 'jacoby149.inbox'
+  AND pg.deleted = 0
+  AND p.author_key != 'jacoby149'     -- not your own sent mail
+ORDER BY p.created_at DESC;
+```
+
+**Sent:** Your posts attached to someone's inbox group.
+```sql
+SELECT p.post_id, p.body, p.created_at,
+       pg.group_id                    -- the group name tells you who it's for
+FROM posts p
+JOIN post_groups pg ON p.post_id = pg.post_id
+WHERE p.deleted = 0
+  AND p.author_key = 'jacoby149'
+  AND p.collection_name = 'outbox'
+ORDER BY p.created_at DESC;
+```
+
+**DM thread:** A group with two members. Both sides' posts appear.
+```sql
+-- alice-and-bob DM
+SELECT p.post_id, p.author_key, p.body, p.created_at
+FROM posts p
+JOIN post_groups pg ON p.post_id = pg.post_id
+WHERE p.deleted = 0
+  AND pg.group_id = 'alice-and-bob'
+  AND pg.deleted = 0
+ORDER BY p.created_at ASC;            -- chronological, oldest first
+```
+
+Alice's messages: `alice.messages` collection, attached to `alice-and-bob` group.
+Bob's messages: `bob.messages` collection, attached to `alice-and-bob` group.
+Same group. Different collections. One query returns both.
+
+**Unread count:** The app tracks read state locally (or in a `message_read` table).
+```sql
+CREATE TABLE message_read (
+    user_key String,       -- who read it
+    post_id String,        -- which message
+    read_at DateTime64(3)
+) ENGINE = MergeTree()
+ORDER BY (user_key, post_id);
+```
+
+Unread = inbox posts minus read posts.
+
+## The Data Flow
+
+```
+User opens /messages
+  → GET /messages/inbox       (posts in jacoby149.inbox group)
+  → GET /messages/sent        (jacoby149's posts in outbox collection)
+  → parallel: resolve sender avatars
+  → parallel: check read status
+  → render
+
+User opens a DM thread
+  → GET /groups/alice-and-bob/posts  (all posts in the group, chronological)
+  → mark messages as read
+  → render
+```
+
+## Send a Message
+
+```
+User types message, taps send to alice
+  → POST /jacoby149/outbox
+     { "text": {"type": "text", "value": "hey"},
+       "groups": ["alice.inbox"] }
+  → API: INSERT INTO posts (jacoby149's collection)
+  → API: INSERT INTO post_groups (alice.inbox)
+  → alice discovers it next time she checks her inbox
+```
+
+One insert. One group attachment. No fan-out. Alice sees it when she queries.
+
+## TODO
+
+- [ ] Read receipts — message_read table, mark on thread open
+- [ ] Typing indicators — WebSocket signal, ephemeral (not stored)
+- [ ] DM creation flow — create group with two members, invite the other person
+- [ ] Message attachment — media in JSON body (minio type), same as posts
+- [ ] Unread badge — counter in Redis, increment on inbox write, decrement on read
+- [ ] Search messages — filter posts by group_id and text search on body
+
+## Proof
+
+Messages are posts with group attachments. Inbox is a group. Sent is your collection. DMs are a two-person group. No dedicated mail table. No dedicated DM table. No fan-out on send. The protocol handles it.

--- a/knowledge/knowledge-base/web10-social-v3/notifications.md
+++ b/knowledge/knowledge-base/web10-social-v3/notifications.md
@@ -19,9 +19,9 @@ Notifications are not a table. They're events derived from writes.
 
 **Reaction notification:** Someone created a post in the `reactions` collection with a ref to your post.
 ```sql
--- New reactions on your posts in the last hour
-SELECT p.post_id, p.author_key, p.body, p.created_at
-FROM posts p
+-- New reactions on your documents in the last hour
+SELECT p.doc_id, p.author_key, p.body, p.created_at
+FROM documents p
 WHERE p.deleted = 0
   AND p.collection_name = 'reactions'
   AND p.created_at > now() - INTERVAL 1 HOUR
@@ -30,11 +30,11 @@ WHERE p.deleted = 0
 
 But you need to know which posts are yours. Join:
 ```sql
-SELECT r.post_id AS reaction_id, r.author_key AS reactor,
+SELECT r.doc_id AS reaction_id, r.author_key AS reactor,
        extractJSONString(r.body, '$.reaction_type.value') AS rtype,
-       p.post_id AS target_post
-FROM posts r
-JOIN posts p ON hasToken(r.body, p.post_id)
+       p.doc_id AS target_post
+FROM documents r
+JOIN documents p ON hasToken(r.body, p.doc_id)
 WHERE r.deleted = 0
   AND r.collection_name = 'reactions'
   AND p.author_key = 'jacoby149'
@@ -44,8 +44,8 @@ ORDER BY r.created_at DESC;
 
 **Comment notification:** Someone created a post in the `comments` collection with a ref to your post.
 ```sql
-SELECT c.post_id AS comment_id, c.author_key AS commenter, c.body, c.created_at
-FROM posts c
+SELECT c.doc_id AS comment_id, c.author_key AS commenter, c.body, c.created_at
+FROM documents c
 WHERE c.deleted = 0
   AND c.collection_name = 'comments'
   AND c.created_at > now() - INTERVAL 1 HOUR
@@ -80,10 +80,10 @@ Polling is wasteful. The right model is push:
 **On every write, the API emits a notification event:**
 ```
 Bob reacts to jacoby149's post
-  → API writes reaction to posts table
+  → API writes reaction to documents table
   → API: who is the post author? (read the target post)
   → API: push notification to jacoby149 via WebSocket
-     { "type": "reaction", "from": "bob", "post_id": "post-123", "reaction_type": "like" }
+     { "type": "reaction", "from": "bob", "doc_id": "post-123", "reaction_type": "like" }
 ```
 
 **On every join request:**
@@ -110,7 +110,7 @@ CREATE TABLE notifications (
     user_key String,          -- who gets the notification
     type String,              -- 'reaction', 'comment', 'follow_request', 'group_join'
     from_key String,          -- who triggered it
-    ref_post_id String,       -- related post (if any)
+    ref_doc_id String,       -- related post (if any)
     ref_group_id String,      -- related group (if any)
     read UInt8 DEFAULT 0,
     created_at DateTime64(3),

--- a/knowledge/knowledge-base/web10-social-v3/notifications.md
+++ b/knowledge/knowledge-base/web10-social-v3/notifications.md
@@ -1,0 +1,153 @@
+# Notifications
+
+Real-time alerts for reactions, comments, follow requests, group activity.
+
+## What the Screen Shows
+
+```
+Notifications
+─────────────────────
+alice liked your post · 2m ago
+bob commented on your post · 15m ago
+charlie requested to follow · 1h ago
+dave joined jazz-collectors · 3h ago
+```
+
+## Protocol Mapping
+
+Notifications are not a table. They're events derived from writes.
+
+**Reaction notification:** Someone created a post in the `reactions` collection with a ref to your post.
+```sql
+-- New reactions on your posts in the last hour
+SELECT p.post_id, p.author_key, p.body, p.created_at
+FROM posts p
+WHERE p.deleted = 0
+  AND p.collection_name = 'reactions'
+  AND p.created_at > now() - INTERVAL 1 HOUR
+  AND hasToken(p.body, '{your post_ids}');
+```
+
+But you need to know which posts are yours. Join:
+```sql
+SELECT r.post_id AS reaction_id, r.author_key AS reactor,
+       extractJSONString(r.body, '$.reaction_type.value') AS rtype,
+       p.post_id AS target_post
+FROM posts r
+JOIN posts p ON hasToken(r.body, p.post_id)
+WHERE r.deleted = 0
+  AND r.collection_name = 'reactions'
+  AND p.author_key = 'jacoby149'
+  AND r.created_at > now() - INTERVAL 1 HOUR
+ORDER BY r.created_at DESC;
+```
+
+**Comment notification:** Someone created a post in the `comments` collection with a ref to your post.
+```sql
+SELECT c.post_id AS comment_id, c.author_key AS commenter, c.body, c.created_at
+FROM posts c
+WHERE c.deleted = 0
+  AND c.collection_name = 'comments'
+  AND c.created_at > now() - INTERVAL 1 HOUR
+  AND hasToken(c.body, '{your post_ids}');
+```
+
+**Follow request notification:** New row in group_join_requests for your groups.
+```sql
+SELECT gjr.requester_key, gjr.group_id, gjr.requested_at
+FROM group_join_requests gjr
+JOIN group_contracts gc ON gjr.group_id = gc.group_id
+WHERE gjr.status = 'pending'
+  AND gc.admin_key = 'jacoby149'
+  AND gjr.created_at > now() - INTERVAL 1 HOUR;
+```
+
+**Group activity:** New members in your groups.
+```sql
+SELECT gm.member_key, gm.group_id, gm.joined_at
+FROM group_members gm
+WHERE gm.group_id IN (
+  SELECT group_id FROM group_contracts
+  WHERE admin_key = 'jacoby149' AND deleted = 0
+)
+AND gm.joined_at > now() - INTERVAL 1 HOUR;
+```
+
+## The Push Model
+
+Polling is wasteful. The right model is push:
+
+**On every write, the API emits a notification event:**
+```
+Bob reacts to jacoby149's post
+  → API writes reaction to posts table
+  → API: who is the post author? (read the target post)
+  → API: push notification to jacoby149 via WebSocket
+     { "type": "reaction", "from": "bob", "post_id": "post-123", "reaction_type": "like" }
+```
+
+**On every join request:**
+```
+Bob requests to join jacoby149.followers
+  → API writes to group_join_requests
+  → API: who is the admin? (read group_contracts)
+  → API: push notification to jacoby149 via WebSocket
+     { "type": "follow_request", "from": "bob", "group_id": "jacoby149.followers" }
+```
+
+The API knows about the write. It pushes the notification. No polling. No background job.
+
+## The Notification History
+
+Notifications are ephemeral by default. But the user needs a history screen.
+
+**Option 1: Query on demand.** Run the notification queries above when the user opens the screen. Accurate, but slow for large datasets.
+
+**Option 2: Notification table.** The API writes to a lightweight notifications table on every event:
+```sql
+CREATE TABLE notifications (
+    notification_id String,
+    user_key String,          -- who gets the notification
+    type String,              -- 'reaction', 'comment', 'follow_request', 'group_join'
+    from_key String,          -- who triggered it
+    ref_post_id String,       -- related post (if any)
+    ref_group_id String,      -- related group (if any)
+    read UInt8 DEFAULT 0,
+    created_at DateTime64(3),
+    updated_at DateTime64(3),
+    deleted UInt8 DEFAULT 0
+) ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY (user_key, created_at);
+```
+
+The API writes to this table on every relevant event. The notification screen queries it. TTL cleans up old notifications.
+
+Option 2 is better for the app. It's a lightweight table, not a core protocol table. The social app owns it.
+
+## The Data Flow
+
+```
+User opens /notifications
+  → GET /notifications
+  → ClickHouse: SELECT FROM notifications WHERE user_key = 'jacoby149' ORDER BY created_at DESC
+  → parallel: resolve avatar for each "from_key"
+  → mark as read
+  → render
+
+Real-time:
+  → WebSocket: subscribe to notifications channel
+  → New notification arrives → append to list, show badge
+```
+
+## TODO
+
+- [ ] Notification table — lightweight, social-app-owned, not core protocol
+- [ ] WebSocket push — on reaction, comment, follow request, group join
+- [ ] Read/unread state — toggle read flag on notification row
+- [ ] Notification badge — counter of unread notifications
+- [ ] Notification preferences — per-type toggle (reactions on/off, comments on/off)
+- [ ] Batch notifications — "15 people liked your post" instead of 15 separate notifications
+
+## Proof
+
+Notifications are derived events, not a core protocol concept. The social app owns the notification table. The API pushes on relevant writes. No polling. No background job. The protocol enables it without defining it.

--- a/knowledge/knowledge-base/web10-social-v3/other-profile.md
+++ b/knowledge/knowledge-base/web10-social-v3/other-profile.md
@@ -1,0 +1,107 @@
+# Other Person's Profile
+
+You visit someone else's profile. You see what's visible to you — groups you share, posts in those groups.
+
+## What the Screen Shows
+
+```
+[avatar] alice
+         bio text here
+
+Public groups:
+[alice.public]     [open] — 50 posts
+[alice.followers]  [request] — "Follow" button
+
+Posts you can see:
+post 1 | 2h ago | [like] [comment]
+post 2 | 1d ago | [like] [comment]
+```
+
+## Protocol Mapping
+
+**Avatar and bio:** Same as your profile.
+```
+GET /alice/profile
+→ { "avatar": {"type": "minio", ...}, "bio": {"type": "text", ...} }
+```
+
+**Public groups:** Groups where join_policy is "open" or you're a member.
+```
+SELECT gc.group_id, gc.name, gc.join_policy
+FROM group_contracts gc
+WHERE gc.admin_key = 'alice'
+  AND gc.deleted = 0
+  AND (gc.join_policy = 'open'
+       OR EXISTS (
+         SELECT 1 FROM group_members gm
+         WHERE gm.group_id = gc.group_id
+           AND gm.member_key = 'jacoby149'
+           AND gm.deleted = 0
+       ));
+```
+
+**"Follow" button:** Check if you're in `alice.followers`.
+```
+SELECT 1 FROM group_members
+WHERE group_id = 'alice.followers'
+  AND member_key = 'jacoby149'
+  AND deleted = 0;
+```
+No row → show "Follow". Row exists → show "Following" + "Unfollow".
+
+**Posts you can see:** Discover query with group membership filter.
+```
+GET /alice/posts?discover=true
+→ ClickHouse: posts WHERE author=alice AND post in groups jacoby149 belongs to
+```
+If you're only in `alice.public`, you see posts attached to `alice.public`. If you're also in `alice.close-friends`, you see those too. The groups control visibility.
+
+**Post counts per group:**
+```
+SELECT pg.group_id, count(DISTINCT p.post_id)
+FROM posts p
+JOIN post_groups pg ON p.post_id = pg.post_id
+WHERE p.author_key = 'alice'
+  AND p.deleted = 0
+  AND pg.deleted = 0
+GROUP BY pg.group_id;
+```
+
+## The Data Flow
+
+```
+User opens /alice
+  → GET /alice/profile                  (avatar, bio)
+  → query: alice's public/member groups (group_contracts + group_members)
+  → query: follow status                (group_members)
+  → GET /alice/posts?discover=true      (posts in shared groups)
+  → render
+```
+
+Same four-call pattern. The groups filter what's visible. No special permissions. No "public" flag on posts — the group membership is the permission.
+
+## The Follow Flow
+
+```
+User taps "Follow" on alice's profile
+  → POST /groups/alice.followers/join-requests
+     { "requester": "jacoby149", "status": "pending" }
+  → INSERT INTO group_join_requests
+  → alice gets a notification
+  → alice approves → INSERT INTO group_members
+  → jacoby149 can now see posts in alice.followers
+```
+
+No follows table. Group join request + group membership. Done.
+
+## TODO
+
+- [ ] Follow/unfollow button state — check group membership, toggle join request
+- [ ] Group visibility filter — only show groups the viewer has access to
+- [ ] Post count per group — aggregation query
+- [ ] "Private group" indicator — show "X posts, request to join" for non-member groups
+- [ ] Block button — INSERT INTO user_blacklist
+
+## Proof
+
+Another person's profile is the same protocol as your own — just filtered by group membership. The groups control what you see. No "public" endpoint. No "private" endpoint. One discover query with a group filter. The protocol handles it.

--- a/knowledge/knowledge-base/web10-social-v3/other-profile.md
+++ b/knowledge/knowledge-base/web10-social-v3/other-profile.md
@@ -58,9 +58,9 @@ If you're only in `alice.public`, you see posts attached to `alice.public`. If y
 
 **Post counts per group:**
 ```
-SELECT pg.group_id, count(DISTINCT p.post_id)
-FROM posts p
-JOIN post_groups pg ON p.post_id = pg.post_id
+SELECT pg.group_id, count(DISTINCT p.doc_id)
+FROM documents p
+JOIN doc_groups pg ON p.doc_id = pg.doc_id
 WHERE p.author_key = 'alice'
   AND p.deleted = 0
   AND pg.deleted = 0

--- a/knowledge/knowledge-base/web10-social-v3/post-detail.md
+++ b/knowledge/knowledge-base/web10-social-v3/post-detail.md
@@ -1,0 +1,162 @@
+# Post Detail
+
+Single post view. Content, reactions, comments, share options.
+
+## What the Screen Shows
+
+```
+jacoby149 · 2h ago · [web10-dev]
+─────────────────────
+"just shipped the new groups feature"
+
+[📷 attachment]
+
+❤️ 42    💬 8    ↗ Share
+
+--- Comments ---
+alice · 1h ago
+  "this is fire 🔥"
+
+  bob · 45m ago (reply to alice)
+    "agree, the ref type is genius"
+
+  charlie · 30m ago
+    "can't wait to try it"
+```
+
+## Protocol Mapping
+
+**The post:** Direct read by post_id.
+```
+GET /jacoby149/posts/{post_id}
+→ check group permissions → allowed
+→ return post with presigned media URLs
+```
+
+**Reactions:** Posts in the `reactions` collection with a ref to this post.
+```sql
+SELECT p.post_id, p.author_key, p.body, p.created_at
+FROM posts p
+WHERE p.deleted = 0
+  AND p.collection_name = 'reactions'
+  AND hasToken(p.body, '{post_id}')
+ORDER BY p.created_at DESC;
+```
+
+The body contains `{ "ref": {"type": "ref", "value": "{post_id}"}, "reaction_type": {"type": "text", "value": "like"} }`.
+
+**Reaction count:**
+```sql
+SELECT count() FROM posts
+WHERE deleted = 0
+  AND collection_name = 'reactions'
+  AND hasToken(body, '{post_id}');
+```
+
+**Reaction breakdown (by type):**
+```sql
+SELECT extractJSONString(body, '$.reaction_type.value') AS rtype, count()
+FROM posts
+WHERE deleted = 0
+  AND collection_name = 'reactions'
+  AND hasToken(body, '{post_id}')
+GROUP BY rtype;
+```
+
+Returns: `like: 35, love: 5, laugh: 2`.
+
+**Your reaction:** Check if you've reacted.
+```sql
+SELECT body FROM posts
+WHERE deleted = 0
+  AND collection_name = 'reactions'
+  AND author_key = 'jacoby149'
+  AND hasToken(body, '{post_id}');
+```
+
+If a row exists, show the active reaction type. Tap again → tombstone old reaction, insert new one.
+
+**Comments:** Posts in the `comments` collection with a ref to this post.
+```sql
+SELECT p.post_id, p.author_key, p.body, p.created_at
+FROM posts p
+WHERE p.deleted = 0
+  AND p.collection_name = 'comments'
+  AND hasToken(p.body, '{post_id}')
+  AND extractJSONString(p.body, '$.parent_ref.value') IS NULL  -- top-level only
+ORDER BY p.created_at ASC;
+```
+
+**Replies to a comment:** Same query, filtered by parent_ref.
+```sql
+SELECT p.post_id, p.author_key, p.body, p.created_at
+FROM posts p
+WHERE p.deleted = 0
+  AND p.collection_name = 'comments'
+  AND hasToken(p.body, '{post_id}')
+  AND extractJSONString(p.body, '$.parent_ref.value') = '{comment_id}'
+ORDER BY p.created_at ASC;
+```
+
+**Comment count:**
+```sql
+SELECT count() FROM posts
+WHERE deleted = 0
+  AND collection_name = 'comments'
+  AND hasToken(body, '{post_id}');
+```
+
+## React to a Post
+
+```
+User taps ❤️
+  → POST /jacoby149/reactions
+     { "ref": {"type": "ref", "value": "{post_id}"},
+       "reaction_type": {"type": "text", "value": "like"},
+       "groups": ["web10-dev"] }
+  → API: INSERT INTO posts (jacoby149's collection)
+  → API: INSERT INTO post_groups (web10-dev, so others can see your reaction)
+```
+
+The reaction is a post. It lives in your collection. It's attached to the same group as the original post so group members can see it.
+
+## Comment on a Post
+
+```
+User types comment, taps send
+  → POST /jacoby149/comments
+     { "ref": {"type": "ref", "value": "{post_id}"},
+       "text": {"type": "text", "value": "this is fire"},
+       "groups": ["web10-dev"] }
+  → API: INSERT INTO posts
+  → API: INSERT INTO post_groups
+```
+
+Reply to a comment: add `parent_ref` to the body. Same endpoint. Same table.
+
+## The Data Flow
+
+```
+User opens post detail
+  → GET /jacoby149/posts/{post_id}        (the post)
+  → query: reactions + count               (posts table, reactions collection)
+  → query: comments + count                (posts table, comments collection)
+  → query: your reaction                   (posts table, reactions collection)
+  → parallel: resolve author avatars
+  → render
+```
+
+Five parallel queries. One table. Different collections and filters.
+
+## TODO
+
+- [ ] Reaction toggle — tap to react, tap again to change, tap again to remove
+- [ ] Comment threading — nested replies via parent_ref
+- [ ] Comment pagination — load more on scroll
+- [ ] Share flow — attach post to a different group (copy the post_groups entry)
+- [ ] Report post — INSERT into a moderation table (future)
+- [ ] Reaction animation — client-side, no protocol impact
+
+## Proof
+
+Post detail is one post read, plus queries for reactions and comments — all posts in the same table. The `ref` type links everything. The `collection_name` distinguishes reactions from comments from posts. No dedicated tables. No dedicated endpoints. The protocol handles it.

--- a/knowledge/knowledge-base/web10-social-v3/post-detail.md
+++ b/knowledge/knowledge-base/web10-social-v3/post-detail.md
@@ -26,40 +26,40 @@ alice · 1h ago
 
 ## Protocol Mapping
 
-**The post:** Direct read by post_id.
+**The post:** Direct read by doc_id.
 ```
-GET /jacoby149/posts/{post_id}
+GET /jacoby149/posts/{doc_id}
 → check group permissions → allowed
 → return post with presigned media URLs
 ```
 
 **Reactions:** Posts in the `reactions` collection with a ref to this post.
 ```sql
-SELECT p.post_id, p.author_key, p.body, p.created_at
-FROM posts p
+SELECT p.doc_id, p.author_key, p.body, p.created_at
+FROM documents p
 WHERE p.deleted = 0
   AND p.collection_name = 'reactions'
-  AND hasToken(p.body, '{post_id}')
+  AND hasToken(p.body, '{doc_id}')
 ORDER BY p.created_at DESC;
 ```
 
-The body contains `{ "ref": {"type": "ref", "value": "{post_id}"}, "reaction_type": {"type": "text", "value": "like"} }`.
+The body contains `{ "ref": {"type": "ref", "value": "{doc_id}"}, "reaction_type": {"type": "text", "value": "like"} }`.
 
 **Reaction count:**
 ```sql
-SELECT count() FROM posts
+SELECT count() FROM documents
 WHERE deleted = 0
   AND collection_name = 'reactions'
-  AND hasToken(body, '{post_id}');
+  AND hasToken(body, '{doc_id}');
 ```
 
 **Reaction breakdown (by type):**
 ```sql
 SELECT extractJSONString(body, '$.reaction_type.value') AS rtype, count()
-FROM posts
+FROM documents
 WHERE deleted = 0
   AND collection_name = 'reactions'
-  AND hasToken(body, '{post_id}')
+  AND hasToken(body, '{doc_id}')
 GROUP BY rtype;
 ```
 
@@ -67,43 +67,43 @@ Returns: `like: 35, love: 5, laugh: 2`.
 
 **Your reaction:** Check if you've reacted.
 ```sql
-SELECT body FROM posts
+SELECT body FROM documents
 WHERE deleted = 0
   AND collection_name = 'reactions'
   AND author_key = 'jacoby149'
-  AND hasToken(body, '{post_id}');
+  AND hasToken(body, '{doc_id}');
 ```
 
 If a row exists, show the active reaction type. Tap again → tombstone old reaction, insert new one.
 
 **Comments:** Posts in the `comments` collection with a ref to this post.
 ```sql
-SELECT p.post_id, p.author_key, p.body, p.created_at
-FROM posts p
+SELECT p.doc_id, p.author_key, p.body, p.created_at
+FROM documents p
 WHERE p.deleted = 0
   AND p.collection_name = 'comments'
-  AND hasToken(p.body, '{post_id}')
+  AND hasToken(p.body, '{doc_id}')
   AND extractJSONString(p.body, '$.parent_ref.value') IS NULL  -- top-level only
 ORDER BY p.created_at ASC;
 ```
 
 **Replies to a comment:** Same query, filtered by parent_ref.
 ```sql
-SELECT p.post_id, p.author_key, p.body, p.created_at
-FROM posts p
+SELECT p.doc_id, p.author_key, p.body, p.created_at
+FROM documents p
 WHERE p.deleted = 0
   AND p.collection_name = 'comments'
-  AND hasToken(p.body, '{post_id}')
+  AND hasToken(p.body, '{doc_id}')
   AND extractJSONString(p.body, '$.parent_ref.value') = '{comment_id}'
 ORDER BY p.created_at ASC;
 ```
 
 **Comment count:**
 ```sql
-SELECT count() FROM posts
+SELECT count() FROM documents
 WHERE deleted = 0
   AND collection_name = 'comments'
-  AND hasToken(body, '{post_id}');
+  AND hasToken(body, '{doc_id}');
 ```
 
 ## React to a Post
@@ -111,11 +111,11 @@ WHERE deleted = 0
 ```
 User taps ❤️
   → POST /jacoby149/reactions
-     { "ref": {"type": "ref", "value": "{post_id}"},
+     { "ref": {"type": "ref", "value": "{doc_id}"},
        "reaction_type": {"type": "text", "value": "like"},
        "groups": ["web10-dev"] }
-  → API: INSERT INTO posts (jacoby149's collection)
-  → API: INSERT INTO post_groups (web10-dev, so others can see your reaction)
+  → API: INSERT INTO documents (jacoby149's collection)
+  → API: INSERT INTO doc_groups (web10-dev, so others can see your reaction)
 ```
 
 The reaction is a post. It lives in your collection. It's attached to the same group as the original post so group members can see it.
@@ -125,11 +125,11 @@ The reaction is a post. It lives in your collection. It's attached to the same g
 ```
 User types comment, taps send
   → POST /jacoby149/comments
-     { "ref": {"type": "ref", "value": "{post_id}"},
+     { "ref": {"type": "ref", "value": "{doc_id}"},
        "text": {"type": "text", "value": "this is fire"},
        "groups": ["web10-dev"] }
-  → API: INSERT INTO posts
-  → API: INSERT INTO post_groups
+  → API: INSERT INTO documents
+  → API: INSERT INTO doc_groups
 ```
 
 Reply to a comment: add `parent_ref` to the body. Same endpoint. Same table.
@@ -138,10 +138,10 @@ Reply to a comment: add `parent_ref` to the body. Same endpoint. Same table.
 
 ```
 User opens post detail
-  → GET /jacoby149/posts/{post_id}        (the post)
-  → query: reactions + count               (posts table, reactions collection)
-  → query: comments + count                (posts table, comments collection)
-  → query: your reaction                   (posts table, reactions collection)
+  → GET /jacoby149/posts/{doc_id}        (the post)
+  → query: reactions + count               (documents table, reactions collection)
+  → query: comments + count                (documents table, comments collection)
+  → query: your reaction                   (documents table, reactions collection)
   → parallel: resolve author avatars
   → render
 ```
@@ -153,7 +153,7 @@ Five parallel queries. One table. Different collections and filters.
 - [ ] Reaction toggle — tap to react, tap again to change, tap again to remove
 - [ ] Comment threading — nested replies via parent_ref
 - [ ] Comment pagination — load more on scroll
-- [ ] Share flow — attach post to a different group (copy the post_groups entry)
+- [ ] Share flow — attach post to a different group (copy the doc_groups entry)
 - [ ] Report post — INSERT into a moderation table (future)
 - [ ] Reaction animation — client-side, no protocol impact
 

--- a/knowledge/knowledge-base/web10-social-v3/search.md
+++ b/knowledge/knowledge-base/web10-social-v3/search.md
@@ -27,7 +27,7 @@ Posts:
 ```sql
 SELECT p.author_key, extractJSONString(p.body, '$.bio.value') AS bio,
        extractJSONString(p.body, '$.avatar.value') AS avatar
-FROM posts p
+FROM documents p
 WHERE p.deleted = 0
   AND p.collection_name = 'profile'
   AND (p.author_key LIKE '%query%'
@@ -36,7 +36,7 @@ WHERE p.deleted = 0
 
 Or better — ClickHouse full-text search on the body JSON:
 ```sql
-SELECT author_key, body FROM posts
+SELECT author_key, body FROM documents
 WHERE deleted = 0
   AND collection_name = 'profile'
   AND match(body, '.*query.*');
@@ -52,8 +52,8 @@ WHERE deleted = 0
 
 **Search posts:** Query posts by body text and tags.
 ```sql
-SELECT p.post_id, p.author_key, p.body, p.created_at
-FROM posts p
+SELECT p.doc_id, p.author_key, p.body, p.created_at
+FROM documents p
 WHERE p.deleted = 0
   AND p.collection_name = 'posts'
   AND (match(p.body, '.*query.*')
@@ -64,12 +64,12 @@ LIMIT 50;
 
 **Ngram index (better search):** ClickHouse has ngram functions for fuzzy search.
 ```sql
-SELECT post_id, author_key, body, created_at,
+SELECT doc_id, author_key, body, created_at,
        sum(ngramDistance('query', p.body)) AS score
-FROM posts
+FROM documents
 WHERE deleted = 0
   AND collection_name = 'posts'
-GROUP BY post_id, author_key, body, created_at
+GROUP BY doc_id, author_key, body, created_at
 HAVING score > 0
 ORDER BY score DESC
 LIMIT 50;
@@ -87,7 +87,7 @@ User types in search bar
   → render combined results
 ```
 
-Three parallel queries. One table (posts) for people and posts. One table (group_contracts) for groups.
+Three parallel queries. One table (documents) for people and posts. One table (group_contracts) for groups.
 
 ## Search Optimization
 
@@ -106,11 +106,11 @@ Day one: ngram index. Eventually: tokenbf or Elasticsearch if needed.
 
 - [ ] Debounced search input — 300ms delay
 - [ ] Search result tabs — People, Groups, Posts
-- [ ] Ngram index on posts.body — CREATE INDEX on the posts table
+- [ ] Ngram index on documents.body — CREATE INDEX on the documents table
 - [ ] Group member count in results — JOIN with group_members count
 - [ ] Recent searches — client-side localStorage
 - [ ] Search within a group — `?group=web10-dev&q=query`
 
 ## Proof
 
-Search is queries on the posts and group_contracts tables. No dedicated search index. No mirrors. No sync. ClickHouse full-text search handles it. The protocol handles it.
+Search is queries on the documents and group_contracts tables. No dedicated search index. No mirrors. No sync. ClickHouse full-text search handles it. The protocol handles it.

--- a/knowledge/knowledge-base/web10-social-v3/search.md
+++ b/knowledge/knowledge-base/web10-social-v3/search.md
@@ -1,0 +1,116 @@
+# Search
+
+Find people, groups, and posts.
+
+## What the Screen Shows
+
+```
+Search
+─────────────────────
+🔍 type to search...
+
+People:
+  [avatar] jacoby149 — builder
+  [avatar] alice — jazz enthusiast
+
+Groups:
+  web10-dev — 100k members, open
+  jazz-collectors — 500 members, request
+
+Posts:
+  jacoby149 · 2h ago — "just shipped the new groups feature"
+```
+
+## Protocol Mapping
+
+**Search people:** Query profiles by bio text.
+```sql
+SELECT p.author_key, extractJSONString(p.body, '$.bio.value') AS bio,
+       extractJSONString(p.body, '$.avatar.value') AS avatar
+FROM posts p
+WHERE p.deleted = 0
+  AND p.collection_name = 'profile'
+  AND (p.author_key LIKE '%query%'
+       OR extractJSONString(p.body, '$.bio.value') ILIKE '%query%');
+```
+
+Or better — ClickHouse full-text search on the body JSON:
+```sql
+SELECT author_key, body FROM posts
+WHERE deleted = 0
+  AND collection_name = 'profile'
+  AND match(body, '.*query.*');
+```
+
+**Search groups:** Query group_contracts by name.
+```sql
+SELECT group_id, name, join_policy, admin_key
+FROM group_contracts
+WHERE deleted = 0
+  AND (group_id ILIKE '%query%' OR name ILIKE '%query%');
+```
+
+**Search posts:** Query posts by body text and tags.
+```sql
+SELECT p.post_id, p.author_key, p.body, p.created_at
+FROM posts p
+WHERE p.deleted = 0
+  AND p.collection_name = 'posts'
+  AND (match(p.body, '.*query.*')
+       OR has(p.tags, 'query'))
+ORDER BY p.created_at DESC
+LIMIT 50;
+```
+
+**Ngram index (better search):** ClickHouse has ngram functions for fuzzy search.
+```sql
+SELECT post_id, author_key, body, created_at,
+       sum(ngramDistance('query', p.body)) AS score
+FROM posts
+WHERE deleted = 0
+  AND collection_name = 'posts'
+GROUP BY post_id, author_key, body, created_at
+HAVING score > 0
+ORDER BY score DESC
+LIMIT 50;
+```
+
+## The Data Flow
+
+```
+User types in search bar
+  → debounce 300ms
+  → GET /search?q=query&type=people
+  → GET /search?q=query&type=groups
+  → GET /search?q=query&type=posts
+  → parallel: all three queries
+  → render combined results
+```
+
+Three parallel queries. One table (posts) for people and posts. One table (group_contracts) for groups.
+
+## Search Optimization
+
+**People search:** Profile posts are few. Full scan is fine. Index the author_key and bio fields.
+
+**Groups search:** Group contracts are few. Full scan is fine.
+
+**Posts search:** This is the heavy one. Options:
+1. **ClickHouse ngram index** — built-in, no extra infrastructure
+2. **ClickHouse tokenbf index** — bloom filter for token presence, faster than full scan
+3. **Elasticsearch** — external search engine, sync from ClickHouse. Overkill for day one.
+
+Day one: ngram index. Eventually: tokenbf or Elasticsearch if needed.
+
+## TODO
+
+- [ ] Debounced search input — 300ms delay
+- [ ] Search result tabs — People, Groups, Posts
+- [ ] Ngram index on posts.body — CREATE INDEX on the posts table
+- [ ] Group member count in results — JOIN with group_members count
+- [ ] Recent searches — client-side localStorage
+- [ ] Search within a group — `?group=web10-dev&q=query`
+
+## Proof
+
+Search is queries on the posts and group_contracts tables. No dedicated search index. No mirrors. No sync. ClickHouse full-text search handles it. The protocol handles it.

--- a/knowledge/knowledge-base/web10-social-v3/settings.md
+++ b/knowledge/knowledge-base/web10-social-v3/settings.md
@@ -1,0 +1,149 @@
+# Settings / Privacy
+
+Manage service contracts, groups, blocking, and account-level controls.
+
+## What the Screen Shows
+
+```
+Settings
+─────────────────────
+
+App Access
+  twitter-clone.web10.com  [Revoke]
+  music.web10.com          [Revoke]
+  [Kill all app access]
+
+Groups
+  jacoby149.public          [Manage]
+  jacoby149.close-friends   [Manage]
+  jazz-collectors            [Block sharing] [Leave]
+
+Blocked Users
+  spam-bot-123   [Unblock]
+  troll-account  [Unblock]
+
+Account
+  [Make everything private]
+  [Export data]
+  [Delete account]
+```
+
+## Protocol Mapping
+
+**App access (service contracts):**
+```sql
+SELECT service_name, allowed_origin
+FROM service_contracts
+WHERE user_key = 'jacoby149' AND deleted = 0;
+```
+
+**Revoke app access:**
+```sql
+INSERT INTO service_contracts
+SELECT user_key, service_name, allowed_origin, created_at, now(), 1
+FROM service_contracts
+WHERE user_key = 'jacoby149'
+  AND allowed_origin = 'twitter-clone.web10.com'
+  AND deleted = 0;
+```
+
+**Kill all app access:**
+```sql
+INSERT INTO service_contracts
+SELECT user_key, service_name, allowed_origin, created_at, now(), 1
+FROM service_contracts
+WHERE user_key = 'jacoby149' AND deleted = 0;
+```
+One tombstone query. All origins revoked. No website touches your data.
+
+**Blocked users:**
+```sql
+SELECT blocked_key FROM user_blacklist
+WHERE user_key = 'jacoby149';
+```
+
+**Block a user:**
+```sql
+INSERT INTO user_blacklist VALUES ('jacoby149', 'spammer', now());
+```
+
+**Unblock a user:**
+```sql
+-- No tombstone for MergeTree — just DELETE
+ALTER TABLE user_blacklist DELETE
+WHERE user_key = 'jacoby149' AND blocked_key = 'spammer';
+```
+
+**Block sharing with a group:**
+```sql
+INSERT INTO user_group_sharing VALUES ('jacoby149', 'jazz-collectors', 0, now(), now(), 0);
+```
+
+**Make everything private:** Bulk tombstone all post_groups entries.
+```sql
+INSERT INTO post_groups (post_id, group_id, permission, created_at, updated_at, deleted)
+SELECT pg.post_id, pg.group_id, pg.permission, pg.created_at, now(), 1
+FROM post_groups pg
+JOIN posts p ON pg.post_id = p.post_id
+WHERE p.author_key = 'jacoby149'
+  AND pg.deleted = 0;
+```
+One query. All posts detached from all groups. Everything goes dark.
+
+**Export data:** Query all your posts, groups, and contracts. Return as JSON.
+```sql
+SELECT * FROM posts WHERE author_key = 'jacoby149' AND deleted = 0;
+SELECT * FROM service_contracts WHERE user_key = 'jacoby149' AND deleted = 0;
+SELECT gm.group_id FROM group_members gm WHERE gm.member_key = 'jacoby149' AND gm.deleted = 0;
+```
+
+**Delete account:** Tombstone everything.
+```sql
+-- Tombstone all posts
+INSERT INTO posts SELECT post_id, author_key, collection_name, body, discoverable, tags, created_at, now(), 1 FROM posts WHERE author_key = 'jacoby149' AND deleted = 0;
+
+-- Tombstone all service contracts
+INSERT INTO service_contracts SELECT user_key, service_name, allowed_origin, created_at, now(), 1 FROM service_contracts WHERE user_key = 'jacoby149' AND deleted = 0;
+
+-- Tombstone all group memberships
+INSERT INTO group_members SELECT group_id, member_key, role, joined_at, now(), 1 FROM group_members WHERE member_key = 'jacoby149' AND deleted = 0;
+```
+
+## The Data Flow
+
+```
+User opens /settings
+  → GET /service-contracts          (app access list)
+  → GET /groups?member=jacoby149   (groups list)
+  → GET /user-blacklist             (blocked users)
+  → parallel: all three queries
+  → render
+```
+
+Three queries. No joins. Clean.
+
+## Per-Group Blacklist
+
+The per-group blacklist is managed from the group management screen, not settings. But it's worth noting:
+
+```
+jazz-collectors → per-group blacklist: dave
+  → INSERT INTO group_blacklist ('jacoby149', 'jazz-collectors', 'dave', now())
+  → dave is still a member
+  → dave sees everyone's posts in jazz-collectors
+  → dave does NOT see jacoby149's posts in jazz-collectors
+```
+
+## TODO
+
+- [ ] Service contract management — list, revoke, kill switch
+- [ ] Block/unblock user — user_blacklist CRUD
+- [ ] Per-group block sharing — user_group_sharing toggle
+- [ ] Make everything private — bulk tombstone post_groups
+- [ ] Export data — query all user data, return JSON blob
+- [ ] Delete account — tombstone everything, TTL cleans up
+- [ ] Notification preferences — per-type toggle (notifications table)
+
+## Proof
+
+Settings is CRUD on contract and blacklist tables. Kill switch is a bulk tombstone. Make everything private is a bulk tombstone. Block a user is an insert. The protocol handles sovereignty through data operations, not special endpoints. The user controls their data.

--- a/knowledge/knowledge-base/web10-social-v3/settings.md
+++ b/knowledge/knowledge-base/web10-social-v3/settings.md
@@ -79,12 +79,12 @@ WHERE user_key = 'jacoby149' AND blocked_key = 'spammer';
 INSERT INTO user_group_sharing VALUES ('jacoby149', 'jazz-collectors', 0, now(), now(), 0);
 ```
 
-**Make everything private:** Bulk tombstone all post_groups entries.
+**Make everything private:** Bulk tombstone all doc_groups entries.
 ```sql
-INSERT INTO post_groups (post_id, group_id, permission, created_at, updated_at, deleted)
-SELECT pg.post_id, pg.group_id, pg.permission, pg.created_at, now(), 1
-FROM post_groups pg
-JOIN posts p ON pg.post_id = p.post_id
+INSERT INTO doc_groups (doc_id, group_id, permission, created_at, updated_at, deleted)
+SELECT pg.doc_id, pg.group_id, pg.permission, pg.created_at, now(), 1
+FROM doc_groups pg
+JOIN documents p ON pg.doc_id = p.doc_id
 WHERE p.author_key = 'jacoby149'
   AND pg.deleted = 0;
 ```
@@ -92,7 +92,7 @@ One query. All posts detached from all groups. Everything goes dark.
 
 **Export data:** Query all your posts, groups, and contracts. Return as JSON.
 ```sql
-SELECT * FROM posts WHERE author_key = 'jacoby149' AND deleted = 0;
+SELECT * FROM documents WHERE author_key = 'jacoby149' AND deleted = 0;
 SELECT * FROM service_contracts WHERE user_key = 'jacoby149' AND deleted = 0;
 SELECT gm.group_id FROM group_members gm WHERE gm.member_key = 'jacoby149' AND gm.deleted = 0;
 ```
@@ -100,7 +100,7 @@ SELECT gm.group_id FROM group_members gm WHERE gm.member_key = 'jacoby149' AND g
 **Delete account:** Tombstone everything.
 ```sql
 -- Tombstone all posts
-INSERT INTO posts SELECT post_id, author_key, collection_name, body, discoverable, tags, created_at, now(), 1 FROM posts WHERE author_key = 'jacoby149' AND deleted = 0;
+INSERT INTO documents SELECT doc_id, author_key, collection_name, body, discoverable, tags, created_at, now(), 1 FROM documents WHERE author_key = 'jacoby149' AND deleted = 0;
 
 -- Tombstone all service contracts
 INSERT INTO service_contracts SELECT user_key, service_name, allowed_origin, created_at, now(), 1 FROM service_contracts WHERE user_key = 'jacoby149' AND deleted = 0;
@@ -139,7 +139,7 @@ jazz-collectors → per-group blacklist: dave
 - [ ] Service contract management — list, revoke, kill switch
 - [ ] Block/unblock user — user_blacklist CRUD
 - [ ] Per-group block sharing — user_group_sharing toggle
-- [ ] Make everything private — bulk tombstone post_groups
+- [ ] Make everything private — bulk tombstone doc_groups
 - [ ] Export data — query all user data, return JSON blob
 - [ ] Delete account — tombstone everything, TTL cleans up
 - [ ] Notification preferences — per-type toggle (notifications table)

--- a/knowledge/knowledge-base/web10-social-v3/your-profile.md
+++ b/knowledge/knowledge-base/web10-social-v3/your-profile.md
@@ -1,0 +1,82 @@
+# Your Profile
+
+You visit your own profile. You see your avatar, bio, groups, and posts.
+
+## What the Screen Shows
+
+```
+[avatar] jacoby149
+         bio text here
+
+Groups:    Posts:    Followers:
+3          42        1,203
+
+[jacoby149.public]     [open]
+[jacoby149.close-friends] [invite only]
+[jazz-collectors]        [request]
+
+--- posts ---
+post 1 | 2h ago | [like] [comment]
+post 2 | 1d ago | [like] [comment]
+```
+
+## Protocol Mapping
+
+**Avatar and bio:** A post in `jacoby149.profile`.
+```
+GET /jacoby149/profile
+→ { "avatar": {"type": "minio", "value": "jacoby149/avatar.png"}, "bio": {"type": "text", "value": "builder"} }
+```
+API converts minio to presigned URL. One CRUD call.
+
+**Groups you belong to:** Group membership query.
+```
+GET /groups?member=jacoby149
+→ [jacoby1449.public, jacoby149.close-friends, jazz-collectors]
+```
+For each group, fetch metadata from `group_contracts`.
+
+**Groups you admin:** Filter by admin key.
+```
+SELECT group_id, name, join_policy FROM group_contracts
+WHERE admin_key = 'jacoby149' AND deleted = 0;
+```
+
+**Follower count:** Group membership count.
+```
+SELECT count() FROM group_members
+WHERE group_id = 'jacoby149.followers' AND deleted = 0;
+```
+
+**Your posts:** CRUD discover.
+```
+GET /jacoby149/posts?discover=true&author=jacoby149
+→ posts in groups jacoby149 belongs to (all of them — you're the author)
+```
+Or simpler: `GET /jacoby149/posts` (no discover flag — you see your own posts regardless of groups).
+
+## The Data Flow
+
+```
+User opens /jacoby149
+  → GET /jacoby149/profile          (avatar, bio)
+  → GET /groups?member=jacoby149   (groups list)
+  → GET /jacoby149/posts           (your posts)
+  → parallel: group metadata for each group
+  → parallel: follower count
+  → render
+```
+
+Four parallel calls. No joins. No mirrors.
+
+## TODO
+
+- [ ] Avatar upload flow — presigned MinIO PUT, then write profile post with minio ref
+- [ ] Bio edit — update profile post (ReplacingMergeTree, higher updated_at)
+- [ ] Group join policy display — fetch from group_contracts
+- [ ] Post list pagination — LIMIT/OFFSET or keyset pagination on created_at
+- [ ] Follower count caching — Redis counter, increment/decrement on group membership change
+
+## Proof
+
+Your profile is one collection, one groups query, and some counts. No dedicated profile endpoint. No user table. No followers table. The protocol handles it.

--- a/knowledge/knowledge-base/web10-v3/contract-schemas.md
+++ b/knowledge/knowledge-base/web10-v3/contract-schemas.md
@@ -1,0 +1,153 @@
+# Contract Schemas
+
+Service contracts and group contracts have no tables in the schema. This doc closes the gap.
+
+## Service Contracts
+
+Which websites can access your service. CORS. App-level. Browser-enforced.
+
+```sql
+CREATE TABLE service_contracts (
+    user_key String,           -- owner of the service
+    service_name String,       -- 'posts', 'mail', 'notes'
+    allowed_origin String,     -- 'twitter-clone.web10.com'
+    created_at DateTime64(3),
+    updated_at DateTime64(3),
+    deleted UInt8 DEFAULT 0
+) ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY (user_key, service_name, allowed_origin);
+```
+
+**Query:** can `twitter-clone.web10.com` access `alice.posts`?
+```sql
+SELECT 1 FROM service_contracts
+WHERE user_key = 'alice'
+  AND service_name = 'posts'
+  AND allowed_origin = 'twitter-clone.web10.com'
+  AND deleted = 0
+LIMIT 1;
+```
+
+**Kill switch:** revoke all origins for a user.
+```sql
+INSERT INTO service_contracts
+SELECT user_key, service_name, allowed_origin, created_at, now(), 1
+FROM service_contracts
+WHERE user_key = 'alice' AND deleted = 0;
+```
+
+Tombstone-append. Background job compacts. Same pattern everywhere.
+
+## Provider Service Contracts
+
+Which apps can participate on this node. Server-enforced. Provider admin manages.
+
+```sql
+CREATE TABLE provider_service_contracts (
+    provider_key String,       -- 'provider-a'
+    allowed_origin String,     -- 'twitter-clone.web10.com'
+    created_at DateTime64(3),
+    updated_at DateTime64(3),
+    deleted UInt8 DEFAULT 0
+) ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY (provider_key, allowed_origin);
+```
+
+**Query:** can `spamapp.com` participate on `provider-a`?
+```sql
+SELECT 1 FROM provider_service_contracts
+WHERE provider_key = 'provider-a'
+  AND allowed_origin = 'spamapp.com'
+  AND deleted = 0
+LIMIT 1;
+```
+
+Blocked apps simply have no row. No row = denied.
+
+## Group Contracts
+
+Group metadata. Join policy. Settings.
+
+```sql
+CREATE TABLE group_contracts (
+    group_id String,
+    name String,
+    admin_key String,
+    join_policy String,        -- 'open', 'request', 'invite_only'
+    settings String,           -- JSON: { "description": "...", "avatar_url": "..." }
+    created_at DateTime64(3),
+    updated_at DateTime64(3),
+    deleted UInt8 DEFAULT 0
+) ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY group_id;
+```
+
+**Query:** what's the join policy for `alice.followers`?
+```sql
+SELECT join_policy, admin_key, name
+FROM group_contracts
+WHERE group_id = 'alice.followers' AND deleted = 0;
+```
+
+## Group Membership Requests
+
+Pending join requests. The "request" join policy needs a queue.
+
+```sql
+CREATE TABLE group_join_requests (
+    group_id String,
+    requester_key String,
+    status String,             -- 'pending', 'approved', 'denied'
+    requested_at DateTime64(3),
+    resolved_at DateTime64(3),
+    updated_at DateTime64(3),
+    deleted UInt8 DEFAULT 0
+) ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY (group_id, requester_key);
+```
+
+**Flow:**
+```
+Bob requests to join alice.followers
+  → INSERT INTO group_join_requests ('alice.followers', 'bob', 'pending', ...)
+Alice approves
+  → UPDATE status to 'approved', resolved_at = now()
+  → INSERT INTO group_members ('alice.followers', 'bob', 'member', ...)
+Alice denies
+  → UPDATE status to 'denied', resolved_at = now()
+```
+
+## Block Sharing
+
+Per-user, per-group toggle. "Pause sharing without leaving."
+
+```sql
+CREATE TABLE user_group_sharing (
+    user_key String,           -- the user controlling sharing
+    group_id String,
+    sharing_enabled UInt8,     -- 1 = sharing, 0 = blocked
+    created_at DateTime64(3),
+    updated_at DateTime64(3),
+    deleted UInt8 DEFAULT 0
+) ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY (user_key, group_id);
+```
+
+**Query:** is Alice sharing with `jazz-collectors`?
+```sql
+SELECT sharing_enabled FROM user_group_sharing
+WHERE user_key = 'alice'
+  AND group_id = 'jazz-collectors'
+  AND deleted = 0;
+```
+
+Default is `1` (sharing on). If the row is missing, sharing is on. Toggle to `0` → the discover query filters out Alice's posts for this group. Toggle back to `1` → posts reappear. Reversible.
+
+## Summary
+
+All contract tables follow the same patterns:
+- `ReplacingMergeTree(updated_at)` for updates
+- `deleted UInt8 DEFAULT 0` for tombstones
+- Background job compacts tombstones on schedule
+- No row = denied (service contracts, provider contracts)
+- Missing row = enabled (sharing toggle — default on)

--- a/knowledge/knowledge-base/web10-v3/cross-app-sharing.md
+++ b/knowledge/knowledge-base/web10-v3/cross-app-sharing.md
@@ -32,7 +32,7 @@ Bob's outbox:
   post-1 → groups: ["alice.inbox"]
 
 Alice discovers:
-  SELECT * FROM posts
+  SELECT * FROM documents
   WHERE group_id = 'alice.inbox'
   → post-1 (bob's mail)
 ```
@@ -78,7 +78,7 @@ Bob's outbox:
   post-1 → groups: ["alice.inbox"]
 
 Alice's saved_mail:
-  saved-1 → body: { "from": "bob", "text": "hi", "original_post_id": "post-1" }
+  saved-1 → body: { "from": "bob", "text": "hi", "original_doc_id": "post-1" }
 ```
 
 The save is opt-in. The ephemeral default is the feature. The save is the app's choice. Slightly fights the manifesto — the protocol makes it hard to save — but the user chooses. The mail app bridges the gap.
@@ -109,7 +109,7 @@ Each message lives in the sender's collection. The group is the bridge. Both can
 
 ## The Comments Pattern
 
-Open. Anyone can participate. Comments are posts with a `ref` to the parent post.
+Open. Anyone can participate. Comments are documents with a `ref` to the parent post.
 
 ```
 post-123-comments → admin: alice, open join
@@ -120,7 +120,7 @@ Alice's post → no groups (private by default).
 Bob's comment → a post in `bob.comments` with `ref: "post-123"`, attached to `post-123-comments` group.
 Charlie's reply → a post in `charlie.comments` with `ref: "post-123"` and `parent_ref: "bob-comment-xyz"`, attached to `post-123-comments` group.
 
-Alice discovers all comments via the group. The `ref` in the JSON body links back to the parent. The `parent_ref` enables threading. No dedicated comments table — just posts with refs.
+Alice discovers all comments via the group. The `ref` in the JSON body links back to the parent. The `parent_ref` enables threading. No dedicated comments table — just documents with refs.
 
 ## The Pattern
 
@@ -162,7 +162,7 @@ post-123-comments → admin: alice, request [Leave]
 
 **Block sharing** — pause sharing without leaving. You stay a member. You still see their posts. They can't see yours. Reversible.
 
-**Opt out all posts** — bulk remove your posts from a group. Reversible.
+**Opt out all documents** — bulk remove your posts from a group. Reversible.
 
 **Make everything private** — remove all groups from all your posts. One click.
 

--- a/knowledge/knowledge-base/web10-v3/cross-app-sharing.md
+++ b/knowledge/knowledge-base/web10-v3/cross-app-sharing.md
@@ -62,6 +62,27 @@ Bob owns his mail. Alice owns her inbox group. The group is the bridge.
 | Request | Anyone can request, admin approves or denies |
 | Invite only | Only people the admin explicitly adds can join |
 
+## The Saved Mail Pattern
+
+Sender deletion is the default. Bob deletes his mail, Alice's view vanishes. But Alice can save mail she wants to keep.
+
+**How it works:**
+1. Alice's mail app has a `saved_mail` service: `service:saved_mail → allowed: mailapp.com`
+2. Alice taps "save" on Bob's mail
+3. The mail app reads Bob's post from the inbox group (Alice has read permission)
+4. The mail app writes a copy to Alice's `saved_mail` collection (her own data, her app, no extra auth)
+5. Bob deletes the original → Alice's saved copy stays. She owns it.
+
+```
+Bob's outbox:
+  post-1 → groups: ["alice.inbox"]
+
+Alice's saved_mail:
+  saved-1 → body: { "from": "bob", "text": "hi", "original_post_id": "post-1" }
+```
+
+The save is opt-in. The ephemeral default is the feature. The save is the app's choice. Slightly fights the manifesto — the protocol makes it hard to save — but the user chooses. The mail app bridges the gap.
+
 ## The Notes Pattern
 
 Personal. No sharing.
@@ -88,17 +109,18 @@ Each message lives in the sender's collection. The group is the bridge. Both can
 
 ## The Comments Pattern
 
-Open. Anyone can participate.
+Open. Anyone can participate. Comments are posts with a `ref` to the parent post.
 
 ```
 post-123-comments → admin: alice, open join
 ```
 
 Alice's post → no groups (private by default).
-Bob's comment → lives in bob.comments, attached to `post-123-comments` group.
-Charlie's comment → lives in charlie.comments, attached to `post-123-comments` group.
 
-Alice discovers all comments via the group. Anyone can join the group and comment. Alice can remove anyone.
+Bob's comment → a post in `bob.comments` with `ref: "post-123"`, attached to `post-123-comments` group.
+Charlie's reply → a post in `charlie.comments` with `ref: "post-123"` and `parent_ref: "bob-comment-xyz"`, attached to `post-123-comments` group.
+
+Alice discovers all comments via the group. The `ref` in the JSON body links back to the parent. The `parent_ref` enables threading. No dedicated comments table — just posts with refs.
 
 ## The Pattern
 

--- a/knowledge/knowledge-base/web10-v3/federated-groups.md
+++ b/knowledge/knowledge-base/web10-v3/federated-groups.md
@@ -56,9 +56,9 @@ WHERE group_id = 'jazz-collectors'
 -- Returns: provider-a
 
 -- Federated query to provider-a
-SELECT * FROM remote('provider-a', 'posts', 'user', 'password')
-WHERE post_id IN (
-  SELECT post_id FROM remote('provider-a', 'post_groups', 'user', 'password')
+SELECT * FROM remote('provider-a', 'documents', 'user', 'password')
+WHERE doc_id IN (
+  SELECT doc_id FROM remote('provider-a', 'doc_groups', 'user', 'password')
   WHERE group_id = 'jazz-collectors'
 )
   AND deleted = 0

--- a/knowledge/knowledge-base/web10-v3/groups.md
+++ b/knowledge/knowledge-base/web10-v3/groups.md
@@ -59,7 +59,7 @@ The service contract is the outer wall. The groups are the inner permissions.
 When you create a post, you pick the groups it belongs to. Those groups already define who sees it.
 
 ```ts
-await createPost({
+await createDocument({
   text: "behind the scenes",
   groups: ["alice.close-friends"]
 });
@@ -69,7 +69,7 @@ Bob sees it because he's a member. Eve doesn't.
 
 A post can belong to multiple groups:
 ```ts
-await createPost({
+await createDocument({
   text: "team update",
   groups: ["alice.close-friends", "web10-dev"]
 });
@@ -99,7 +99,7 @@ The author decides the permission level, not the group. You set it when you atta
 
 ```ts
 await attachToGroup({
-  post_id: "post-1",
+  doc_id: "post-1",
   group_id: "jazz-collectors",
   permission: "read"   // or "write"
 });
@@ -190,7 +190,7 @@ jazz-collectors → [Block sharing]
   [Unblock]
 ```
 
-**Opt out all posts** — bulk remove every post you've attached to a group. Reversible.
+**Opt out all documents** — bulk remove every post you've attached to a group. Reversible.
 
 **Make everything private** — remove all groups from all your posts. One click. Everything goes dark.
 

--- a/knowledge/knowledge-base/web10-v3/overview.md
+++ b/knowledge/knowledge-base/web10-v3/overview.md
@@ -34,13 +34,10 @@ graph TB
     end
 
     subgraph ClickHouse
-        Posts["posts"]
+        Posts["posts (everything)"]
         PostGroups["post_groups"]
-        Reactions["reactions"]
-        Comments["comments"]
         GroupsTable["groups"]
         GroupMembers["group_members"]
-        Engagement["engagement\n(materialized view)"]
     end
 
     subgraph MinIO
@@ -52,9 +49,6 @@ graph TB
     App --> Media
     CRUD --> Posts
     CRUD --> PostGroups
-    CRUD --> Reactions
-    CRUD --> Comments
-    CRUD --> Engagement
     Groups --> GroupsTable
     Groups --> GroupMembers
     Media --> Blobs
@@ -65,11 +59,8 @@ graph TB
     style Media fill:#e3f2fd,stroke:#1565c0,color:#000
     style Posts fill:#fff3e0,stroke:#e65100,color:#000
     style PostGroups fill:#fff3e0,stroke:#e65100,color:#000
-    style Reactions fill:#fff3e0,stroke:#e65100,color:#000
-    style Comments fill:#fff3e0,stroke:#e65100,color:#000
     style GroupsTable fill:#fff3e0,stroke:#e65100,color:#000
     style GroupMembers fill:#fff3e0,stroke:#e65100,color:#000
-    style Engagement fill:#fff3e0,stroke:#e65100,color:#000
     style Blobs fill:#fce4ec,stroke:#c62828,color:#000
 ```
 
@@ -95,9 +86,69 @@ TTL created_at + INTERVAL 90 DAY;
 CREATE TABLE post_groups (
     post_id String,
     group_id String,
-    created_at DateTime64(3)
-) ENGINE = MergeTree()
+    permission String,          -- 'read', 'write' — author decides at attachment time
+    created_at DateTime64(3),
+    updated_at DateTime64(3),
+    deleted UInt8 DEFAULT 0
+) ENGINE = ReplacingMergeTree(updated_at)
 ORDER BY (post_id, group_id);
+
+-- Service contracts. Which websites can access your service. CORS.
+CREATE TABLE service_contracts (
+    user_key String,
+    service_name String,        -- 'posts', 'mail', 'notes'
+    allowed_origin String,      -- 'twitter-clone.web10.com'
+    created_at DateTime64(3),
+    updated_at DateTime64(3),
+    deleted UInt8 DEFAULT 0
+) ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY (user_key, service_name, allowed_origin);
+
+-- Provider service contracts. Which apps can participate on this node.
+CREATE TABLE provider_service_contracts (
+    provider_key String,
+    allowed_origin String,
+    created_at DateTime64(3),
+    updated_at DateTime64(3),
+    deleted UInt8 DEFAULT 0
+) ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY (provider_key, allowed_origin);
+
+-- Group contracts. Join policy, settings.
+CREATE TABLE group_contracts (
+    group_id String,
+    name String,
+    admin_key String,
+    join_policy String,         -- 'open', 'request', 'invite_only'
+    settings String,            -- JSON
+    created_at DateTime64(3),
+    updated_at DateTime64(3),
+    deleted UInt8 DEFAULT 0
+) ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY group_id;
+
+-- Group join requests. Pending approvals for "request" join policy.
+CREATE TABLE group_join_requests (
+    group_id String,
+    requester_key String,
+    status String,              -- 'pending', 'approved', 'denied'
+    requested_at DateTime64(3),
+    resolved_at DateTime64(3),
+    updated_at DateTime64(3),
+    deleted UInt8 DEFAULT 0
+) ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY (group_id, requester_key);
+
+-- User-group sharing toggle. Block sharing without leaving.
+CREATE TABLE user_group_sharing (
+    user_key String,
+    group_id String,
+    sharing_enabled UInt8,      -- 1 = sharing, 0 = blocked
+    created_at DateTime64(3),
+    updated_at DateTime64(3),
+    deleted UInt8 DEFAULT 0
+) ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY (user_key, group_id);
 
 -- User-wide blacklist. Blocks someone entirely.
 CREATE TABLE user_blacklist (
@@ -116,34 +167,10 @@ CREATE TABLE group_blacklist (
 ) ENGINE = MergeTree()
 ORDER BY (user_key, group_id, blocked_key);
 
--- Reactions: append-only. Tombstone deletes.
-CREATE TABLE reactions (
-    reaction_id String,
-    actor_key String,
-    target_post_id String,
-    type String,                -- 'like', 'love', 'laugh', etc.
-    created_at DateTime64(3),
-    deleted UInt8 DEFAULT 0
-) ENGINE = MergeTree()
-ORDER BY (target_post_id, created_at);
-
--- Comments: append-only. ReplacingMergeTree for edits.
-CREATE TABLE comments (
-    comment_id String,
-    actor_key String,
-    target_post_id String,
-    parent_comment_id String,   -- for threading
-    body String,                -- JSON: comment content
-    created_at DateTime64(3),
-    updated_at DateTime64(3),
-    deleted UInt8 DEFAULT 0
-) ENGINE = ReplacingMergeTree(updated_at)
-ORDER BY (target_post_id, created_at);
-
 -- Groups: policy containers. Hold people, not data.
+-- (Metadata like join_policy lives in group_contracts table)
 CREATE TABLE groups (
     group_id String,
-    name String,
     admin_key String,
     created_at DateTime64(3),
     updated_at DateTime64(3),
@@ -161,19 +188,67 @@ CREATE TABLE group_members (
     deleted UInt8 DEFAULT 0
 ) ENGINE = ReplacingMergeTree(updated_at)
 ORDER BY (group_id, member_key);
-
--- Engagement: materialized view, auto-updates on reaction insert.
-CREATE MATERIALIZED VIEW engagement
-TO engagement_base
-AS SELECT
-    target_post_id AS record_id,
-    count() AS reaction_count,
-    count() * 1.0 AS score,
-    now() AS updated_at
-FROM reactions
-WHERE deleted = 0
-GROUP BY target_post_id;
 ```
+
+## Everything Is a Post
+
+No dedicated reactions table. No dedicated comments table. No dedicated follows table. No dedicated social media endpoints. One table. One CRUD. One permission model.
+
+**A reaction is a post:**
+```json
+{
+  "post_id": "react-abc",
+  "author_key": "bob",
+  "collection_name": "reactions",
+  "body": {
+    "ref": {"type": "ref", "value": "post-123"},
+    "reaction_type": {"type": "text", "value": "like"}
+  }
+}
+```
+
+**A comment is a post:**
+```json
+{
+  "post_id": "comment-xyz",
+  "author_key": "charlie",
+  "collection_name": "comments",
+  "body": {
+    "ref": {"type": "ref", "value": "post-123"},
+    "parent_ref": {"type": "ref", "value": "comment-abc"},
+    "text": {"type": "text", "value": "great post!"}
+  }
+}
+```
+
+**A follow is a group membership:**
+```
+alice.followers → members: bob, charlie
+```
+
+The `ref` type (see `document-typing.md`) is the universal pointer. Any post can reference any other post. The API resolves refs on read. The app decides what a ref means — reaction, comment, reply, quote, remix. The platform doesn't care.
+
+**Engagement is a query, not a table:**
+```sql
+-- Reaction count for post-123
+SELECT count(), any(body)
+FROM posts
+WHERE deleted = 0
+  AND collection_name = 'reactions'
+  AND hasToken(body, 'post-123');  -- ref contains the target post_id
+```
+
+**Comments for a post:**
+```sql
+SELECT post_id, author_key, body, created_at
+FROM posts
+WHERE deleted = 0
+  AND collection_name = 'comments'
+  AND hasToken(body, 'post-123')
+ORDER BY created_at ASC;
+```
+
+The `hasToken` function scans the JSON body for the ref value. ClickHouse can index JSON paths for faster lookup. No dedicated table. No dedicated endpoint. Just posts with refs.
 
 ## Media Library
 
@@ -237,6 +312,16 @@ WHERE p.deleted = 0
   AND p.discoverable = 1
   AND gm.member_key = 'alice'
   AND gm.deleted = 0
+  AND NOT EXISTS (
+    SELECT 1 FROM user_blacklist
+    WHERE user_key = p.author_key AND blocked_key = 'alice'
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM group_blacklist
+    WHERE user_key = p.author_key
+      AND group_id = pg.group_id
+      AND blocked_key = 'alice'
+  )
 ORDER BY p.created_at DESC
 LIMIT 50;
 ```
@@ -445,7 +530,7 @@ sequenceDiagram
 | `/discover` endpoint | `?discover=true` on CRUD |
 | `/public` endpoint | Gone (group membership filter) |
 | Discovery index table | Gone (posts table IS the index) |
-| Public ledger | Gone (reactions table + materialized view) |
+| Public ledger | Gone (posts with `ref` type) |
 | Client-side ledger mirrors | Gone (server writes once) |
 | Server-side indexing hooks | Gone (single insert) |
 | FerretDB translation layer | Gone |
@@ -463,12 +548,23 @@ sequenceDiagram
 
 ## Summary
 
-ClickHouse + MinIO. Two services. One table for posts. One table for reactions. One table for comments. One table for groups. One table for group membership. One table for post-to-group mapping. Materialized views for engagement. TTL for cleanup. Tombstones for deletes. JSON columns for schema flexibility. Inverted index for search.
+ClickHouse + MinIO. Two services. One table for everything structured. One table for posts — reactions, comments, notes, mail, everything is a post. The `ref` type in the JSON body links posts together. Groups. Group membership. Post-to-group mapping. Service contracts. Group contracts. Blacklist tables. Sharing toggle. TTL for cleanup. Tombstones for deletes. JSON body for schema flexibility.
 
-No mirrors. No sync. No double-write. No discovery index. No ledger. No FerretDB. No MongoDB. No Postgres.
+No mirrors. No sync. No double-write. No discovery index. No ledger. No FerretDB. No MongoDB. No Postgres. No dedicated reactions table. No dedicated comments table. No dedicated social media endpoints.
 
 One CRUD endpoint. `?discover=true` for cross-user visibility. Service contracts control app access. Groups control people access. Both must pass.
 
 Groups are policy containers. They hold people, not data. One membership. Infinite apps. Follows are groups. The authenticator manages everything — block sharing, opt out, privatize all, kill switch.
 
-The dev calls `createPost({ text, tags, groups: ["alice.close-friends"] })`. The API writes one post row, one post_groups row. ClickHouse queries it. That's it.
+**Additional docs in this directory:**
+- `groups.md` — policy containers, join policies, moderation, blocking, authenticator
+- `contract-schemas.md` — full table schemas for service contracts, group contracts, join requests, sharing toggle
+- `cross-app-sharing.md` — mailer pattern, saved mail, DMs, comments, notes
+- `federated-groups.md` — federation across providers, remote() queries
+- `document-typing.md` — leaf-level type convention, the `ref` type, planned schemas
+- `tombstone-cleanup.md` — append-only write pattern, TTL cleanup, background compaction
+- `real-time-feeds.md` — Redis cache, WebSocket push, hot group scaling
+- `manifesto-additions.md` — internet permanence, sender deletion, groups on the internet
+- `skeptical-points-addressed.md` — concerns from the v2-to-v3 transition, resolved
+
+The dev calls `createPost({ text, tags, groups: ["alice.close-friends"] })`. A reaction is `createPost({ ref: "post-123", reaction_type: "like" })`. A comment is `createPost({ ref: "post-123", text: "great!" })`. Same endpoint. Same table. Same permissions. That's it.

--- a/knowledge/knowledge-base/web10-v3/overview.md
+++ b/knowledge/knowledge-base/web10-v3/overview.md
@@ -34,8 +34,8 @@ graph TB
     end
 
     subgraph ClickHouse
-        Posts["posts (everything)"]
-        PostGroups["post_groups"]
+        Documents["documents (everything)"]
+        DocGroups["doc_groups"]
         GroupsTable["groups"]
         GroupMembers["group_members"]
     end
@@ -47,8 +47,8 @@ graph TB
     App --> CRUD
     App --> Groups
     App --> Media
-    CRUD --> Posts
-    CRUD --> PostGroups
+    CRUD --> Documents
+    CRUD --> DocGroups
     Groups --> GroupsTable
     Groups --> GroupMembers
     Media --> Blobs
@@ -57,8 +57,8 @@ graph TB
     style CRUD fill:#e3f2fd,stroke:#1565c0,color:#000
     style Groups fill:#e3f2fd,stroke:#1565c0,color:#000
     style Media fill:#e3f2fd,stroke:#1565c0,color:#000
-    style Posts fill:#fff3e0,stroke:#e65100,color:#000
-    style PostGroups fill:#fff3e0,stroke:#e65100,color:#000
+    style Documents fill:#fff3e0,stroke:#e65100,color:#000
+    style DocGroups fill:#fff3e0,stroke:#e65100,color:#000
     style GroupsTable fill:#fff3e0,stroke:#e65100,color:#000
     style GroupMembers fill:#fff3e0,stroke:#e65100,color:#000
     style Blobs fill:#fce4ec,stroke:#c62828,color:#000
@@ -68,8 +68,8 @@ graph TB
 
 ```sql
 -- Posts: everything. JSON body for schema flexibility.
-CREATE TABLE posts (
-    post_id String,
+CREATE TABLE documents (
+    doc_id String,
     author_key String,
     collection_name String,     -- 'public_posts', 'private_posts', etc.
     body String,                -- JSON: full post content
@@ -79,19 +79,19 @@ CREATE TABLE posts (
     updated_at DateTime64(3),
     deleted UInt8 DEFAULT 0
 ) ENGINE = ReplacingMergeTree(updated_at)
-ORDER BY (author_key, post_id)
+ORDER BY (author_key, doc_id)
 TTL created_at + INTERVAL 90 DAY;
 
 -- Post-to-group mapping. Groups define who can see the post.
-CREATE TABLE post_groups (
-    post_id String,
+CREATE TABLE doc_groups (
+    doc_id String,
     group_id String,
     permission String,          -- 'read', 'write' — author decides at attachment time
     created_at DateTime64(3),
     updated_at DateTime64(3),
     deleted UInt8 DEFAULT 0
 ) ENGINE = ReplacingMergeTree(updated_at)
-ORDER BY (post_id, group_id);
+ORDER BY (doc_id, group_id);
 
 -- Service contracts. Which websites can access your service. CORS.
 CREATE TABLE service_contracts (
@@ -197,7 +197,7 @@ No dedicated reactions table. No dedicated comments table. No dedicated follows 
 **A reaction is a post:**
 ```json
 {
-  "post_id": "react-abc",
+  "doc_id": "react-abc",
   "author_key": "bob",
   "collection_name": "reactions",
   "body": {
@@ -210,7 +210,7 @@ No dedicated reactions table. No dedicated comments table. No dedicated follows 
 **A comment is a post:**
 ```json
 {
-  "post_id": "comment-xyz",
+  "doc_id": "comment-xyz",
   "author_key": "charlie",
   "collection_name": "comments",
   "body": {
@@ -232,23 +232,23 @@ The `ref` type (see `document-typing.md`) is the universal pointer. Any post can
 ```sql
 -- Reaction count for post-123
 SELECT count(), any(body)
-FROM posts
+FROM documents
 WHERE deleted = 0
   AND collection_name = 'reactions'
-  AND hasToken(body, 'post-123');  -- ref contains the target post_id
+  AND hasToken(body, 'post-123');  -- ref contains the target doc_id
 ```
 
 **Comments for a post:**
 ```sql
-SELECT post_id, author_key, body, created_at
-FROM posts
+SELECT doc_id, author_key, body, created_at
+FROM documents
 WHERE deleted = 0
   AND collection_name = 'comments'
   AND hasToken(body, 'post-123')
 ORDER BY created_at ASC;
 ```
 
-The `hasToken` function scans the JSON body for the ref value. ClickHouse can index JSON paths for faster lookup. No dedicated table. No dedicated endpoint. Just posts with refs.
+The `hasToken` function scans the JSON body for the ref value. ClickHouse can index JSON paths for faster lookup. No dedicated table. No dedicated endpoint. Just documents with refs.
 
 ## Media Library
 
@@ -294,7 +294,7 @@ sequenceDiagram
     participant ClickHouse
 
     Client->>API: GET /alice/posts?discover=true
-    API->>ClickHouse: SELECT posts WHERE<br/>group membership check for alice<br/>+ discoverable = 1<br/>+ deleted = 0
+    API->>ClickHouse: SELECT documents WHERE<br/>group membership check for alice<br/>+ discoverable = 1<br/>+ deleted = 0
     ClickHouse-->>API: 50 post IDs + metadata
     API-->>Client: feed response
 
@@ -304,9 +304,9 @@ sequenceDiagram
 The query ClickHouse runs:
 
 ```sql
-SELECT p.post_id, p.author_key, p.body, p.tags, p.created_at
-FROM posts p
-JOIN post_groups pg ON p.post_id = pg.post_id
+SELECT p.doc_id, p.author_key, p.body, p.tags, p.created_at
+FROM documents p
+JOIN doc_groups pg ON p.doc_id = pg.doc_id
 JOIN group_members gm ON pg.group_id = gm.group_id
 WHERE p.deleted = 0
   AND p.discoverable = 1
@@ -481,7 +481,7 @@ jazz-collectors → admin: dave, request
 web10-dev       → admin: charlie, open
 ```
 
-**Opt out all posts** — bulk remove every post you've attached to a group. Reversible.
+**Opt out all documents** — bulk remove every post you've attached to a group. Reversible.
 **Make everything private** — remove all groups from all your posts. One click.
 
 ## The Write Flow
@@ -495,8 +495,8 @@ sequenceDiagram
     participant ClickHouse
 
     Client->>API: POST /alice/posts<br/>{ text, tags, groups: ["alice.close-friends"] }
-    API->>ClickHouse: INSERT INTO posts
-    API->>ClickHouse: INSERT INTO post_groups
+    API->>ClickHouse: INSERT INTO documents
+    API->>ClickHouse: INSERT INTO doc_groups
     ClickHouse-->>API: OK
     API-->>Client: 201 Created
 
@@ -514,7 +514,7 @@ sequenceDiagram
     participant ClickHouse
 
     Client->>API: DELETE /alice/posts/abc
-    API->>ClickHouse: INSERT tombstone<br/>(same post_id, deleted=1,<br/>higher updated_at)
+    API->>ClickHouse: INSERT tombstone<br/>(same doc_id, deleted=1,<br/>higher updated_at)
     ClickHouse-->>API: OK
     API-->>Client: 200 OK
 
@@ -529,8 +529,8 @@ sequenceDiagram
 | Term records (whitelist/blacklist) | Service contracts + group contracts |
 | `/discover` endpoint | `?discover=true` on CRUD |
 | `/public` endpoint | Gone (group membership filter) |
-| Discovery index table | Gone (posts table IS the index) |
-| Public ledger | Gone (posts with `ref` type) |
+| Discovery index table | Gone (documents table IS the index) |
+| Public ledger | Gone (documents with `ref` type) |
 | Client-side ledger mirrors | Gone (server writes once) |
 | Server-side indexing hooks | Gone (single insert) |
 | FerretDB translation layer | Gone |
@@ -548,7 +548,7 @@ sequenceDiagram
 
 ## Summary
 
-ClickHouse + MinIO. Two services. One table for everything structured. One table for posts — reactions, comments, notes, mail, everything is a post. The `ref` type in the JSON body links posts together. Groups. Group membership. Post-to-group mapping. Service contracts. Group contracts. Blacklist tables. Sharing toggle. TTL for cleanup. Tombstones for deletes. JSON body for schema flexibility.
+ClickHouse + MinIO. Two services. One table for everything structured. One table for documents — reactions, comments, notes, mail, everything is a document. The `ref` type in the JSON body links documents together. Groups. Group membership. Doc-to-group mapping. Service contracts. Group contracts. Blacklist tables. Sharing toggle. TTL for cleanup. Tombstones for deletes. JSON body for schema flexibility.
 
 No mirrors. No sync. No double-write. No discovery index. No ledger. No FerretDB. No MongoDB. No Postgres. No dedicated reactions table. No dedicated comments table. No dedicated social media endpoints.
 
@@ -567,4 +567,4 @@ Groups are policy containers. They hold people, not data. One membership. Infini
 - `manifesto-additions.md` — internet permanence, sender deletion, groups on the internet
 - `skeptical-points-addressed.md` — concerns from the v2-to-v3 transition, resolved
 
-The dev calls `createPost({ text, tags, groups: ["alice.close-friends"] })`. A reaction is `createPost({ ref: "post-123", reaction_type: "like" })`. A comment is `createPost({ ref: "post-123", text: "great!" })`. Same endpoint. Same table. Same permissions. That's it.
+The dev calls `createDocument({ text, tags, groups: ["alice.close-friends"] })`. A reaction is `createDocument({ ref: "post-123", reaction_type: "like" })`. A comment is `createDocument({ ref: "post-123", text: "great!" })`. Same endpoint. Same table. Same permissions. That's it.

--- a/knowledge/knowledge-base/web10-v3/real-time-feeds.md
+++ b/knowledge/knowledge-base/web10-v3/real-time-feeds.md
@@ -1,0 +1,99 @@
+# Real-Time Feeds
+
+Hot groups need real-time updates. ClickHouse is fast but not instant for push. This doc covers the Redis + WebSocket layer for high-activity groups.
+
+## The Problem
+
+A celeb has 100k followers. Someone comments. 100k clients shouldn't poll. Polling is wasteful. The answer is push.
+
+## The Architecture
+
+```
+Client → WebSocket → API → Redis (pub/sub) → ClickHouse (source of truth)
+```
+
+Three layers:
+1. **ClickHouse** — source of truth. All writes go here.
+2. **Redis** — cache for hot group activity. Pub/sub for push.
+3. **WebSocket** — persistent connection to each client. Pushes updates.
+
+## The Write Path
+
+When Bob posts to `alice.followers`:
+
+```
+1. API receives POST /bob/posts { groups: ["alice.followers"] }
+2. API writes to ClickHouse (INSERT INTO posts, post_groups)
+3. API writes to Redis:
+   - SET group:alice.followers:recent:{post_id} → post data, TTL 30s
+   - RPUSH group:alice.followers:feed → post_id, LTRIM to 100
+   - PUBLISH group:alice.followers:updates → { post_id, author: "bob" }
+4. WebSocket server subscribes to channel, pushes to all clients in the group
+```
+
+The API does the Redis write. No pub/sub from ClickHouse needed. The API knows about the write — it just pushes to both.
+
+## The Read Path
+
+**Initial load (page open):**
+```
+1. Client opens /alice/posts?discover=true
+2. API checks Redis: group:alice.followers:recent
+3. If cache hit → return cached posts (fast)
+4. If cache miss → query ClickHouse, populate cache, return
+```
+
+**Live updates (after page open):**
+```
+1. Client opens WebSocket: ws://api/websocket?groups=alice.followers
+2. Server subscribes to Redis channel: group:alice.followers:updates
+3. New post arrives → Redis pub → WebSocket push → client updates
+```
+
+No polling. No long-polling. Real push.
+
+## The Redis Keys
+
+```
+group:{group_id}:recent:{post_id}   → Hash: post data, TTL 30s
+group:{group_id}:feed               → List: post IDs (newest first), LTRIM 100
+group:{group_id}:trending           → Sorted Set: post IDs scored by engagement, TTL 5m
+group:{group_id}:updates            → Pub/Sub channel: live push
+group:{group_id}:members            → Set: member keys (for WebSocket fan-out)
+```
+
+## The WebSocket Server
+
+```python
+# Subscribes to Redis channels for groups the client follows
+async def handle_websocket(ws):
+    groups = ws.query_params['groups']  # 'alice.followers,bob.posts'
+    
+    # Subscribe to Redis pub/sub
+    pubsub = redis.pubsub()
+    for g in groups:
+        pubsub.subscribe(f'group:{g}:updates')
+    
+    # Forward messages to client
+    async for message in pubsub.listen():
+        if message['type'] == 'message':
+            post_id = message['data']['post_id']
+            post = redis.hgetall(f'group:{g}:recent:{post_id}')
+            await ws.send(json.dumps(post))
+```
+
+## The Scale
+
+**Small group** (< 1k members): ClickHouse direct query. No Redis. No WebSocket. Simple.
+
+**Medium group** (1k - 10k): Redis cache for recent posts. No WebSocket. Polling is fine.
+
+**Hot group** (10k+): Redis cache + WebSocket push. Real-time updates. The infrastructure scales with the group.
+
+## The Trade-off
+
+Complexity. You're adding Redis and WebSockets to a stack that was "ClickHouse + MinIO." But this is day-two complexity. Day one, ClickHouse handles reasonable group sizes with polling. The Redis + WebSocket layer is the scaling story, not the foundation.
+
+## Summary
+
+ClickHouse is the source. Redis caches hot activity and pushes updates. WebSocket delivers to clients. The API writes to both ClickHouse and Redis on every insert. No pub/sub from ClickHouse needed. The model doesn't change — the infrastructure adds a cache and a push channel.

--- a/knowledge/knowledge-base/web10-v3/real-time-feeds.md
+++ b/knowledge/knowledge-base/web10-v3/real-time-feeds.md
@@ -23,11 +23,11 @@ When Bob posts to `alice.followers`:
 
 ```
 1. API receives POST /bob/posts { groups: ["alice.followers"] }
-2. API writes to ClickHouse (INSERT INTO posts, post_groups)
+2. API writes to ClickHouse (INSERT INTO documents, doc_groups)
 3. API writes to Redis:
-   - SET group:alice.followers:recent:{post_id} → post data, TTL 30s
-   - RPUSH group:alice.followers:feed → post_id, LTRIM to 100
-   - PUBLISH group:alice.followers:updates → { post_id, author: "bob" }
+   - SET group:alice.followers:recent:{doc_id} → post data, TTL 30s
+   - RPUSH group:alice.followers:feed → doc_id, LTRIM to 100
+   - PUBLISH group:alice.followers:updates → { doc_id, author: "bob" }
 4. WebSocket server subscribes to channel, pushes to all clients in the group
 ```
 
@@ -39,7 +39,7 @@ The API does the Redis write. No pub/sub from ClickHouse needed. The API knows a
 ```
 1. Client opens /alice/posts?discover=true
 2. API checks Redis: group:alice.followers:recent
-3. If cache hit → return cached posts (fast)
+3. If cache hit → return cached documents (fast)
 4. If cache miss → query ClickHouse, populate cache, return
 ```
 
@@ -55,7 +55,7 @@ No polling. No long-polling. Real push.
 ## The Redis Keys
 
 ```
-group:{group_id}:recent:{post_id}   → Hash: post data, TTL 30s
+group:{group_id}:recent:{doc_id}   → Hash: post data, TTL 30s
 group:{group_id}:feed               → List: post IDs (newest first), LTRIM 100
 group:{group_id}:trending           → Sorted Set: post IDs scored by engagement, TTL 5m
 group:{group_id}:updates            → Pub/Sub channel: live push
@@ -77,8 +77,8 @@ async def handle_websocket(ws):
     # Forward messages to client
     async for message in pubsub.listen():
         if message['type'] == 'message':
-            post_id = message['data']['post_id']
-            post = redis.hgetall(f'group:{g}:recent:{post_id}')
+            doc_id = message['data']['doc_id']
+            post = redis.hgetall(f'group:{g}:recent:{doc_id}')
             await ws.send(json.dumps(post))
 ```
 

--- a/knowledge/knowledge-base/web10-v3/skeptical-points-addressed.md
+++ b/knowledge/knowledge-base/web10-v3/skeptical-points-addressed.md
@@ -1,0 +1,143 @@
+# Skeptical Points Addressed
+
+The v2-to-v3 transition raised real concerns. Here's how each resolves.
+
+## "Blacklist tables aren't wired into the discovery query"
+
+**The concern:** `user_blacklist` and `group_blacklist` exist in the schema, but the discovery query at overview.md doesn't filter on them. A blocked user would still see posts.
+
+**The resolution:** It's a WHERE clause. Mechanical fix, not a model problem.
+
+```sql
+SELECT p.post_id, p.author_key, p.body, p.tags, p.created_at
+FROM posts p
+JOIN post_groups pg ON p.post_id = pg.post_id
+JOIN group_members gm ON pg.group_id = gm.group_id
+WHERE p.deleted = 0
+  AND p.discoverable = 1
+  AND gm.member_key = 'alice'
+  AND gm.deleted = 0
+  AND NOT EXISTS (
+    SELECT 1 FROM user_blacklist
+    WHERE user_key = p.author_key AND blocked_key = 'alice'
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM group_blacklist
+    WHERE user_key = p.author_key
+      AND group_id = pg.group_id
+      AND blocked_key = 'alice'
+  )
+ORDER BY p.created_at DESC
+LIMIT 50;
+```
+
+Two anti-joins. ClickHouse handles them fine. The model was always correct — the query just needed to be written.
+
+## "The permission model is hand-wavy — where does read/write live?"
+
+**The concern:** The docs say the author decides permission level (read/write) at attachment time, but `post_groups` only had `post_id` and `group_id`. No column for the permission.
+
+**The resolution:** Per-document permission on the `post_groups` row. Uses `ReplacingMergeTree(updated_at)` — same tombstone-append pattern as every other table. Full schema in `contract-schemas.md`. Cleanup strategy in `tombstone-cleanup.md`.
+
+```sql
+CREATE TABLE post_groups (
+    post_id String,
+    group_id String,
+    permission String,   -- 'read', 'write' — author decides at attachment time
+    created_at DateTime64(3),
+    updated_at DateTime64(3),
+    deleted UInt8 DEFAULT 0
+) ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY (post_id, group_id);
+```
+
+The group manages who. The author manages how. Separated at the row level. The group admin can add/remove people but can't escalate `read` to `write` on your doc.
+
+## "Federated queries are optimistic — too much network latency"
+
+**The concern:** `remote()` to 10 providers, merge results, return — that's a lot of hidden latency. What about caching, consistency, slow providers?
+
+**The resolution:** Three layers of reality:
+1. **You're not federated yet.** No rush to solve a problem you don't have.
+2. **Targeted queries, not broadcasts.** A mail query hits specific providers from the group membership list. One person's mail is likely on one or two shards. It's not a fan-out to every node.
+3. **ClickHouse OLTP improvements.** Lightweight updates, Iceberg integration, and better point queries make per-provider targeting faster. The federation is a future problem with future tools.
+
+## "Sender deletion breaks mail — the receiver loses messages they haven't read"
+
+**The concern:** Bob sends mail to Alice. Bob owns it. Bob deletes it. Alice's copy vanishes. For an inbox, losing unread mail is bad UX.
+
+**The resolution:** A mail app can create a `saved_mail` service. The user explicitly saves mail they want to keep. See `cross-app-sharing.md` for the full saved-mail pattern.
+
+```
+service:saved_mail → allowed: mailapp.com
+```
+
+The mail app reads from the inbox group (Alice has read permission), then writes to Alice's `saved_mail` collection (her own data, no auth needed — it's her app, her collection). It's an opt-in copy, not a default. Slightly fights the ephemeral manifesto, but the user chooses. The sender-deletion default is the feature. The save feature is the app's choice.
+
+The user saves what matters. The ephemeral default protects privacy. The save feature protects utility. Both exist.
+
+## "Discoverable is just a hidden visibility column"
+
+**The concern:** You eliminated `visibility` from posts, but `discoverable` is functionally the same — a boolean controlling feed appearance.
+
+**The resolution:** Different category. Visibility was "who can see this." Discoverable is "should this appear in feeds at all?" A post can be in a group (so members can see it) but `discoverable: false` — only reachable by direct link. The group still controls who. The author controls feed participation. Not the same thing.
+
+```
+Post in alice.close-friends, discoverable: false
+  → members can find it by direct link
+  → does NOT appear in group discover feed
+  → author controls feed visibility, group controls access
+```
+
+## "Service contracts are redundant if groups handle everything"
+
+**The concern:** During the brainstorm, it seemed like groups could replace service contracts entirely. Why keep both?
+
+**The resolution:** They solve different problems. Service contracts control which websites can talk to your data (CORS, browser-enforced). Groups control which people can see content (server-enforced). Both must pass. The service contract is the outer wall. The groups are the inner permissions. Removing service contracts means any website can query your data — the browser won't stop them. Full schemas for both contract types in `contract-schemas.md`.
+
+## "Dedicated reactions and comments tables are v2 thinking"
+
+**The concern:** v2 had weird dedicated social media endpoints — `/reactions`, `/comments`, `/follows`. v3 is supposed to be a ubiquitous system, not a social media API. Why carry dedicated tables?
+
+**The resolution:** They're gone. Everything is a post. The `ref` type (see `document-typing.md`) is the universal pointer.
+
+```json
+// A reaction is a post
+{ "ref": {"type": "ref", "value": "post-123"}, "reaction_type": {"type": "text", "value": "like"} }
+
+// A comment is a post
+{ "ref": {"type": "ref", "value": "post-123"}, "text": {"type": "text", "value": "great!"} }
+
+// A reply is a post
+{ "ref": {"type": "ref", "value": "post-123"}, "parent_ref": {"type": "ref", "value": "comment-abc"}, "text": {"type": "text", "value": "agree"} }
+```
+
+One table. One CRUD. One permission model. The app decides what a ref means — reaction, comment, reply, quote, remix, pin. The platform doesn't care. Engagement is a query on the posts table, not a materialized view on a reactions table.
+
+## "Big groups will hammer ClickHouse — every member queries the full table"
+
+**The concern:** A group with 100k members means 100k discover queries hitting ClickHouse. Even fast queries add up. The node takes a hit proportional to group size.
+
+**The resolution:** Two layers. Redis cache for hot group activity (recent posts, trending). WebSocket push for real-time updates. Full treatment in `real-time-feeds.md`.
+
+```
+alice.followers → 100k members
+  New post attached → written to ClickHouse (one insert)
+  Redis: group:alice.followers:recent → cached post IDs, TTL 30s
+  Redis: group:alice.followers:trending → engagement-sorted, TTL 5m
+  WebSocket: push to subscribed clients in this group
+```
+
+Discover flow with cache:
+1. **Hot group** (recent activity) → Redis returns cached post IDs. Sub-millisecond.
+2. **Trending** (engagement-sorted) → Redis returns cached trending list. Sub-millisecond.
+3. **Real-time** (live updates) → WebSocket push. New posts arrive without polling.
+4. **Cold path** (cache miss, deep pagination, older posts) → ClickHouse query. Still fast.
+
+The API writes both ClickHouse and Redis on every insert — no pub/sub needed. TTL as fallback. No stale data longer than 30 seconds. The node protects itself. ClickHouse handles the writes. Redis handles the read fan-out. WebSockets handle the live updates.
+
+Eventually, yes. Not day one. Day one, ClickHouse alone handles reasonable group sizes. Redis and WebSockets are the scaling layer for when groups hit 100k+ and activity is hot. The model doesn't change — the infrastructure adds a cache and a push channel.
+
+## Summary
+
+Every skeptical point resolved without changing the architecture. The model collapsed further: no dedicated reactions table, no dedicated comments table, no dedicated social media endpoints. Everything is a post. The `ref` type links posts together. The app decides semantics. One table. One CRUD. One permission model. The foundation holds.

--- a/knowledge/knowledge-base/web10-v3/skeptical-points-addressed.md
+++ b/knowledge/knowledge-base/web10-v3/skeptical-points-addressed.md
@@ -9,9 +9,9 @@ The v2-to-v3 transition raised real concerns. Here's how each resolves.
 **The resolution:** It's a WHERE clause. Mechanical fix, not a model problem.
 
 ```sql
-SELECT p.post_id, p.author_key, p.body, p.tags, p.created_at
-FROM posts p
-JOIN post_groups pg ON p.post_id = pg.post_id
+SELECT p.doc_id, p.author_key, p.body, p.tags, p.created_at
+FROM documents p
+JOIN doc_groups pg ON p.doc_id = pg.doc_id
 JOIN group_members gm ON pg.group_id = gm.group_id
 WHERE p.deleted = 0
   AND p.discoverable = 1
@@ -35,20 +35,20 @@ Two anti-joins. ClickHouse handles them fine. The model was always correct — t
 
 ## "The permission model is hand-wavy — where does read/write live?"
 
-**The concern:** The docs say the author decides permission level (read/write) at attachment time, but `post_groups` only had `post_id` and `group_id`. No column for the permission.
+**The concern:** The docs say the author decides permission level (read/write) at attachment time, but `doc_groups` only had `doc_id` and `group_id`. No column for the permission.
 
-**The resolution:** Per-document permission on the `post_groups` row. Uses `ReplacingMergeTree(updated_at)` — same tombstone-append pattern as every other table. Full schema in `contract-schemas.md`. Cleanup strategy in `tombstone-cleanup.md`.
+**The resolution:** Per-document permission on the `doc_groups` row. Uses `ReplacingMergeTree(updated_at)` — same tombstone-append pattern as every other table. Full schema in `contract-schemas.md`. Cleanup strategy in `tombstone-cleanup.md`.
 
 ```sql
-CREATE TABLE post_groups (
-    post_id String,
+CREATE TABLE doc_groups (
+    doc_id String,
     group_id String,
     permission String,   -- 'read', 'write' — author decides at attachment time
     created_at DateTime64(3),
     updated_at DateTime64(3),
     deleted UInt8 DEFAULT 0
 ) ENGINE = ReplacingMergeTree(updated_at)
-ORDER BY (post_id, group_id);
+ORDER BY (doc_id, group_id);
 ```
 
 The group manages who. The author manages how. Separated at the row level. The group admin can add/remove people but can't escalate `read` to `write` on your doc.
@@ -99,7 +99,7 @@ Post in alice.close-friends, discoverable: false
 
 **The concern:** v2 had weird dedicated social media endpoints — `/reactions`, `/comments`, `/follows`. v3 is supposed to be a ubiquitous system, not a social media API. Why carry dedicated tables?
 
-**The resolution:** They're gone. Everything is a post. The `ref` type (see `document-typing.md`) is the universal pointer.
+**The resolution:** They're gone. Everything is a document. The `ref` type (see `document-typing.md`) is the universal pointer.
 
 ```json
 // A reaction is a post
@@ -112,7 +112,7 @@ Post in alice.close-friends, discoverable: false
 { "ref": {"type": "ref", "value": "post-123"}, "parent_ref": {"type": "ref", "value": "comment-abc"}, "text": {"type": "text", "value": "agree"} }
 ```
 
-One table. One CRUD. One permission model. The app decides what a ref means — reaction, comment, reply, quote, remix, pin. The platform doesn't care. Engagement is a query on the posts table, not a materialized view on a reactions table.
+One table. One CRUD. One permission model. The app decides what a ref means — reaction, comment, reply, quote, remix, pin. The platform doesn't care. Engagement is a query on the documents table, not a materialized view on a reactions table.
 
 ## "Big groups will hammer ClickHouse — every member queries the full table"
 
@@ -131,7 +131,7 @@ alice.followers → 100k members
 Discover flow with cache:
 1. **Hot group** (recent activity) → Redis returns cached post IDs. Sub-millisecond.
 2. **Trending** (engagement-sorted) → Redis returns cached trending list. Sub-millisecond.
-3. **Real-time** (live updates) → WebSocket push. New posts arrive without polling.
+3. **Real-time** (live updates) → WebSocket push. New documents arrive without polling.
 4. **Cold path** (cache miss, deep pagination, older posts) → ClickHouse query. Still fast.
 
 The API writes both ClickHouse and Redis on every insert — no pub/sub needed. TTL as fallback. No stale data longer than 30 seconds. The node protects itself. ClickHouse handles the writes. Redis handles the read fan-out. WebSockets handle the live updates.
@@ -140,4 +140,4 @@ Eventually, yes. Not day one. Day one, ClickHouse alone handles reasonable group
 
 ## Summary
 
-Every skeptical point resolved without changing the architecture. The model collapsed further: no dedicated reactions table, no dedicated comments table, no dedicated social media endpoints. Everything is a post. The `ref` type links posts together. The app decides semantics. One table. One CRUD. One permission model. The foundation holds.
+Every skeptical point resolved without changing the architecture. The model collapsed further: no dedicated reactions table, no dedicated comments table, no dedicated social media endpoints. Everything is a document. The `ref` type links posts together. The app decides semantics. One table. One CRUD. One permission model. The foundation holds.

--- a/knowledge/knowledge-base/web10-v3/tombstone-cleanup.md
+++ b/knowledge/knowledge-base/web10-v3/tombstone-cleanup.md
@@ -8,7 +8,7 @@ Every update or delete is an insert. A tombstone row with `deleted = 1` and a hi
 
 **Update a post:**
 ```sql
-INSERT INTO posts VALUES (
+INSERT INTO documents VALUES (
     'post-1', 'alice', 'posts', '{"text": "updated"}', 1, [],
     '2026-01-01 00:00:00.000', '2026-01-02 00:00:00.000', 0
 );
@@ -17,7 +17,7 @@ ReplacingMergeTree keeps the row with the highest `updated_at`. Old version is g
 
 **Delete a post:**
 ```sql
-INSERT INTO posts VALUES (
+INSERT INTO documents VALUES (
     'post-1', 'alice', 'posts', '{"text": "original"}', 1, [],
     '2026-01-01 00:00:00.000', '2026-01-03 00:00:00.000', 1
 );
@@ -26,7 +26,7 @@ Tombstone stays. Query filters `WHERE deleted = 0`. TTL physically removes it.
 
 **Revoke a post_group attachment:**
 ```sql
-INSERT INTO post_groups VALUES (
+INSERT INTO doc_groups VALUES (
     'post-1', 'alice.close-friends', 'read',
     '2026-01-01 00:00:00.000', '2026-01-03 00:00:00.000', 1
 );
@@ -41,7 +41,7 @@ ClickHouse is optimized for inserts, not deletes. A `DELETE FROM` is a heavy mut
 
 Two mechanisms:
 
-**1. ReplacingMergeTree auto-compact.** When ClickHouse merges parts, it keeps only the row with the highest `updated_at` for each `(post_id, group_id)` key. Old versions disappear. No action needed.
+**1. ReplacingMergeTree auto-compact.** When ClickHouse merges parts, it keeps only the row with the highest `updated_at` for each `(doc_id, group_id)` key. Old versions disappear. No action needed.
 
 **2. TTL physical removal.** Every table has a TTL clause:
 ```sql
@@ -60,8 +60,8 @@ Runs weekly. Lightweight. Only touches old tombstones.
 
 | Table | Strategy | Cleanup |
 |---|---|---|
-| `posts` | ReplacingMergeTree + TTL | 90 day TTL, physical removal |
-| `post_groups` | ReplacingMergeTree + TTL | 90 day TTL, physical removal |
+| `documents` | ReplacingMergeTree + TTL | 90 day TTL, physical removal |
+| `doc_groups` | ReplacingMergeTree + TTL | 90 day TTL, physical removal |
 | `groups` | ReplacingMergeTree | Weekly DELETE of old tombstones |
 | `group_members` | ReplacingMergeTree | Weekly DELETE of old tombstones |
 | `group_contracts` | ReplacingMergeTree | Weekly DELETE of old tombstones |
@@ -71,7 +71,7 @@ Runs weekly. Lightweight. Only touches old tombstones.
 | `user_group_sharing` | ReplacingMergeTree | Weekly DELETE of old tombstones |
 | `group_join_requests` | ReplacingMergeTree | Weekly DELETE of old tombstones |
 
-Reactions and comments are posts — they use the `posts` table TTL. No separate cleanup needed.
+Reactions and comments are documents — they use the `documents` table TTL. No separate cleanup needed.
 
 ## The Trade-off
 

--- a/knowledge/knowledge-base/web10-v3/tombstone-cleanup.md
+++ b/knowledge/knowledge-base/web10-v3/tombstone-cleanup.md
@@ -1,0 +1,82 @@
+# Tombstone Cleanup
+
+Every table in web10 v3 uses append-only writes with tombstones. This doc covers the pattern and the cleanup strategy.
+
+## The Pattern
+
+Every update or delete is an insert. A tombstone row with `deleted = 1` and a higher `updated_at`.
+
+**Update a post:**
+```sql
+INSERT INTO posts VALUES (
+    'post-1', 'alice', 'posts', '{"text": "updated"}', 1, [],
+    '2026-01-01 00:00:00.000', '2026-01-02 00:00:00.000', 0
+);
+```
+ReplacingMergeTree keeps the row with the highest `updated_at`. Old version is gone on next merge.
+
+**Delete a post:**
+```sql
+INSERT INTO posts VALUES (
+    'post-1', 'alice', 'posts', '{"text": "original"}', 1, [],
+    '2026-01-01 00:00:00.000', '2026-01-03 00:00:00.000', 1
+);
+```
+Tombstone stays. Query filters `WHERE deleted = 0`. TTL physically removes it.
+
+**Revoke a post_group attachment:**
+```sql
+INSERT INTO post_groups VALUES (
+    'post-1', 'alice.close-friends', 'read',
+    '2026-01-01 00:00:00.000', '2026-01-03 00:00:00.000', 1
+);
+```
+Same pattern. Append tombstone. ReplacingMergeTree keeps the latest.
+
+## Why Not DELETE?
+
+ClickHouse is optimized for inserts, not deletes. A `DELETE FROM` is a heavy mutation — it rewrites entire parts. An insert is cheap. The tombstone pattern matches the engine.
+
+## The Cleanup
+
+Two mechanisms:
+
+**1. ReplacingMergeTree auto-compact.** When ClickHouse merges parts, it keeps only the row with the highest `updated_at` for each `(post_id, group_id)` key. Old versions disappear. No action needed.
+
+**2. TTL physical removal.** Every table has a TTL clause:
+```sql
+TTL created_at + INTERVAL 90 DAY;
+```
+After 90 days, ClickHouse physically removes the row. Tombstones included. The data is gone from disk.
+
+**3. Background compaction job.** For tables without TTL (like `group_members`), a scheduled job runs:
+```sql
+ALTER TABLE group_members DELETE
+WHERE deleted = 1 AND updated_at < now() - INTERVAL 30 DAY;
+```
+Runs weekly. Lightweight. Only touches old tombstones.
+
+## Schedule
+
+| Table | Strategy | Cleanup |
+|---|---|---|
+| `posts` | ReplacingMergeTree + TTL | 90 day TTL, physical removal |
+| `post_groups` | ReplacingMergeTree + TTL | 90 day TTL, physical removal |
+| `groups` | ReplacingMergeTree | Weekly DELETE of old tombstones |
+| `group_members` | ReplacingMergeTree | Weekly DELETE of old tombstones |
+| `group_contracts` | ReplacingMergeTree | Weekly DELETE of old tombstones |
+| `service_contracts` | ReplacingMergeTree | Weekly DELETE of old tombstones |
+| `user_blacklist` | MergeTree | Weekly DELETE of old tombstones |
+| `group_blacklist` | MergeTree | Weekly DELETE of old tombstones |
+| `user_group_sharing` | ReplacingMergeTree | Weekly DELETE of old tombstones |
+| `group_join_requests` | ReplacingMergeTree | Weekly DELETE of old tombstones |
+
+Reactions and comments are posts — they use the `posts` table TTL. No separate cleanup needed.
+
+## The Trade-off
+
+Tombstones take space. A busy table has old versions sitting around until the next merge. But ClickHouse merges are cheap at scale — they're the core operation. The trade-off is worth it: inserts are fast, deletes are cheap, and cleanup is automatic.
+
+## Summary
+
+Append tombstones everywhere. ReplacingMergeTree compacts on merge. TTL removes old data physically. Background job handles tables without TTL. No manual intervention. The engine does the work.


### PR DESCRIPTION
Complete v3 architecture docs. Replaces the old layered permissions model with a clean two-contract system:

**Service contracts** — which websites can access your data (CORS, browser-enforced) + which apps can participate on each provider node.

**Group contracts** — which people can see which content. Groups are policy containers that hold people, not data. Content lives in the author's collection. Groups define discovery.

Key docs:
- **overview.md** — ClickHouse + MinIO architecture, tables, discover flows, write/delete flows, media library
- **groups.md** — join policies (open/request/invite), permission levels, moderation, blocking (user-wide + per-group), authenticator management
- **cross-app-sharing.md** — mailer pattern (sender's outbox, receiver's inbox group), DMs, comments, notes — all same model, one insert, zero fan-out
- **federated-groups.md** — group membership as federation map, ClickHouse remote() queries across providers, provider-level app filtering
- **manifesto-additions.md** — internet is too permanent, sender deletion is the feature, groups are hard on the internet, natural app certification
- **document-typing.md** — leaf-level type convention for API scanning, planned enforced schemas via service contracts

New in this PR:
- **contract-schemas.md** — full table schemas for service contracts, group contracts, join requests, sharing toggle
- **tombstone-cleanup.md** — append-only write pattern, TTL cleanup, background compaction schedule
- **real-time-feeds.md** — Redis cache, WebSocket push, hot group scaling
- **skeptical-points-addressed.md** — concerns from v2-to-v3 transition, all resolved
- **web10-social-v3/** — 11 screen docs proving the protocol: your profile, other profile, discover, feed, messages, groups tab, post detail, create post, search, notifications, settings. Zero dedicated endpoints. Zero special tables. Every screen is CRUD + groups + refs.