### PR TITLE
docs: refactor knowledge base — documents, service-scoped roles, discover group

### DIFF
--- a/knowledge/knowledge-base/web10-social-v3/create-post.md
+++ b/knowledge/knowledge-base/web10-social-v3/create-post.md
@@ -15,8 +15,10 @@ Type something...
 📷 Add media    👥 Pick groups
 
 Groups:
-  [jacoby149.public] ✓
-  [web10-dev]        ✓
+  [web10.app/groups/web10/discover] ✓
+  [web10.app/groups/jacoby149/followers] ✓
+  [web10.app/groups/jacoby149/close-friends]
+  [web10.app/groups/charlie/st-louis-chess-club] ✓
 
 [POST]
 ```
@@ -34,25 +36,30 @@ User selects image
   → Client: "I uploaded it, key is jacoby149/media/img-abc.jpg"
 ```
 
-**Group picker:** Groups the user belongs to (as member or admin).
+**Group picker:** Groups the user belongs to (as member or owner).
 ```
 GET /groups?member=jacoby149
-→ [jacoby149.public, jacoby149.close-friends, web10-dev, jazz-collectors, ...]
+→ [web10.app/groups/web10/discover,
+   web10.app/groups/jacoby149/followers,
+   web10.app/groups/jacoby149/close-friends,
+    web10.app/groups/charlie/st-louis-chess-club,
+   web10.app/groups/dave/jazz-collectors, ...]
 ```
 The app filters to groups where posting makes sense. Shows group name and member count.
 
 **Publish:**
 ```
 User taps POST
-  → POST /jacoby149/posts
-     { "text": {"type": "text", "value": "just shipped the new groups feature"},
-       "media": [{"type": "minio", "value": "jacoby149/media/img-abc.jpg"}],
-       "tags": ["web10", "groups"],
-       "groups": ["jacoby149.public", "web10-dev"],
-       "discoverable": true }
-  → API: INSERT INTO documents
-  → API: INSERT INTO doc_groups (one row per group)
-  → WebSocket: push to subscribers in both groups
+   → POST /jacoby149/posts
+      { "text": {"type": "text", "value": "just shipped the new groups feature"},
+        "media": [{"type": "minio", "value": "jacoby149/media/img-abc.jpg"}],
+        "tags": ["web10", "groups"],
+        "groups": ["web10.app/groups/web10/discover",
+                    "web10.app/groups/jacoby149/followers",
+                    "web10.app/groups/charlie/st-louis-chess-club"] }
+   → API: INSERT INTO documents
+   → API: INSERT INTO doc_groups (one row per group)
+   → WebSocket: push to subscribers in both groups
 ```
 
 One insert into documents. N inserts into doc_groups. Done.
@@ -61,11 +68,12 @@ One insert into documents. N inserts into doc_groups. Done.
 
 ```
 Client → POST /jacoby149/posts { body, groups: [...] }
-  API → INSERT INTO documents (doc_id, author_key, 'posts', body_json, discoverable, tags, ...)
-  API → INSERT INTO doc_groups (doc_id, 'jacoby149.public', 'read', ...)
-  API → INSERT INTO doc_groups (doc_id, 'web10-dev', 'read', ...)
-  API → Redis: update group:jacoby149.public:recent, group:web10-dev:recent
-  API → WebSocket: PUBLISH to both group channels
+  API → INSERT INTO documents (doc_id, author_key, 'posts', body_json, tags, ...)
+  API → INSERT INTO doc_groups (doc_id, 'web10.app/groups/web10/discover', ...)
+  API → INSERT INTO doc_groups (doc_id, 'web10.app/groups/jacoby149/followers', ...)
+  API → INSERT INTO doc_groups (doc_id, 'web10.app/groups/charlie/st-louis-chess-club', ...)
+  API → Redis: update group:web10/discover:recent, group:jacoby149/followers:recent, ...
+  API → WebSocket: PUBLISH to all group channels
   API → 201 Created { doc_id }
 ```
 

--- a/knowledge/knowledge-base/web10-social-v3/discover.md
+++ b/knowledge/knowledge-base/web10-social-v3/discover.md
@@ -7,18 +7,20 @@ The discover page. Posts from all groups you're a member of, sorted by time or e
 ```
 Discover
 ─────────────────────
-[jacoby149] posted 2h ago in [web10-dev]
-  "just shipped the new groups feature"
-  [❤️ 42] [💬 8]
+[jacoby149] posted 2h ago
+   "just shipped the new groups feature"
+   [📷 attachment]
+   [❤️ 42] [💬 8]
 
-[alice] posted 3h ago in [jazz-collectors]
-  "this album is fire"
-  [🎵 attachment]
-  [❤️ 15] [💬 3]
+[alice] posted 3h ago
+   "this album is fire"
+   [🎵 attachment]
+   [❤️ 15] [💬 3]
 
-[bob] posted 5h ago in [alice.followers]
-  "behind the scenes"
-  [❤️ 120] [💬 24]
+[bob] posted 5h ago
+   "behind the scenes"
+   [📷 attachment]
+   [❤️ 120] [💬 24]
 ```
 
 ## Protocol Mapping
@@ -31,10 +33,9 @@ FROM documents p
 JOIN doc_groups pg ON p.doc_id = pg.doc_id
 JOIN group_members gm ON pg.group_id = gm.group_id
 WHERE p.deleted = 0
-  AND p.discoverable = 1
-  AND gm.member_key = 'jacoby149'
-  AND gm.deleted = 0
-  AND NOT EXISTS (
+   AND gm.member_key = 'jacoby149'
+   AND gm.deleted = 0
+   AND NOT EXISTS (
     SELECT 1 FROM user_blacklist
     WHERE user_key = p.author_key AND blocked_key = 'jacoby149'
   )
@@ -56,9 +57,8 @@ FROM documents p
 JOIN doc_groups pg ON p.doc_id = pg.doc_id
 JOIN group_members gm ON pg.group_id = gm.group_id
 WHERE p.deleted = 0
-  AND p.discoverable = 1
-  AND gm.member_key = 'jacoby149'
-  AND gm.deleted = 0
+   AND gm.member_key = 'jacoby149'
+   AND gm.deleted = 0
 ORDER BY reaction_count DESC, p.created_at DESC
 LIMIT 50;
 ```
@@ -96,7 +96,7 @@ Option 3 is simplest. The API already knows about the write. Increment a counter
 - [ ] Author avatar caching — Redis, TTL 5m
 - [ ] Group name caching — Redis, TTL 1h (groups don't change often)
 - [ ] Engagement counter table — `post_engagement(doc_id, reaction_count, comment_count)`
-- [ ] Filter by group — `?group=jazz-collectors` to narrow discover
+- [ ] Filter by group — `?group=web10.app/groups/dave/jazz-collectors` to narrow discover
 
 ## Proof
 

--- a/knowledge/knowledge-base/web10-social-v3/feed.md
+++ b/knowledge/knowledge-base/web10-social-v3/feed.md
@@ -1,6 +1,6 @@
 # Your Feed
 
-Your personal feed. Posts from people you follow, sorted chronologically.
+Your personal feed. Posts from all groups you belong to, minus the public board.
 
 ## What the Screen Shows
 
@@ -8,77 +8,81 @@ Your personal feed. Posts from people you follow, sorted chronologically.
 Feed
 ─────────────────────
 [alice] posted 1h ago
-  "morning coffee run"
-  [📷 attachment]
-  [❤️ 12] [💬 2]
+   "morning coffee run"
+   [📷 attachment]
+   [❤️ 12] [💬 2]
 
 [bob] posted 3h ago
-  "working on something cool"
-  [❤️ 5] [💬 0]
+   "working on something cool"
+   [❤️ 5] [💬 0]
 ```
 
 ## Protocol Mapping
 
-**The feed is discover filtered to your followers groups.** You follow people → you're a member of their `username.followers` groups → their documents attached to that group appear in your feed.
+**Your feed is all groups you belong to, minus the discover group.** The discover group (`web10.app/groups/web10/discover`) is the public board — it has its own screen. Your feed is personal: followers, communities, close-friends.
 
-```sql
-SELECT p.doc_id, p.author_key, p.body, p.created_at
-FROM documents p
-JOIN doc_groups pg ON p.doc_id = pg.doc_id
-JOIN group_members gm ON pg.group_id = gm.group_id
-WHERE p.deleted = 0
-  AND p.discoverable = 1
-  AND gm.member_key = 'jacoby149'
-  AND gm.deleted = 0
-  AND pg.group_id LIKE '%.followers'    -- only followers groups, not jazz-collectors
-  AND NOT EXISTS (
-    SELECT 1 FROM user_blacklist
-    WHERE user_key = p.author_key AND blocked_key = 'jacoby149'
-  )
-ORDER BY p.created_at DESC
-LIMIT 50;
+```ts
+const groups = await getGroups({ member: 'jacoby149' });
+// → [web10.app/groups/web10/discover,
+//    web10.app/groups/jacoby149/followers,
+//    web10.app/groups/jacoby149/close-friends,
+//    web10.app/groups/charlie/st-louis-chess-club,
+//    web10.app/groups/dave/jazz-collectors, ...]
+
+const feedGroups = groups.filter(g => g !== 'web10.app/groups/web10/discover');
+
+const posts = await getDocuments({ groups: feedGroups, sort: 'newest', limit: 50 });
 ```
 
-The `LIKE '%.followers'` filter narrows to follow relationships. Your feed is discover with a group filter. Same query, different scope.
+One SDK call. All your groups. Public board excluded.
 
-**Alternative:** The app tracks which users you follow in a local list. Build the group_ids explicitly:
-```sql
--- jacoby149 follows alice, bob, charlie
-WHERE pg.group_id IN ('alice.followers', 'bob.followers', 'charlie.followers')
+**Narrowing to followers only.** The app can filter to just followers groups:
+```ts
+const followersGroups = groups.filter(g => g.endsWith('/followers'));
+const feed = await getDocuments({ groups: followersGroups, sort: 'newest', limit: 50 });
 ```
-Faster than LIKE. The app maintains the follow list as a convenience.
+
+**Narrowing to a specific group.** This is how profile pages and group pages work:
+```ts
+// Alice's profile — only her followers group
+const profilePosts = await getDocuments({ groups: ['web10.app/groups/alice/followers'], sort: 'newest' });
+
+// Chess club page — only that group
+const clubPosts = await getDocuments({ groups: ['web10.app/groups/charlie/st-louis-chess-club'], sort: 'newest' });
+```
+
+Same SDK call. Different groups.
 
 ## The Data Flow
 
 ```
 User opens /feed
-  → GET /feed
-  → ClickHouse: discover query filtered to *.followers groups
+  → getGroups({ member: 'jacoby149' })
+  → filter out web10/discover
+  → getDocuments({ groups: feedGroups, sort: 'newest', limit: 50 })
   → parallel: resolve author avatars
   → render
 ```
 
-Same discover query, narrower filter. The protocol doesn't need a "feed" concept — it's discover with a group filter.
-
 ## Feed vs Discover
 
-| Feed | Discover |
+| Your Feed | Discover |
 |---|---|
-| `*.followers` groups only | All groups you're a member of |
+| All groups you belong to, minus discover | Only `web10.app/groups/web10/discover` |
+| Personal: followers, communities, close-friends | Public board: everything posted to discover |
 | Chronological | Chronological or trending |
-| People you follow | All shared content |
-| Personal | Broad |
+| Excludes discover group | Is the discover group |
 
-Same query. Different WHERE clause. The groups define the difference.
+Same SDK call. Different groups. Your feed is personal. Discover is public.
 
 ## TODO
 
 - [ ] Follow list caching — app maintains list of followed users for faster queries
-- [ ] Mute feature — per-author exclusion (extend user_blacklist or add mute table)
-- [ ] "See post" from feed → post detail screen (ref to post-detail.md)
+- [ ] Mute feature — per-author exclusion
+- [ ] "See post" from feed → post detail screen
 - [ ] Infinite scroll — keyset pagination on created_at
-- [ ] WebSocket push — new posts from followed users arrive in real-time (see real-time-feeds.md)
+- [ ] WebSocket push — new posts from groups arrive in real-time
 
 ## Proof
 
-Your feed is a discover query with a group filter. No feed table. No fan-out on write. No "compute feed" job. One query at read time. The groups define what's in your feed. The protocol handles it.
+Your feed is one SDK call with a list of groups. No feed table. No fan-out on write. No "compute feed" job. The groups define what's in your feed. The protocol handles it.

--- a/knowledge/knowledge-base/web10-social-v3/groups-tab.md
+++ b/knowledge/knowledge-base/web10-social-v3/groups-tab.md
@@ -9,27 +9,31 @@ Groups
 ─────────────────────
 You Admin (2)
 ─────────────────────
-jacoby149.public          [open]    1,203 members  [Manage]
-jacoby149.close-friends   [invite]  12 members     [Manage]
+web10.app/groups/jacoby149/public          [open]    1,203 members  [Manage]
+web10.app/groups/jacoby149/close-friends   [invite]  12 members     [Manage]
 
 You Belong To (3)
 ─────────────────────
-jazz-collectors           [request] admin: dave     [View] [Leave]
-web10-dev                 [open]    admin: charlie  [View] [Leave]
-alice.followers           [request] admin: alice    [Unfollow]
+web10.app/groups/dave/jazz-collectors           [request] owner: dave     [View] [Leave]
+web10.app/groups/charlie/st-louis-chess-club                 [open]    owner: charlie  [View] [Leave]
+web10.app/groups/alice/followers           [request] owner: alice    [Unfollow]
 
 Pending Requests (1)
 ─────────────────────
-bob wants to join jacoby149.close-friends  [Approve] [Deny]
+bob wants to join web10.app/groups/jacoby149/close-friends  [Approve] [Deny]
 ```
 
 ## Protocol Mapping
 
 **Groups you admin:**
 ```sql
-SELECT group_id, name, join_policy
-FROM group_contracts
-WHERE admin_key = 'jacoby149' AND deleted = 0;
+SELECT gm.group_id, gc.name, gc.join_policy
+FROM group_members gm
+JOIN group_contracts gc ON gm.group_id = gc.group_id
+WHERE gm.member_key = 'jacoby149'
+  AND gm.role = 'owner'
+  AND gm.deleted = 0
+  AND gc.deleted = 0;
 ```
 
 **Member counts:**
@@ -42,13 +46,13 @@ GROUP BY group_id;
 
 **Groups you belong to (not admin):**
 ```sql
-SELECT gm.group_id, gc.name, gc.admin_key, gc.join_policy
+SELECT gm.group_id, gc.name, gc.join_policy
 FROM group_members gm
 JOIN group_contracts gc ON gm.group_id = gc.group_id
 WHERE gm.member_key = 'jacoby149'
   AND gm.deleted = 0
   AND gc.deleted = 0
-  AND gc.admin_key != 'jacoby149';
+  AND gm.role != 'owner';
 ```
 
 **Pending join requests:**
@@ -57,7 +61,10 @@ SELECT gjr.group_id, gjr.requester_key, gjr.requested_at, gc.name
 FROM group_join_requests gjr
 JOIN group_contracts gc ON gjr.group_id = gc.group_id
 WHERE gjr.status = 'pending'
-  AND gc.admin_key = 'jacoby149'
+  AND gjr.group_id IN (
+    SELECT group_id FROM group_members
+    WHERE member_key = 'jacoby149' AND role = 'owner' AND deleted = 0
+  )
   AND gjr.deleted = 0;
 ```
 
@@ -67,10 +74,10 @@ WHERE gjr.status = 'pending'
 INSERT INTO group_join_requests
 SELECT group_id, requester_key, 'approved', requested_at, now(), updated_at, deleted
 FROM group_join_requests
-WHERE group_id = 'jacoby149.close-friends' AND requester_key = 'bob';
+WHERE group_id = 'web10.app/groups/jacoby149/close-friends' AND requester_key = 'bob';
 
 -- Add to group members
-INSERT INTO group_members VALUES ('jacoby149.close-friends', 'bob', 'member', now(), now(), 0);
+INSERT INTO group_members VALUES ('web10.app/groups/jacoby149/close-friends', 'bob', 'member', now(), now(), 0);
 ```
 
 **Leave a group:**
@@ -78,13 +85,13 @@ INSERT INTO group_members VALUES ('jacoby149.close-friends', 'bob', 'member', no
 INSERT INTO group_members
 SELECT group_id, member_key, role, joined_at, now(), 1
 FROM group_members
-WHERE group_id = 'jazz-collectors' AND member_key = 'jacoby149';
+WHERE group_id = 'web10.app/groups/dave/jazz-collectors' AND member_key = 'jacoby149';
 ```
 Tombstone the membership. You're out.
 
 **Block sharing (without leaving):**
 ```sql
-INSERT INTO user_group_sharing VALUES ('jacoby149', 'jazz-collectors', 0, now(), now(), 0);
+INSERT INTO user_group_sharing VALUES ('jacoby149', 'web10.app/groups/dave/jazz-collectors', 0, now(), now(), 0);
 ```
 Your posts are hidden from the group. You still see their posts. Reversible.
 
@@ -105,11 +112,11 @@ Four parallel queries. No joins between them. Clean.
 ## Group Management Screen
 
 ```
-jacoby149.close-friends
+web10.app/groups/jacoby149/close-friends
 ─────────────────────
 Join policy: invite only  [Change]
 Members (12):
-  jacoby149  [admin]
+  jacoby149  [owner]
   alice      [member]  [Remove]
   bob        [member]  [Remove]
   ...
@@ -123,17 +130,17 @@ Your posts in this group: 24
 INSERT INTO doc_groups
 SELECT doc_id, group_id, permission, created_at, now(), 1
 FROM doc_groups
-WHERE group_id = 'jacoby149.close-friends'
+WHERE group_id = 'web10.app/groups/jacoby149/close-friends'
   AND deleted = 0
   -- need author_key, which isn't in doc_groups — join with documents
 ```
-Actually, need to join with posts to filter by author:
+Actually, need to join with documents to filter by author:
 ```sql
-INSERT INTO doc_groups (doc_id, group_id, permission, created_at, updated_at, deleted)
-SELECT pg.doc_id, pg.group_id, pg.permission, pg.created_at, now(), 1
+INSERT INTO doc_groups (doc_id, group_id, created_at, updated_at, deleted)
+SELECT pg.doc_id, pg.group_id, pg.created_at, now(), 1
 FROM doc_groups pg
 JOIN documents p ON pg.doc_id = p.doc_id
-WHERE pg.group_id = 'jacoby149.close-friends'
+WHERE pg.group_id = 'web10.app/groups/jacoby149/close-friends'
   AND p.author_key = 'jacoby149'
   AND pg.deleted = 0;
 ```

--- a/knowledge/knowledge-base/web10-social-v3/messages.md
+++ b/knowledge/knowledge-base/web10-social-v3/messages.md
@@ -29,7 +29,7 @@ SELECT p.doc_id, p.author_key, p.body, p.created_at
 FROM documents p
 JOIN doc_groups pg ON p.doc_id = pg.doc_id
 WHERE p.deleted = 0
-  AND pg.group_id = 'jacoby149.inbox'
+  AND pg.group_id = 'web10.app/groups/jacoby149/inbox'
   AND pg.deleted = 0
   AND p.author_key != 'jacoby149'     -- not your own sent mail
 ORDER BY p.created_at DESC;
@@ -54,13 +54,13 @@ SELECT p.doc_id, p.author_key, p.body, p.created_at
 FROM documents p
 JOIN doc_groups pg ON p.doc_id = pg.doc_id
 WHERE p.deleted = 0
-  AND pg.group_id = 'alice-and-bob'
+  AND pg.group_id = 'web10.app/groups/jacoby149/alice-and-bob'
   AND pg.deleted = 0
 ORDER BY p.created_at ASC;            -- chronological, oldest first
 ```
 
-Alice's messages: `alice.messages` collection, attached to `alice-and-bob` group.
-Bob's messages: `bob.messages` collection, attached to `alice-and-bob` group.
+Alice's messages: `alice.messages` collection, attached to `web10.app/groups/jacoby149/alice-and-bob` group.
+Bob's messages: `bob.messages` collection, attached to `web10.app/groups/jacoby149/alice-and-bob` group.
 Same group. Different collections. One query returns both.
 
 **Unread count:** The app tracks read state locally (or in a `message_read` table).
@@ -79,28 +79,28 @@ Unread = inbox documents minus read documents.
 
 ```
 User opens /messages
-  → GET /messages/inbox       (documents in jacoby149.inbox group)
-  → GET /messages/sent        (jacoby149's posts in outbox collection)
-  → parallel: resolve sender avatars
-  → parallel: check read status
-  → render
+   → GET /messages/inbox       (documents in web10.app/groups/jacoby149/inbox group)
+   → GET /messages/sent        (jacoby149's posts in outbox collection)
+   → parallel: resolve sender avatars
+   → parallel: check read status
+   → render
 
 User opens a DM thread
-  → GET /groups/alice-and-bob/posts  (all documents in the group, chronological)
-  → mark messages as read
-  → render
+   → GET /groups/web10.app/groups/jacoby149/alice-and-bob/posts  (all documents in the group, chronological)
+   → mark messages as read
+   → render
 ```
 
 ## Send a Message
 
 ```
 User types message, taps send to alice
-  → POST /jacoby149/outbox
-     { "text": {"type": "text", "value": "hey"},
-       "groups": ["alice.inbox"] }
-  → API: INSERT INTO documents (jacoby149's collection)
-  → API: INSERT INTO doc_groups (alice.inbox)
-  → alice discovers it next time she checks her inbox
+   → POST /jacoby149/outbox
+      { "text": {"type": "text", "value": "hey"},
+        "groups": ["web10.app/groups/alice/inbox"] }
+   → API: INSERT INTO documents (jacoby149's collection)
+   → API: INSERT INTO doc_groups (web10.app/groups/alice/inbox)
+   → alice discovers it next time she checks her inbox
 ```
 
 One insert. One group attachment. No fan-out. Alice sees it when she queries.

--- a/knowledge/knowledge-base/web10-social-v3/notifications.md
+++ b/knowledge/knowledge-base/web10-social-v3/notifications.md
@@ -10,7 +10,7 @@ Notifications
 alice liked your post · 2m ago
 bob commented on your post · 15m ago
 charlie requested to follow · 1h ago
-dave joined jazz-collectors · 3h ago
+dave joined web10.app/groups/dave/jazz-collectors · 3h ago
 ```
 
 ## Protocol Mapping
@@ -56,9 +56,11 @@ WHERE c.deleted = 0
 ```sql
 SELECT gjr.requester_key, gjr.group_id, gjr.requested_at
 FROM group_join_requests gjr
-JOIN group_contracts gc ON gjr.group_id = gc.group_id
 WHERE gjr.status = 'pending'
-  AND gc.admin_key = 'jacoby149'
+  AND gjr.group_id IN (
+    SELECT group_id FROM group_members
+    WHERE member_key = 'jacoby149' AND role = 'owner' AND deleted = 0
+  )
   AND gjr.created_at > now() - INTERVAL 1 HOUR;
 ```
 
@@ -67,8 +69,8 @@ WHERE gjr.status = 'pending'
 SELECT gm.member_key, gm.group_id, gm.joined_at
 FROM group_members gm
 WHERE gm.group_id IN (
-  SELECT group_id FROM group_contracts
-  WHERE admin_key = 'jacoby149' AND deleted = 0
+  SELECT group_id FROM group_members
+  WHERE member_key = 'jacoby149' AND role = 'owner' AND deleted = 0
 )
 AND gm.joined_at > now() - INTERVAL 1 HOUR;
 ```
@@ -88,11 +90,11 @@ Bob reacts to jacoby149's post
 
 **On every join request:**
 ```
-Bob requests to join jacoby149.followers
-  → API writes to group_join_requests
-  → API: who is the admin? (read group_contracts)
-  → API: push notification to jacoby149 via WebSocket
-     { "type": "follow_request", "from": "bob", "group_id": "jacoby149.followers" }
+Bob requests to join web10.app/groups/jacoby149/followers
+   → API writes to group_join_requests
+   → API: who is the owner? (read group_members with role='owner')
+   → API: push notification to jacoby149 via WebSocket
+      { "type": "follow_request", "from": "bob", "group_id": "web10.app/groups/jacoby149/followers" }
 ```
 
 The API knows about the write. It pushes the notification. No polling. No background job.

--- a/knowledge/knowledge-base/web10-social-v3/other-profile.md
+++ b/knowledge/knowledge-base/web10-social-v3/other-profile.md
@@ -9,8 +9,8 @@ You visit someone else's profile. You see what's visible to you — groups you s
          bio text here
 
 Public groups:
-[alice.public]     [open] — 50 posts
-[alice.followers]  [request] — "Follow" button
+[web10.app/groups/alice/public]     [open] — 50 posts
+[web10.app/groups/alice/followers]  [request] — "Follow" button
 
 Posts you can see:
 post 1 | 2h ago | [like] [comment]
@@ -29,8 +29,7 @@ GET /alice/profile
 ```
 SELECT gc.group_id, gc.name, gc.join_policy
 FROM group_contracts gc
-WHERE gc.admin_key = 'alice'
-  AND gc.deleted = 0
+WHERE gc.deleted = 0
   AND (gc.join_policy = 'open'
        OR EXISTS (
          SELECT 1 FROM group_members gm
@@ -40,10 +39,10 @@ WHERE gc.admin_key = 'alice'
        ));
 ```
 
-**"Follow" button:** Check if you're in `alice.followers`.
+**"Follow" button:** Check if you're in `web10.app/groups/alice/followers`.
 ```
 SELECT 1 FROM group_members
-WHERE group_id = 'alice.followers'
+WHERE group_id = 'web10.app/groups/alice/followers'
   AND member_key = 'jacoby149'
   AND deleted = 0;
 ```
@@ -54,7 +53,7 @@ No row → show "Follow". Row exists → show "Following" + "Unfollow".
 GET /alice/posts?discover=true
 → ClickHouse: posts WHERE author=alice AND post in groups jacoby149 belongs to
 ```
-If you're only in `alice.public`, you see posts attached to `alice.public`. If you're also in `alice.close-friends`, you see those too. The groups control visibility.
+If you're only in `web10.app/groups/alice/public`, you see posts attached to `web10.app/groups/alice/public`. If you're also in `web10.app/groups/alice/close-friends`, you see those too. The groups control visibility.
 
 **Post counts per group:**
 ```
@@ -84,12 +83,12 @@ Same four-call pattern. The groups filter what's visible. No special permissions
 
 ```
 User taps "Follow" on alice's profile
-  → POST /groups/alice.followers/join-requests
-     { "requester": "jacoby149", "status": "pending" }
-  → INSERT INTO group_join_requests
-  → alice gets a notification
-  → alice approves → INSERT INTO group_members
-  → jacoby149 can now see posts in alice.followers
+   → POST /groups/web10.app/groups/alice/followers/join-requests
+      { "requester": "jacoby149", "status": "pending" }
+   → INSERT INTO group_join_requests
+   → alice gets a notification
+   → alice approves → INSERT INTO group_members
+   → jacoby149 can now see posts in web10.app/groups/alice/followers
 ```
 
 No follows table. Group join request + group membership. Done.

--- a/knowledge/knowledge-base/web10-social-v3/post-detail.md
+++ b/knowledge/knowledge-base/web10-social-v3/post-detail.md
@@ -5,7 +5,7 @@ Single post view. Content, reactions, comments, share options.
 ## What the Screen Shows
 
 ```
-jacoby149 · 2h ago · [web10-dev]
+jacoby149 · 2h ago · [web10.app/groups/charlie/st-louis-chess-club]
 ─────────────────────
 "just shipped the new groups feature"
 
@@ -113,9 +113,9 @@ User taps ❤️
   → POST /jacoby149/reactions
      { "ref": {"type": "ref", "value": "{doc_id}"},
        "reaction_type": {"type": "text", "value": "like"},
-       "groups": ["web10-dev"] }
-  → API: INSERT INTO documents (jacoby149's collection)
-  → API: INSERT INTO doc_groups (web10-dev, so others can see your reaction)
+       "groups": ["web10.app/groups/charlie/st-louis-chess-club"] }
+   → API: INSERT INTO documents (jacoby149's collection)
+   → API: INSERT INTO doc_groups (web10.app/groups/charlie/st-louis-chess-club, so others can see your reaction)
 ```
 
 The reaction is a post. It lives in your collection. It's attached to the same group as the original post so group members can see it.
@@ -127,7 +127,7 @@ User types comment, taps send
   → POST /jacoby149/comments
      { "ref": {"type": "ref", "value": "{doc_id}"},
        "text": {"type": "text", "value": "this is fire"},
-       "groups": ["web10-dev"] }
+       "groups": ["web10.app/groups/charlie/st-louis-chess-club"] }
   → API: INSERT INTO documents
   → API: INSERT INTO doc_groups
 ```

--- a/knowledge/knowledge-base/web10-social-v3/search.md
+++ b/knowledge/knowledge-base/web10-social-v3/search.md
@@ -14,8 +14,8 @@ People:
   [avatar] alice — jazz enthusiast
 
 Groups:
-  web10-dev — 100k members, open
-  jazz-collectors — 500 members, request
+  web10.app/groups/charlie/st-louis-chess-club — 100k members, open
+  web10.app/groups/dave/jazz-collectors — 500 members, request
 
 Posts:
   jacoby149 · 2h ago — "just shipped the new groups feature"
@@ -109,7 +109,7 @@ Day one: ngram index. Eventually: tokenbf or Elasticsearch if needed.
 - [ ] Ngram index on documents.body — CREATE INDEX on the documents table
 - [ ] Group member count in results — JOIN with group_members count
 - [ ] Recent searches — client-side localStorage
-- [ ] Search within a group — `?group=web10-dev&q=query`
+- [ ] Search within a group — `?group=web10.app/groups/charlie/st-louis-chess-club&q=query`
 
 ## Proof
 

--- a/knowledge/knowledge-base/web10-social-v3/settings.md
+++ b/knowledge/knowledge-base/web10-social-v3/settings.md
@@ -14,9 +14,9 @@ App Access
   [Kill all app access]
 
 Groups
-  jacoby149.public          [Manage]
-  jacoby149.close-friends   [Manage]
-  jazz-collectors            [Block sharing] [Leave]
+  web10.app/groups/jacoby149/public          [Manage]
+  web10.app/groups/jacoby149/close-friends   [Manage]
+  web10.app/groups/dave/jazz-collectors            [Block sharing] [Leave]
 
 Blocked Users
   spam-bot-123   [Unblock]
@@ -76,13 +76,13 @@ WHERE user_key = 'jacoby149' AND blocked_key = 'spammer';
 
 **Block sharing with a group:**
 ```sql
-INSERT INTO user_group_sharing VALUES ('jacoby149', 'jazz-collectors', 0, now(), now(), 0);
+INSERT INTO user_group_sharing VALUES ('jacoby149', 'web10.app/groups/dave/jazz-collectors', 0, now(), now(), 0);
 ```
 
 **Make everything private:** Bulk tombstone all doc_groups entries.
 ```sql
-INSERT INTO doc_groups (doc_id, group_id, permission, created_at, updated_at, deleted)
-SELECT pg.doc_id, pg.group_id, pg.permission, pg.created_at, now(), 1
+INSERT INTO doc_groups (doc_id, group_id, created_at, updated_at, deleted)
+SELECT pg.doc_id, pg.group_id, pg.created_at, now(), 1
 FROM doc_groups pg
 JOIN documents p ON pg.doc_id = p.doc_id
 WHERE p.author_key = 'jacoby149'
@@ -100,7 +100,7 @@ SELECT gm.group_id FROM group_members gm WHERE gm.member_key = 'jacoby149' AND g
 **Delete account:** Tombstone everything.
 ```sql
 -- Tombstone all posts
-INSERT INTO documents SELECT doc_id, author_key, collection_name, body, discoverable, tags, created_at, now(), 1 FROM documents WHERE author_key = 'jacoby149' AND deleted = 0;
+INSERT INTO documents SELECT doc_id, author_key, collection_name, body, tags, created_at, now(), 1 FROM documents WHERE author_key = 'jacoby149' AND deleted = 0;
 
 -- Tombstone all service contracts
 INSERT INTO service_contracts SELECT user_key, service_name, allowed_origin, created_at, now(), 1 FROM service_contracts WHERE user_key = 'jacoby149' AND deleted = 0;
@@ -127,11 +127,11 @@ Three queries. No joins. Clean.
 The per-group blacklist is managed from the group management screen, not settings. But it's worth noting:
 
 ```
-jazz-collectors → per-group blacklist: dave
-  → INSERT INTO group_blacklist ('jacoby149', 'jazz-collectors', 'dave', now())
+web10.app/groups/dave/jazz-collectors → per-group blacklist: dave
+  → INSERT INTO group_blacklist ('jacoby149', 'web10.app/groups/dave/jazz-collectors', 'dave', now())
   → dave is still a member
-  → dave sees everyone's posts in jazz-collectors
-  → dave does NOT see jacoby149's posts in jazz-collectors
+  → dave sees everyone's posts in web10.app/groups/dave/jazz-collectors
+  → dave does NOT see jacoby149's posts in web10.app/groups/dave/jazz-collectors
 ```
 
 ## TODO

--- a/knowledge/knowledge-base/web10-social-v3/your-profile.md
+++ b/knowledge/knowledge-base/web10-social-v3/your-profile.md
@@ -11,9 +11,9 @@ You visit your own profile. You see your avatar, bio, groups, and posts.
 Groups:    Posts:    Followers:
 3          42        1,203
 
-[jacoby149.public]     [open]
-[jacoby149.close-friends] [invite only]
-[jazz-collectors]        [request]
+[web10.app/groups/jacoby149/public]     [open]
+[web10.app/groups/jacoby149/close-friends] [invite only]
+[web10.app/groups/dave/jazz-collectors]        [request]
 
 --- posts ---
 post 1 | 2h ago | [like] [comment]
@@ -32,20 +32,25 @@ API converts minio to presigned URL. One CRUD call.
 **Groups you belong to:** Group membership query.
 ```
 GET /groups?member=jacoby149
-→ [jacoby1449.public, jacoby149.close-friends, jazz-collectors]
+→ [web10.app/groups/jacoby149/public, web10.app/groups/jacoby149/close-friends, web10.app/groups/dave/jazz-collectors]
 ```
 For each group, fetch metadata from `group_contracts`.
 
-**Groups you admin:** Filter by admin key.
+**Groups you admin:** Filter by owner role.
 ```
-SELECT group_id, name, join_policy FROM group_contracts
-WHERE admin_key = 'jacoby149' AND deleted = 0;
+SELECT gm.group_id, gc.name, gc.join_policy
+FROM group_members gm
+JOIN group_contracts gc ON gm.group_id = gc.group_id
+WHERE gm.member_key = 'jacoby149'
+  AND gm.role = 'owner'
+  AND gm.deleted = 0
+  AND gc.deleted = 0;
 ```
 
 **Follower count:** Group membership count.
 ```
 SELECT count() FROM group_members
-WHERE group_id = 'jacoby149.followers' AND deleted = 0;
+WHERE group_id = 'web10.app/groups/jacoby149/followers' AND deleted = 0;
 ```
 
 **Your posts:** CRUD discover.

--- a/knowledge/knowledge-base/web10-v2-to-v3/discovery-is-crud.md
+++ b/knowledge/knowledge-base/web10-v2-to-v3/discovery-is-crud.md
@@ -2,99 +2,65 @@
 
 ## The Problem
 
-`/public` and `/discover` are separate endpoints from CRUD. The discovery index is a separate data surface. The public ledger is a separate data surface. The client writes to CRUD and mirrors to the ledger. The server indexes to the discovery table. Three surfaces. Sync problems. Double-write.
+v2 had `/public` and `/discover` as separate endpoints from CRUD. The discovery index was a separate data surface. The public ledger was a separate data surface. The client wrote to CRUD and mirrored to the ledger. The server indexed to the discovery table. Three surfaces. Sync problems. Double-write.
 
-The discovery index exists because MongoDB can't query across users. ClickHouse can. The discovery index is a MongoDB workaround, not a platform feature.
+The discovery index existed because MongoDB can't query across users. ClickHouse can. The discovery index was a MongoDB workaround, not a platform feature.
 
 ## The Solution
 
-Discovery is a CRUD parameter. One endpoint. One data surface. No mirrors. No sync.
+Discovery is a CRUD parameter. One endpoint. One table. No mirrors. No sync.
 
 ```
-GET /alice/posts?discover=true    → posts Alice can see (public + followers + groups)
+GET /alice/posts?discover=true    → posts Alice can see (groups she belongs to)
 GET /alice/posts?discover=false   → only Alice's own posts
 GET /alice/posts                  → default: Alice's own posts (private)
 ```
 
-The `discover` flag tells the API to apply cross-user visibility filtering. Without it, the API returns only the authenticated user's own data. With it, the API returns data from other users where the authenticated user has permission.
+The `discover` flag tells the API to apply cross-user visibility filtering. Without it, the API returns only the authenticated user's own data. With it, the API returns data from other users where the user is a member of a group the post is attached to.
 
 ## How It Works
 
-The CRUD endpoint handles everything. ClickHouse filters by permissions at query time:
+The CRUD endpoint handles everything. ClickHouse filters by group membership at query time:
 
 ```sql
 -- discover=false: only the user's own posts
-SELECT * FROM posts
+SELECT * FROM documents
 WHERE author_key = 'alice' AND deleted = 0
 ORDER BY created_at DESC;
 
--- discover=true: posts Alice can see (cross-user, permission-filtered)
-SELECT * FROM posts
-WHERE deleted = 0
-  AND (
-    -- Public posts from anyone
-    visibility = 'public'
-    AND collection_visibility = 'public'
-
-    OR
-
-    -- Followers-only: Alice sees them if she follows the author
-    (visibility = 'followers'
-     AND author_key IN (
-       SELECT following_key FROM follows
-       WHERE follower_key = 'alice' AND deleted = 0
-     ))
-
-    OR
-
-    -- Group posts: Alice sees them if she's a member
-    (visibility = 'group'
-     AND visibility_scope IN (
-       SELECT group_id FROM group_members
-       WHERE member_key = 'alice' AND deleted = 0
-     ))
-
-    OR
-
-    -- Alice's own posts (always visible)
-    author_key = 'alice'
+-- discover=true: posts Alice can see (cross-user, group membership)
+SELECT p.doc_id, p.author_key, p.body, p.tags, p.created_at
+FROM documents p
+JOIN doc_groups pg ON p.doc_id = pg.doc_id
+JOIN group_members gm ON pg.group_id = gm.group_id
+WHERE p.deleted = 0
+  AND gm.member_key = 'alice'
+  AND gm.deleted = 0
+  AND NOT EXISTS (
+    SELECT 1 FROM user_blacklist
+    WHERE user_key = p.author_key AND blocked_key = 'alice'
   )
-ORDER BY created_at DESC
+  AND NOT EXISTS (
+    SELECT 1 FROM group_blacklist
+    WHERE user_key = p.author_key
+      AND group_id = pg.group_id
+      AND blocked_key = 'alice'
+  )
+ORDER BY p.created_at DESC
 LIMIT 50;
 ```
 
-## The Post-Level `discoverable` Flag
+Alice sees every post attached to a group she belongs to. No visibility column. No collection ceiling. Just group membership.
 
-Every post has a `discoverable` flag. The author controls it:
-
-```ts
-// Public and discoverable (default for public posts)
-await createPost({ text: "hello world", visibility: "public", discoverable: true });
-
-// Public but not discoverable (visible by direct link, not in feeds)
-await createPost({ text: "private link post", visibility: "public", discoverable: false });
-
-// Followers-only (discoverable within followers)
-await createPost({ text: "behind the scenes", visibility: "followers", discoverable: true });
-```
-
-The `discoverable` flag is per-record. The author sets it. The API respects it. If `discoverable: false`, the post is excluded from `discover=true` queries but still visible to the author and anyone with a direct link.
-
-```sql
--- discover=true also filters by discoverable flag
-SELECT * FROM posts
-WHERE deleted = 0
-  AND discoverable = 1
-  AND (visibility checks...)
-```
+**The discover group.** Public posts are attached to `web10/discover` — an open group with auto-enrollment on signup, including the anon user. Anyone can read posts attached to it. The author controls it: attach to the group for public, don't for private.
 
 ## What Disappears
 
 - `/discover` endpoint — replaced by `?discover=true` on CRUD
-- `/public` endpoint — replaced by `?discover=true&visibility=public`
-- Discovery index table — replaced by ClickHouse filtering on the posts table
-- Public ledger — replaced by ClickHouse aggregation on the reactions table
-- Server-side indexing hooks — replaced by a single insert into the posts table
+- `/public` endpoint — replaced by `?discover=true` (discover group membership)
+- Discovery index table — replaced by ClickHouse filtering on the documents table
+- Public ledger — replaced by ClickHouse aggregation on documents with `ref` type
+- Server-side indexing hooks — replaced by a single insert into documents + doc_groups
 - Client-side ledger mirrors — replaced by the API writing once
 
 ## The API Surface
@@ -108,29 +74,29 @@ GET  /{user}/posts?discover=true&tags=web10     → posts with tag
 GET  /{user}/posts/{id}              → single post (by ID, if permitted)
 
 POST /{user}/posts                   → create a post
-PATCH /{user}/posts/{id}             → update a post
+PATCH /{user}/posts/{id}             → update a post (tombstone + new version)
 DELETE /{user}/posts/{id}            → delete a post (tombstone)
 
-# Same pattern for reactions, comments, follows
+# Same pattern for reactions, comments, everything
 GET  /{user}/reactions?discover=true → reactions the user can see
 GET  /{user}/comments?discover=true  → comments the user can see
 ```
 
-One endpoint per resource. The `discover` flag controls cross-user visibility. The `sort` and `tags` parameters control ordering and filtering. ClickHouse handles the rest.
+One endpoint per service. The `discover` flag controls cross-user visibility. The `sort` and `tags` parameters control ordering and filtering. ClickHouse handles the rest.
 
 ## Why This Is Better
 
 **1. No double-write.** One insert. One table. No discovery index mirror. No public ledger mirror. The API writes once. ClickHouse queries it.
 
-**2. No sync problem.** The data is in one place. ClickHouse filters at query time. No stale projections. No reconciliation. No tombstone cleanup for the index.
+**2. No sync problem.** The data is in one place. ClickHouse filters at query time. No stale projections. No reconciliation.
 
-**3. Simpler API.** One endpoint per resource. The `discover` flag is a boolean. The client doesn't think about which endpoint to hit. It just sets the flag.
+**3. Simpler API.** One endpoint per service. The `discover` flag is a boolean. The client doesn't think about which endpoint to hit. It just sets the flag.
 
-**4. Simpler stack.** No discovery index table. No public ledger table. No server-side hooks. No client-side mirrors. One table for posts. One table for reactions. One table for comments.
+**4. Simpler stack.** No discovery index table. No public ledger table. No server-side hooks. No client-side mirrors. One table for documents. Groups for permissions.
 
 **5. Real-time.** No delay between write and discovery. The post is discoverable immediately because it's in the same table ClickHouse queries.
 
-**6. The author controls it.** The `discoverable` flag is per-record. The author decides. The API respects it. No platform override. No shadow-banning. No algorithmic suppression.
+**6. The author controls it.** Attaching a post to a group is the author's choice. The discover group makes it public. The followers group makes it followers-only. No groups makes it private. No platform override. No shadow-banning. No algorithmic suppression.
 
 ## The Developer Experience
 
@@ -147,15 +113,18 @@ const trending = await readPosts({ discover: true, sort: 'trending' });
 // Read posts with a tag
 const tagged = await readPosts({ discover: true, tags: ['web10'] });
 
-// Create a discoverable post
-await createPost({ text: "hello", visibility: "public", discoverable: true });
+// Create a public post (attach to discover group)
+await createPost({ text: "hello", groups: ["web10/discover"] });
 
-// Create a non-discoverable post (visible by link only)
-await createPost({ text: "secret", visibility: "public", discoverable: false });
+// Create a private post (no groups)
+await createPost({ text: "secret" });
+
+// Create a followers-only post
+await createPost({ text: "behind the scenes", groups: ["alice.followers"] });
 ```
 
-The dev doesn't think about endpoints. They don't think about the discovery index. They don't think about the ledger. They just set `discover: true` and it works.
+The dev doesn't think about endpoints. They don't think about the discovery index. They don't think about the ledger. They attach to groups and set `discover: true`. That's it.
 
 ## Summary
 
-`/discover` and `/public` disappear. Discovery is a CRUD parameter. One endpoint. One table. No mirrors. No sync. The `discover` flag controls cross-user visibility. The `discoverable` flag controls whether the author wants to be found. ClickHouse filters at query time. The API writes once. The client sets a boolean. That's it.
+`/discover` and `/public` disappear. Discovery is a CRUD parameter. One endpoint. One table. No mirrors. No sync. The `discover` flag controls cross-user visibility. Group membership controls what's visible. The discover group makes posts public. ClickHouse filters at query time. The API writes once. The client sets a boolean. That's it.

--- a/knowledge/knowledge-base/web10-v2-to-v3/groups-platform-primitive.md
+++ b/knowledge/knowledge-base/web10-v2-to-v3/groups-platform-primitive.md
@@ -2,18 +2,17 @@
 
 ## The Idea
 
-Groups are not just a visibility type. They are a fundamental platform feature. Users create groups, add members, manage admins, and post to them. Groups are the building block for communities, teams, and circles.
+Groups are not just a visibility type. They are a fundamental platform feature. Users create groups, add members, manage roles, and post to them. Groups are the building block for communities, teams, and circles.
 
-Groups are a CRUD endpoint. The platform manages them. The user controls them.
+Groups are policy containers. They hold people, not data. Any document from any service can be attached to any group. The group's roles define who sees it and what they can do.
 
 ## The Schema
 
 ```sql
-CREATE TABLE groups (
-    group_id String,
-    name String,
-    description String,
-    admin_key String,          -- the creator/admin
+CREATE TABLE group_contracts (
+    group_id String,           -- 'web10.app/groups/jacoby149/abacus-enthusiasts'
+    roles String,              -- JSON array of roles with services + permissions
+    join_policy String,        -- 'open', 'request', 'invite_only'
     created_at DateTime64(3),
     updated_at DateTime64(3),
     deleted UInt8 DEFAULT 0
@@ -23,7 +22,7 @@ ORDER BY group_id;
 CREATE TABLE group_members (
     group_id String,
     member_key String,
-    role String,               -- 'admin', 'member'
+    role String,               -- role name from the contract (e.g. 'member', 'owner')
     joined_at DateTime64(3),
     updated_at DateTime64(3),
     deleted UInt8 DEFAULT 0
@@ -31,24 +30,27 @@ CREATE TABLE group_members (
 ORDER BY (group_id, member_key);
 ```
 
+No `admin_key` in the groups table. The owner is the member with the `owner` role. The contract defines what `owner` means.
+
 ## The API
 
 ```
 # Group CRUD
 POST   /groups                          → create a group
 GET    /groups/{id}                     → get a group
-PATCH  /groups/{id}                     → update a group (name, description)
+PATCH  /groups/{id}                     → update a group (roles, join policy)
 DELETE /groups/{id}                     → delete a group (tombstone)
 
 # Membership
 POST   /groups/{id}/members             → add a member
 GET    /groups/{id}/members             → list members
-PATCH  /groups/{id}/members/{user}      → update role (promote to admin)
+PATCH  /groups/{id}/members/{user}      → update role
 DELETE /groups/{id}/members/{user}      → remove a member
 
 # Posts to a group
-POST   /{user}/posts?group={group_id}   → create a post visible to group members
-GET    /{user}/posts?group={group_id}   → read posts in this group
+POST   /{user}/posts                    → create a post
+   { text: "hello", groups: ["grp-abc"] }
+GET    /{user}/posts?discover=true      → discover posts (group membership filter)
 ```
 
 ## Creating a Group
@@ -56,12 +58,24 @@ GET    /{user}/posts?group={group_id}   → read posts in this group
 ```ts
 const group = await createGroup({
   name: "Web10 Dev Team",
-  description: "Internal team discussions"
+  join_policy: "invite_only",
+  roles: [
+    {
+      name: "owner",
+      services: ["*"],
+      permissions: ["readAll", "create", "updateOwn", "updateAll", "deleteOwn", "deleteAll", "hideAll", "manageRoles", "assignRoles", "revokeRoles", "deleteGroup"]
+    },
+    {
+      name: "member",
+      services: ["posts", "comments"],
+      permissions: ["readAll", "create", "updateOwn", "deleteOwn"]
+    }
+  ]
 });
-// Returns: { group_id: "grp-abc", name: "Web10 Dev Team", admin_key: "alice" }
+// Returns: { group_id: "grp-abc", name: "Web10 Dev Team" }
 ```
 
-The creator is the admin. The admin can add members and promote other admins.
+The creator is the owner. The owner can add members and assign roles.
 
 ## Adding Members
 
@@ -71,80 +85,69 @@ await addMember({
   member_key: "bob",
   role: "member"
 });
-
-await addMember({
-  group_id: "grp-abc",
-  member_key: "charlie",
-  role: "admin"  // promote to admin
-});
 ```
 
-The member receives a notification. They can see posts in the group on discover. They can post to the group.
+The member receives a notification. They can see posts in the group on discover. They can post to the group if their role allows it.
 
 ## Posting to a Group
 
 ```ts
-await createPost({
+await createDocument({
   text: "team update: v3 architecture locked",
-  visibility: "group",
-  visibility_scope: "grp-abc",
-  discoverable: true  // discoverable within the group
+  groups: ["grp-abc"]
 });
 ```
 
-The post is visible to all group members on `discover=true`. It is not visible to non-members. The `discoverable` flag controls whether it appears in the group feed or only by direct link.
+The post is visible to all group members on `discover=true`. It is not visible to non-members. The author controls which groups the post is attached to.
 
 ## Group Discovery Query
 
 When Alice hits discover, group posts are included if she's a member:
 
 ```sql
-SELECT * FROM posts
-WHERE deleted = 0
-  AND (
-    visibility = 'public'
-    OR (visibility = 'followers' AND author_key IN (SELECT following_key FROM follows WHERE follower_key = 'alice'))
-    OR (visibility = 'group'
-        AND visibility_scope IN (
-          SELECT group_id FROM group_members
-          WHERE member_key = 'alice' AND deleted = 0
-        ))
-    OR author_key = 'alice'
-  );
+SELECT p.doc_id, p.author_key, p.body, p.tags, p.created_at
+FROM documents p
+JOIN doc_groups pg ON p.doc_id = pg.doc_id
+JOIN group_members gm ON pg.group_id = gm.group_id
+WHERE p.deleted = 0
+  AND gm.member_key = 'alice'
+  AND gm.deleted = 0
+ORDER BY p.created_at DESC
+LIMIT 50;
 ```
+
+No visibility column. No collection ceiling. Just group membership.
 
 ## Group Permissions
 
 | Action | Who Can Do It |
 |---|---|
 | Create group | Any user |
-| Add member | Admin or member (depending on group settings) |
-| Remove member | Admin only |
-| Promote to admin | Admin only |
-| Delete group | Admin only |
-| Post to group | Any member |
-| See group posts | Any member (if discoverable) |
+| Add member | Owner or member with `assignRoles` |
+| Remove member | Owner or member with `revokeRoles` |
+| Update role | Owner or member with `assignRoles` |
+| Delete group | Owner (member with `deleteGroup`) |
+| Post to group | Any member with `create` on the service |
+| See group posts | Any member with `readAll` on the service |
 
 ## Group Settings
 
-Groups can have settings that control membership:
+Groups control membership through join policies:
 
 ```json
 {
   "group_id": "grp-abc",
-  "name": "Web10 Dev Team",
-  "join_policy": "invite-only",  // "open", "invite-only", "approval"
-  "post_policy": "members-only", // "members-only", "admins-only"
-  "discoverable": true           // group posts appear in member feeds
+  "join_policy": "invite_only",
+  "roles": [
+    { "name": "owner", "services": ["*"], "permissions": ["readAll", "create", "updateOwn", "updateAll", "deleteOwn", "deleteAll", "hideAll", "manageRoles", "assignRoles", "revokeRoles", "deleteGroup"] },
+    { "name": "member", "services": ["posts", "comments"], "permissions": ["readAll", "create", "updateOwn", "deleteOwn"] }
+  ]
 }
 ```
 
-- `join_policy: "open"` — anyone can join
-- `join_policy: "invite-only"` — only admins can add members
-- `join_policy: "approval"` — members request to join, admins approve
-
-- `post_policy: "members-only"` — any member can post
-- `post_policy: "admins-only"` — only admins can post
+- `join_policy: "open"` — anyone can join instantly
+- `join_policy: "request"` — members request to join, owner approves
+- `join_policy: "invite_only"` — only the owner can add members
 
 ## Why Groups Are Fundamental
 
@@ -153,24 +156,27 @@ Groups are not a feature. They are the building block for:
 - **Teams** — internal collaboration, project discussions
 - **Communities** — interest-based groups, hobby circles
 - **Circles** — close friends, family, trusted contacts
-- **Audiences** — newsletter subscribers, beta testers
-- **Moderation** — admin-controlled spaces with rules
+- **Audiences** — followers, newsletter subscribers, beta testers
+- **Moderation** — owner-controlled spaces with roles
 
 Groups replace the need for separate collection types. Instead of `public_posts`, `private_posts`, `group-posts`, the user creates groups and posts to them. The visibility is per-group. The membership is managed by the platform.
 
-## The Privacy Panel Integration
+## The Authenticator Integration
 
-The privacy panel shows groups the user is a member of:
+The authenticator shows groups the user manages and belongs to:
 
 ```
-Groups:
-  Web10 Dev Team (admin) → 5 members, 120 posts
-  Personal Circle (member) → 3 members, 45 posts
-  Public Community (member) → 1200 members, 5000 posts
+Groups you manage:
+  Web10 Dev Team (owner) → 5 members, invite only
+  Personal Circle (owner) → 3 members, invite only
+
+Groups you belong to:
+  Public Community (member) → 1200 members, open
+  Jazz Collectors (member) → 500 members, request
 ```
 
 The user can leave groups, manage membership, and control which groups their posts appear in.
 
 ## Summary
 
-Groups are a platform primitive. CRUD endpoint. Membership management. Admin controls. Post visibility. The building block for communities, teams, and circles. No separate collections. No term records. One table for groups. One table for membership. The API handles the rest.
+Groups are a platform primitive. Policy containers. Service-scoped roles. Join policies. Membership management. The building block for communities, teams, and circles. No visibility column. No collection ceiling. No term records. Groups define who sees what. Roles define what they can do.

--- a/knowledge/knowledge-base/web10-v2-to-v3/layered-permissions.md
+++ b/knowledge/knowledge-base/web10-v2-to-v3/layered-permissions.md
@@ -1,14 +1,8 @@
-# Layered Permissions: Collection Ceiling, Post-Level Narrowing
+# Layered Permissions: Replaced by Groups
 
-## The Model
+## What v2 Had
 
-The collection is the ceiling. The post can only narrow, never widen. The strictest permission wins.
-
-This is the Unix file permission model: directory permission is the ceiling, file permission can only narrow. The user's privacy panel manages collections. Individual posts can only be more private.
-
-## How It Works
-
-Each collection has a default visibility set by the user's privacy panel. Each post inherits that default. The post can override to be stricter — never less strict.
+v2 used a collection ceiling model. Each collection had a default visibility set by the user's privacy panel. Individual posts could only narrow that visibility — never widen it. The strictest permission won.
 
 ```
 Collection: public_posts (whitelist: ".*") → anyone can read
@@ -18,141 +12,71 @@ Result: followers-only (stricter wins)
 Collection: private_posts (whitelist: []) → owner only
 Post-level: visibility = "public" → IGNORED
 Result: owner-only (collection ceiling)
-
-Collection: group-posts (whitelist: group members)
-Post-level: visibility = "followers" → only followers who are also members
-Result: intersection (stricter wins)
 ```
 
-## The ClickHouse Schema
+This was the Unix file permission model: directory permission is the ceiling, file permission can only narrow. It was conceptually clean but operationally complex — term records with whitelists, blacklists, regex matching, per-action permissions. It was the source of most bugs in v2.
 
-```sql
-CREATE TABLE posts (
-    post_id String,
-    author_key String,
-    collection_name String,  -- 'public_posts', 'private_posts', 'group-posts'
-    body String,             -- JSON: full post content
-    visibility String,       -- post-level: 'public', 'private', 'followers', 'group'
-    visibility_scope String, -- group_id, if group
-    tags Array(String),
-    created_at DateTime64(3),
-    updated_at DateTime64(3),
-    deleted UInt8 DEFAULT 0
-) ENGINE = ReplacingMergeTree(updated_at)
-ORDER BY (author_key, post_id);
+## What v3 Does
 
--- Collection-level permissions (the ceiling)
-CREATE TABLE collection_permissions (
-    author_key String,
-    collection_name String,
-    visibility String,       -- 'public', 'private', 'followers', 'group'
-    visibility_scope String, -- group_id, if group
-    whitelist String,        -- JSON: who can access this collection
-    blacklist String,        -- JSON: who is blocked
-    updated_at DateTime64(3),
-    deleted UInt8 DEFAULT 0
-) ENGINE = ReplacingMergeTree(updated_at)
-ORDER BY (author_key, collection_name);
-```
+Groups replace the collection ceiling entirely. There is no `visibility` column. No `collection_permissions` table. No post-level narrowing. No ceiling. Just groups.
 
-When a post is created, it inherits the collection's visibility. The dev can narrow it:
+**A post is visible to whoever is in the groups it's attached to.**
 
 ```ts
-// Inherits collection default (public_posts → public)
-await createPost({ text: "hello world", collection: "public_posts" });
+// Public — attached to the discover group (open, auto-enrolled, anon is a member)
+await createDocument({
+  text: "hello world",
+  groups: ["web10/discover"]
+});
 
-// Narrows to followers-only (collection allows it, post is stricter)
-await createPost({ text: "behind the scenes", collection: "public_posts", visibility: "followers" });
+// Private — no groups
+await createDocument({
+  text: "secret"
+});
 
-// Tries to widen (private_posts → public) — REJECTED
-await createPost({ text: "going viral", collection: "private_posts", visibility: "public" });
-// API rejects: post visibility "public" exceeds collection ceiling "private"
+// Followers-only — attached to the followers group
+await createDocument({
+  text: "behind the scenes",
+  groups: ["alice.followers"]
+});
+
+// Multiple groups — visible to members of either
+await createDocument({
+  text: "team update",
+   groups: ["alice.followers", "charlie/st-louis-chess-club"]
+});
 ```
 
-## The Privacy Panel
+The discover group is the public surface. Open join policy. Auto-enrolled on signup. Anon is a member. Posts attached to it are public. Posts not attached to it are private.
 
-The user's UI shows collections and their default permissions. This is the primary way to manage data privacy:
+The followers group controls the followers-only surface. Join policy determines if it's public (open) or private (request). Members see posts attached to it.
 
-```
-alice/
-  public_posts/    → visibility: public (whitelist: ".*")
-  private_posts/   → visibility: private (whitelist: [])
-  group-posts/     → visibility: group (group: "web10-dev")
-  followers-posts/ → visibility: followers
-```
+**The role model replaces the ceiling.** Each group defines roles with service-scoped permissions. A follower gets `readAll` on posts. A member gets `readAll`, `create`, `updateOwn`, `deleteOwn`. An owner gets everything. The role defines what you can do. The group defines who can see.
 
-The user manages these at the collection level. 99% of posts inherit the collection default. The per-record `visibility` column handles the 1% exception.
+## Why Groups Are Simpler
 
-Posts that deviate from the collection default are shown in the data viewer as exceptions. The user can see them, understand them, and restore them to the collection default.
+| v2 (Collection Ceiling) | v3 (Groups) |
+|---|---|
+| Term records with whitelists/blacklists | Group membership |
+| `visibility` column per post | Groups array per post |
+| Collection-level ceiling + post-level narrowing | One permission model: roles |
+| Regex matching on whitelists | Exact group membership check |
+| Two checks must pass (collection + post) | One check: group membership |
+| Privacy panel manages collections | Authenticator manages groups |
 
-## The Query: Both Checks Must Pass
-
-Every discover query enforces both layers:
-
-```sql
-SELECT p.post_id, p.author_key, p.body, p.tags, p.created_at
-FROM posts p
-JOIN collection_permissions cp
-  ON p.author_key = cp.author_key AND p.collection_name = cp.collection_name
-WHERE p.deleted = 0
-  AND cp.deleted = 0
-  -- Collection-level check (the ceiling)
-  AND collection_visible_to(cp, 'alice')
-  -- Post-level check (stricter, can only narrow)
-  AND post_visible_to(p, 'alice')
-ORDER BY p.created_at DESC
-LIMIT 50;
-```
-
-The `collection_visible_to()` function checks if the collection allows the user. The `post_visible_to()` function checks if the post allows the user. Both must return true. The strictest permission is always enforced.
-
-## The Validation: API Enforces the Ceiling
-
-When a post is created, the API checks that the post-level visibility doesn't exceed the collection ceiling:
-
-```python
-def create_post(author, collection, body, visibility=None):
-    # Get the collection's default visibility
-    collection_perm = get_collection_permission(author, collection)
-
-    # Use collection default if no post-level visibility specified
-    effective_visibility = visibility or collection_perm.visibility
-
-    # Enforce the ceiling: post can only be stricter
-    if is_wider(effective_visibility, collection_perm.visibility):
-        raise PermissionError(
-            f"Post visibility '{effective_visibility}' exceeds "
-            f"collection ceiling '{collection_perm.visibility}'"
-        )
-
-    # Insert the post with the effective visibility
-    clickhouse.execute("""
-        INSERT INTO posts VALUES (%s, %s, %s, %s, %s, %s, %s, now(), now(), 0)
-    """, (str(uuid4()), author, collection, json.dumps(body),
-          effective_visibility, '', body.get('tags', []), ))
-```
-
-The `is_wider()` function compares visibility levels:
-
-```
-public > followers > group > private
-```
-
-A post in a `followers` collection can be `followers` or `private`. It cannot be `public`.
+The ceiling model required two checks at query time: collection visible AND post visible. Groups require one: is the requester a member of a group the post is attached to?
 
 ## The Sovereignty Story
 
-The user's privacy panel is the source of truth for their data. Collections set the default. Posts can only narrow. The user manages the 99% at collection level. The per-record column handles the 1% exception.
+The user's authenticator is the source of truth for their data. Groups set the default. The author attaches to groups. The user manages groups at the authenticator level. Block sharing, opt out, privatize all, kill switch.
 
-This is the WordPress for YouTube vibe. The user manages privacy like file permissions. The directory is the ceiling. The file can only be more private. The strictest permission wins.
-
-The data viewer shows posts that deviate from the collection default. The user can understand them and restore them. The system is transparent. The user is in control.
+The data viewer shows which groups each post is attached to. The user can add or remove group attachments. The system is transparent. The user is in control.
 
 ## Summary
 
-- **Collection is the ceiling.** The user's privacy panel manages collections.
-- **Post can only narrow.** Individual posts can be more private, never less.
-- **Strictest wins.** Both collection and post checks must pass.
-- **API enforces it.** The API rejects posts that exceed the collection ceiling.
-- **99% collection, 1% post.** Most posts inherit the default. Exceptions are rare.
-- **Transparent.** The data viewer shows deviations. The user understands and controls.
+- **No collection ceiling.** Groups replace it.
+- **No visibility column.** Groups replace it.
+- **No term records.** Groups replace them.
+- **One permission model.** Roles define access. Groups define membership.
+- **One check at query time.** Group membership.
+- **Transparent.** The authenticator shows groups. The author controls attachments.

--- a/knowledge/knowledge-base/web10-v2-to-v3/personal-vs-discoverable.md
+++ b/knowledge/knowledge-base/web10-v2-to-v3/personal-vs-discoverable.md
@@ -1,4 +1,4 @@
-# Personal Data vs Discoverable Data
+# Personal Data vs Discoverable Data: Resolved by Groups
 
 ## Two Kinds of Data, Two Kinds of Needs
 
@@ -8,97 +8,118 @@ web10 has to serve two fundamentally different needs:
 
 **Discoverable data** — the public surface. A trending feed, engagement counts, follower counts, search results, suggested accounts. This is the growth story. An influencer needs people to find them. A platform needs content to surface.
 
-In v2, these are built as separate systems that happen to overlap. The overlap is where everything breaks.
+In v2, these were built as separate systems that happened to overlap. The overlap is where everything broke.
 
-## Personal Data — The User Collection
+## v2: Two Surfaces, One Sync Problem
 
-Every user gets a collection. Everything they own lives there. Service terms control access. The CRUD endpoints are the gate.
+**Personal data** lived in the user's collection. Service terms controlled access. The CRUD endpoints were the gate.
 
 ```
 alice/
-  ├── star record (*)          — identity, verification, credits
-  ├── services                 — contracts for each service
   ├── public_posts             — public posts (anon-read whitelisted)
   ├── private_posts            — private posts (owner-only)
-  ├── staging_posts            — drafts (owner-only)
-  ├── inbox                    — delivered content (fan-out writes)
-  ├── follows                  — who alice follows
   ├── reactions                — alice's reactions
   ├── comments                 — alice's comments
-  ├── dms                      — direct messages
-  ├── media                    — private media metadata
-  └── public_media             — public media metadata
+  └── follows                  — who alice follows
 ```
 
-This works perfectly for ownership. Alice controls every record. She can change the terms. She can export and leave. The platform can't touch her data without a contract.
-
-**The problem:** nothing is discoverable by default. Every collection is a walled garden. To find Alice's content, you need to know her username, hit her CRUD endpoint, and hope her contract allows it. That's fine for DMs, terrible for a trending feed.
-
-## Discoverable Data — The System Collections
-
-To make content findable, v2 added system collections — cross-user surfaces that live outside any single user's control:
+**Discoverable data** lived in system collections — cross-user surfaces outside any single user's control:
 
 ```
 web10/
   ├── discovery_posts          — public post index (text, tags, media refs)
   ├── public                   — structured interactions (reactions, comments, follows)
-  ├── schemas                  — JSON schema registry
-  ├── apps                     — app store registrations
   └── metering_events          — per-request metering
 ```
 
-The discovery index is a **projection** — a subset of each user's public posts, stripped down to what's needed for display (text, tags, author, created_at). Engagement counts are derived at read time from the public ledger.
+The discovery index was a **projection** — a subset of each user's public posts. The public ledger was a **mirror** — every reaction, comment, and follow got copied here. The client was responsible for keeping them in sync. The sync broke.
 
-The public ledger is a **mirror** — every reaction, comment, and follow gets copied here so it can be read by anyone, including anon.
+**The tension:** the user must own their data, but the system must be able to project it. In v2, the compromise was "the system projects from the user's data via server-side hooks." That worked for posts. It didn't work for reactions, comments, and follows — those still needed the client to write the ledger mirror.
 
-**The problem:** these are separate data surfaces that the client is responsible for keeping in sync. The double-write problem exists because personal data and discoverable data live in different places and the client has to write to both.
+## v3: One Surface, Groups Marry the Two
 
-## The Tension
+v3 eliminates the tension. One table. Groups handle both personal ownership and cross-user discovery.
 
-| | Personal Data | Discoverable Data |
-|---|---|---|
-| **Owner** | The user | The system |
-| **Access** | Contract-gated | Public (anon-read) |
-| **Write** | CRUD endpoint | Projection hooks + ledger mirrors |
-| **Read** | `PATCH /{user}/{service}` | `PATCH /discover/*`, `PATCH /public/entries` |
-| **Sync** | Source of truth | Derived, must stay current |
-| **Delete** | User deletes, gone | Projection must be cleaned up |
+**Personal data** is a post with no groups. Only the author sees it. The author owns it.
 
-The tension is: **the user must own their data, but the system must be able to project it.**
-
-In v2, the compromise is "the system projects from the user's data via server-side hooks." That works for posts (discovery index). It doesn't work for reactions, comments, and follows — those still need the client to write the ledger mirror.
-
-## Why It's Like This
-
-The public ledger exists because of invariant I3: you can't read another user's collection directly for engagement counts. If Alice wants to know how many people reacted to her post, the system can't aggregate across every user's `reactions` collection — that would be a cross-collection read. So reactions must be written to a shared surface the system can query.
-
-The discovery index exists for the same reason: a trending feed can't scan every user's `public_posts` collection. It needs a single index to sort and paginate.
-
-Both are necessary. But both create a sync problem when the client is responsible for the mirror.
-
-## What v3 Should Do
-
-Marry the two together. Not merge them — keep personal data personal, keep discoverable data public — but make the projection automatic and server-side for everything, not just posts.
-
-**The principle:** every CRUD write that should be discoverable triggers a server-side projection. The client never writes to a system collection directly. The client writes to their own collection. The server handles the rest.
-
-```
-Client → POST /alice/reactions → Server
-                                  → CRUD write (source of truth)
-                                  → server-side hook: mirror to web10.public
-                                  → engagement count updated
+```ts
+await createDocument({ text: "private note" });  // no groups → private
 ```
 
-Same for comments. Same for follows. Same for everything that needs to be public.
+**Discoverable data** is a post attached to groups. Members see it. The discover group makes it public.
 
-**The result:** one client call. One source of truth. The projection is a server-side guarantee, not a client-side hope. The personal data stays personal. The discoverable data stays discoverable. They're married by the hook, not by the client.
+```ts
+await createDocument({
+  text: "hello world",
+  groups: ["web10/discover"]  // public
+});
+```
 
-## The Deeper Question
+The discover group is an open group with auto-enrollment on signup, including the anon user. Posts attached to it are discoverable by anyone. Posts not attached to it are private.
 
-There's a deeper architectural question underneath this: **should the system collections even exist?**
+**The projection is automatic.** ClickHouse queries the documents table. Group membership filters at query time. No mirror. No sync. No double-write.
 
-The discovery index and public ledger are projections because the database model (one collection per user) makes cross-user queries impossible. But what if the data model supported both personal ownership and cross-user discovery natively?
+```sql
+SELECT p.doc_id, p.author_key, p.body, p.tags, p.created_at
+FROM documents p
+JOIN doc_groups pg ON p.doc_id = pg.doc_id
+JOIN group_members gm ON pg.group_id = gm.group_id
+WHERE p.deleted = 0
+  AND gm.member_key = 'alice'
+  AND gm.deleted = 0
+ORDER BY p.created_at DESC
+LIMIT 50;
+```
 
-That's a v3 question. The v2 answer is "server-side hooks." The v3 answer might be "a data model that doesn't require two surfaces."
+Alice sees every post attached to a group she belongs to. No visibility column. No collection ceiling. No discovery index. No public ledger. Just group membership.
 
-Until then, the hooks are the bridge. Make them comprehensive, make them reliable, and make the client never think about sync again.
+## The Double-Write Problem: Gone
+
+v2's double-write problem existed because personal data and discoverable data lived in different places. The client had to write to both. The mirror was fire-and-forget. If it failed, the data was silently out of sync.
+
+v3 eliminates it. One insert. One table. The API writes the document and the doc_groups attachment. ClickHouse queries it. No mirror. No sync. No double-write.
+
+```
+Client → POST /alice/posts → API
+                               → INSERT INTO documents (alice's post)
+                               → INSERT INTO doc_groups (group attachment)
+                               → done
+```
+
+One client call. One source of truth. The projection is a query, not a mirror.
+
+## Engagement: Queries, Not Mirrors
+
+v2 needed the public ledger because MongoDB couldn't aggregate across users. Reactions, comments, and follows had to be mirrored to a shared surface.
+
+v3 uses ClickHouse. Cross-user queries are native. Engagement is a query, not a mirror.
+
+```sql
+-- Reaction count for post-123
+SELECT count() FROM documents
+WHERE deleted = 0
+  AND collection_name = 'reactions'
+  AND hasToken(body, 'post-123');
+
+-- Comments for post-123
+SELECT doc_id, author_key, body, created_at
+FROM documents
+WHERE deleted = 0
+  AND collection_name = 'comments'
+  AND hasToken(body, 'post-123')
+ORDER BY created_at ASC;
+```
+
+No ledger. No mirror. Just documents with `ref` types. ClickHouse aggregates them.
+
+## The Sovereignty Story
+
+The user owns their data. Posts are in their collection. Groups define who sees them. The user controls group attachments. The authenticator manages groups — block sharing, opt out, privatize all, kill switch.
+
+The user can export their data. They can delete their posts. They can take their data with them. The platform can't touch their data without a service contract.
+
+The discover group is opt-in. The author attaches to it. The author can remove it. The post becomes private. The user is in control.
+
+## Summary
+
+v2 had two surfaces: personal collections and system mirrors. The sync broke. v3 has one surface: the documents table. Groups marry personal ownership and cross-user discovery. No mirrors. No sync. No double-write. The user owns their data. Groups define who sees it. ClickHouse queries it. One insert. One table. One permission model.

--- a/knowledge/knowledge-base/web10-v2-to-v3/why-not-just-clickhouse.md
+++ b/knowledge/knowledge-base/web10-v2-to-v3/why-not-just-clickhouse.md
@@ -11,32 +11,25 @@ Idea:     ClickHouse + MinIO + API
 
 ## What ClickHouse Would Need to Do
 
-Everything. Posts, reactions, comments, follows, permissions, engagement. All stored in ClickHouse tables. Deletes are tombstones. Updates are new rows with higher version numbers.
+Everything. Posts, reactions, comments, groups, permissions, engagement. All stored in one ClickHouse table. Deletes are tombstones. Updates are new rows with higher version numbers.
 
 ```sql
-CREATE TABLE posts (
-    post_id String,
+CREATE TABLE documents (
+    doc_id String,
     author_key String,
-    body String,          -- JSON: the full post content
-    visibility String,
+    collection_name String,     -- 'posts', 'reactions', 'comments', 'outbox'
+    body String,                -- JSON: full content
+    discoverable UInt8,         -- can this post appear in feeds?
+    tags Array(String),
     created_at DateTime64(3),
     updated_at DateTime64(3),
     deleted UInt8 DEFAULT 0
 ) ENGINE = ReplacingMergeTree(updated_at)
-ORDER BY (author_key, post_id);
-
-CREATE TABLE reactions (
-    reaction_id String,
-    actor_key String,
-    target_post_id String,
-    type String,
-    created_at DateTime64(3),
-    deleted UInt8 DEFAULT 0
-) ENGINE = MergeTree()
-ORDER BY (target_post_id, created_at);
+ORDER BY (author_key, doc_id)
+TTL created_at + INTERVAL 90 DAY;
 ```
 
-MinIO stores the media blobs. ClickHouse stores the metadata. That's it.
+MinIO stores the media blobs. ClickHouse stores everything structured. That's it.
 
 ## Where It Works
 
@@ -48,27 +41,29 @@ MinIO stores the media blobs. ClickHouse stores the metadata. That's it.
 
 **Discovery, trending, search.** ClickHouse is built for this. Local queries, vectorized execution, inverted index. No MongoDB needed.
 
-**Permissions.** `visibility` is a column. Filter at query time. No Postgres needed. No separate permissions layer needed.
+**Permissions.** Groups define who can see what. `doc_groups` maps documents to groups. `group_members` defines membership. Filter at query time. No Postgres needed. No separate permissions layer needed.
 
 **Media.** MinIO stores blobs. ClickHouse stores metadata (URL, size, type). ClickHouse can query MinIO directly for metadata if needed. Works.
 
+**Engagement.** Reactions and comments are documents with `ref` types. ClickHouse aggregates them. No ledger. No mirror. No double-write.
+
 ## Where It Hurts
 
-**Schema evolution.** ClickHouse has a schema. Adding a field means `ALTER TABLE posts ADD COLUMN new_field String`. At scale, ALTER TABLE is a heavy operation — it rewrites data parts. MongoDB is schemaless — every document can have different fields. For a social network where features change weekly, schema rigidity is real pain.
+**Schema evolution.** ClickHouse has a schema. Adding a field means `ALTER TABLE documents ADD COLUMN new_field String`. At scale, ALTER TABLE is a heavy operation — it rewrites data parts. MongoDB is schemaless — every document can have different fields. For a social network where features change weekly, schema rigidity is real pain.
 
-**Mitigation:** store the body as JSON. ClickHouse has `JSON` type and `extractJSONString()` functions. The schema is wide (post_id, author, body JSON, visibility, created_at). New fields go into the JSON blob. No ALTER TABLE needed.
+**Mitigation:** store the body as JSON. ClickHouse has `JSON` type and `extractJSONString()` functions. The schema is wide (doc_id, author, body JSON, tags, created_at). New fields go into the JSON blob. No ALTER TABLE needed.
 
-**Point lookups.** `GET /alice/posts/abc` — fetching a single post by ID. ClickHouse has no secondary index on `post_id`. It scans partitions. For a hot path (every page load fetches posts), this is slow.
+**Point lookups.** `GET /alice/posts/abc` — fetching a single post by ID. ClickHouse has no secondary index on `doc_id`. It scans partitions. For a hot path (every page load fetches posts), this is slow.
 
-**Mitigation:** API-level caching. Redis cache for hot posts. Or a small local ClickHouse table with a primary key on `post_id` that's kept in memory. Or accept that ClickHouse point lookups are ~10ms, not ~1ms, and that's fine for a feed.
+**Mitigation:** API-level caching. Redis cache for hot posts. Or a small local ClickHouse table with a primary key on `doc_id` that's kept in memory. Or accept that ClickHouse point lookups are ~10ms, not ~1ms, and that's fine for a feed.
 
-**Atomic operations.** MongoDB's `find_one_and_update` is atomic. "Increment reaction count if the user hasn't reacted yet." ClickHouse has no atomic counters. You insert a reaction row. The count is computed at query time (`COUNT(*) WHERE target_post_id = 'X'`).
+**Atomic operations.** MongoDB's `find_one_and_update` is atomic. "Increment reaction count if the user hasn't reacted yet." ClickHouse has no atomic counters. You insert a reaction row. The count is computed at query time (`COUNT(*) WHERE hasToken(body, 'post-123')`).
 
-**Mitigation:** this is actually fine. The count is a materialized view in ClickHouse. It updates on insert. No atomic counter needed. The reaction is an insert. The count is an aggregation. This is the OLAP model.
+**Mitigation:** this is actually fine. The count is a query in ClickHouse. It updates on insert. No atomic counter needed. The reaction is an insert. The count is an aggregation. This is the OLAP model.
 
-**Write latency for single rows.** ClickHouse is optimized for batch inserts. A single `INSERT INTO posts VALUES (...)` works but it's slower than MongoDB's in-memory write. At scale, you batch inserts anyway.
+**Write latency for single rows.** ClickHouse is optimized for batch inserts. A single `INSERT INTO documents VALUES (...)` works but it's slower than MongoDB's in-memory write. At scale, you batch inserts anyway.
 
-**Mitigation:** batch inserts in the API. Accumulate writes, flush every 100ms or 100 records. Accept eventual consistency for the index. The MongoDB write is synchronous (source of truth). The ClickHouse write is async (index). If ClickHouse is behind by 100ms, the feed is 100ms stale. Acceptable.
+**Mitigation:** batch inserts in the API. Accumulate writes, flush every 100ms or 100 records. Accept eventual consistency for the index. The ClickHouse write is the source of truth. If ClickHouse is behind by 100ms, the feed is 100ms stale. Acceptable.
 
 **Complex nested data.** A post can have rich media, nested comments, threaded replies, reactions with metadata. MongoDB stores this as nested BSON naturally. ClickHouse needs flat tables or JSON columns.
 
@@ -90,11 +85,9 @@ MinIO stores the media blobs. ClickHouse stores the metadata. That's it.
 
 ## The Verdict
 
-**For the public layer: ClickHouse only.** No MongoDB needed. Discovery, trending, engagement, search — ClickHouse does it all faster and cheaper.
+**ClickHouse + MinIO only.** No MongoDB needed. Discovery, trending, engagement, search — ClickHouse does it all faster and cheaper.
 
-**For personal data: it depends.**
-
-If personal data is mostly append-only (posts, reactions, comments) and point lookups can be cached, ClickHouse can handle it. The JSON column workaround solves schema flexibility. The materialized view workaround solves atomic counters. The cache workaround solves point lookup latency.
+**For personal data: ClickHouse handles it.** Personal data is mostly append-only (posts, reactions, comments). Point lookups can be cached. The JSON column workaround solves schema flexibility. The materialized view workaround solves atomic counters. The cache workaround solves point lookup latency.
 
 The cost: every workaround is application complexity. MongoDB does these things natively. ClickHouse requires you to design around its limitations.
 
@@ -110,12 +103,12 @@ The trade-offs (schema rigidity, point lookup latency, no atomic updates) are ac
 
 ```
 ClickHouse:
-  posts (with JSON body)
-  reactions
-  comments
-  follows
-  engagement (materialized view)
-  discovery_posts (materialized view)
+  documents (everything — posts, reactions, comments, notes, mail)
+  doc_groups (document-to-group mapping)
+  group_contracts (group policy, roles, join policy)
+  group_members (membership)
+  service_contracts (app access)
+  user_blacklist, group_blacklist (blocking)
 
 MinIO:
   media blobs
@@ -125,6 +118,7 @@ API:
   orchestrates ClickHouse + MinIO
   caches hot point lookups
   batches inserts
+  converts MinIO URLs to presigned
 ```
 
 Two services. That's the stack.

--- a/knowledge/knowledge-base/web10-v3-brainstorm/contract-schemas.md
+++ b/knowledge/knowledge-base/web10-v3-brainstorm/contract-schemas.md
@@ -114,10 +114,10 @@ ORDER BY (group_id, requester_key);
 **Flow:**
 ```
 Bob requests to join alice.followers
-  → INSERT INTO group_join_requests ('alice.followers', 'bob', 'pending', ...)
+   → INSERT INTO group_join_requests ('web10.app/groups/alice/followers', 'bob', 'pending', ...)
 Alice approves
-  → UPDATE status to 'approved', resolved_at = now()
-  → INSERT INTO group_members ('alice.followers', 'bob', 'member', ...)
+   → UPDATE status to 'approved', resolved_at = now()
+   → INSERT INTO group_members ('web10.app/groups/alice/followers', 'bob', 'member', ...)
 Alice denies
   → UPDATE status to 'denied', resolved_at = now()
 ```
@@ -138,11 +138,11 @@ CREATE TABLE user_group_sharing (
 ORDER BY (user_key, group_id);
 ```
 
-**Query:** is Alice sharing with `jazz-collectors`?
+**Query:** is Alice sharing with `web10.app/groups/dave/jazz-collectors`?
 ```sql
 SELECT sharing_enabled FROM user_group_sharing
 WHERE user_key = 'alice'
-  AND group_id = 'jazz-collectors'
+  AND group_id = 'web10.app/groups/dave/jazz-collectors'
   AND deleted = 0;
 ```
 

--- a/knowledge/knowledge-base/web10-v3-brainstorm/cross-app-sharing.md
+++ b/knowledge/knowledge-base/web10-v3-brainstorm/cross-app-sharing.md
@@ -16,9 +16,7 @@ The browser enforces this. A site without a service contract can't touch your da
 **Group contract** — which people can see which content. Sharing. People-level.
 
 ```
-alice.inbox → admin: alice, open join
-alice.close-friends → admin: alice, invite only
-web10-dev → admin: charlie, open join
+web10.app/groups/jacoby149/jazz-collectors → members: alice, dave, eve
 ```
 
 Both must pass. The app needs a service contract to make the call. The groups decide what's visible.
@@ -29,11 +27,11 @@ The elegant flip: mail lives in the **sender's** collection, not the receiver's.
 
 ```
 Bob's outbox:
-  post-1 → groups: ["alice.inbox"]
+  post-1 → groups: ["web10.app/groups/alice/inbox"]
 
 Alice discovers:
   SELECT * FROM documents
-  WHERE group_id = 'alice.inbox'
+  WHERE group_id = 'web10.app/groups/alice/inbox'
   → post-1 (bob's mail)
 ```
 
@@ -41,9 +39,9 @@ Bob owns his mail. Alice owns her inbox group. The group is the bridge.
 
 **How it works:**
 
-1. Alice creates `alice.inbox` group (open join — anyone can send)
+1. Alice creates `web10.app/groups/alice/inbox` group (open join — anyone can send)
 2. Bob writes a mail in his `outbox` collection
-3. Bob attaches the mail to `alice.inbox` group
+3. Bob attaches the mail to `web10.app/groups/alice/inbox` group
 4. Alice discovers the mail via group membership check
 
 **Why it's better:**
@@ -75,7 +73,7 @@ Sender deletion is the default. Bob deletes his mail, Alice's view vanishes. But
 
 ```
 Bob's outbox:
-  post-1 → groups: ["alice.inbox"]
+  post-1 → groups: ["web10.app/groups/alice/inbox"]
 
 Alice's saved_mail:
   saved-1 → body: { "from": "bob", "text": "hi", "original_doc_id": "post-1" }
@@ -99,11 +97,11 @@ The service contract lets the notes app read/write. No groups means no one else 
 Two people. Private.
 
 ```
-alice-and-bob → admin: alice, members: alice, bob
+web10.app/groups/jacoby149/alice-and-bob → members: alice, bob
 ```
 
-Alice's message → attached to `alice-and-bob` → Bob sees it via group membership.
-Bob's message → attached to `alice-and-bob` → Alice sees it via group membership.
+Alice's message → attached to `web10.app/groups/jacoby149/alice-and-bob` → Bob sees it via group membership.
+Bob's message → attached to `web10.app/groups/jacoby149/alice-and-bob` → Alice sees it via group membership.
 
 Each message lives in the sender's collection. The group is the bridge. Both can discover via the group.
 
@@ -112,13 +110,13 @@ Each message lives in the sender's collection. The group is the bridge. Both can
 Open. Anyone can participate. Comments are documents with a `ref` to the parent post.
 
 ```
-post-123-comments → admin: alice, open join
+web10.app/groups/jacoby149/post-123-comments → owner: jacoby149, request [Leave]
 ```
 
 Alice's post → no groups (private by default).
 
-Bob's comment → a post in `bob.comments` with `ref: "post-123"`, attached to `post-123-comments` group.
-Charlie's reply → a post in `charlie.comments` with `ref: "post-123"` and `parent_ref: "bob-comment-xyz"`, attached to `post-123-comments` group.
+Bob's comment → a post in `bob.comments` with `ref: "post-123"`, attached to `web10.app/groups/jacoby149/post-123-comments` group.
+Charlie's reply → a post in `charlie.comments` with `ref: "post-123"` and `parent_ref: "bob-comment-xyz"`, attached to `web10.app/groups/jacoby149/post-123-comments` group.
 
 Alice discovers all comments via the group. The `ref` in the JSON body links back to the parent. The `parent_ref` enables threading. No dedicated comments table — just documents with refs.
 
@@ -150,14 +148,14 @@ service:mail → allowed: mailapp.com [Revoke]
 
 **Groups you administer** — who can send you content.
 ```
-alice.inbox → open join [Block sharing] [Leave]
-alice.close-friends → invite only [Add member] [Remove member]
+web10.app/groups/alice/inbox → open join [Block sharing] [Leave]
+web10.app/groups/alice/close-friends → invite only [Add member] [Remove member]
 ```
 
 **Groups you belong to** — what you can see.
 ```
-web10-dev → admin: charlie, open join [Block sharing] [Leave]
-post-123-comments → admin: alice, request [Leave]
+web10.app/groups/charlie/st-louis-chess-club → owner: charlie, open join [Block sharing] [Leave]
+web10.app/groups/jacoby149/post-123-comments → owner: jacoby149, request [Leave]
 ```
 
 **Block sharing** — pause sharing without leaving. You stay a member. You still see their posts. They can't see yours. Reversible.
@@ -172,7 +170,7 @@ No Gmail mailing list limits. A group can have 100k members. ClickHouse filters 
 
 ```
 alice.inbox → 50k senders
-web10-dev → 100k members
+charlie/st-louis-chess-club → 100k members
 jazz-collectors → 500k members
 ```
 

--- a/knowledge/knowledge-base/web10-v3-brainstorm/federated-groups.md
+++ b/knowledge/knowledge-base/web10-v3-brainstorm/federated-groups.md
@@ -11,7 +11,7 @@ Each provider runs its own ClickHouse instance. A group can have members on diff
 The group tells you which providers to query.
 
 ```
-jazz-collectors:
+web10.app/groups/dave/jazz-collectors:
   members:
     alice @ provider-a
     bob @ provider-b
@@ -21,12 +21,12 @@ jazz-collectors:
 When Bob queries the group on provider-B, he sees: "there are members on provider-A too." He queries provider-A's instance.
 
 ```
-Bob → GET /groups/jazz-collectors/posts
-  provider-b: scans local posts in jazz-collectors
-  provider-b: sees alice, charlie are on provider-a
-  provider-b: federated query → provider-a: "posts in jazz-collectors?"
-  provider-a: returns alice's posts
-  provider-b: merges results
+Bob → GET /groups/web10.app/groups/dave/jazz-collectors/posts
+   provider-b: scans local posts in web10.app/groups/dave/jazz-collectors
+   provider-b: sees alice, charlie are on provider-a
+   provider-b: federated query → provider-a: "posts in web10.app/groups/dave/jazz-collectors?"
+   provider-a: returns alice's posts
+   provider-b: merges results
 ```
 
 ## The Group Membership Table
@@ -51,15 +51,15 @@ ORDER BY (group_id, member_key);
 ```sql
 -- Bob queries jazz-collectors on provider-b
 SELECT DISTINCT provider_key FROM group_members
-WHERE group_id = 'jazz-collectors'
-  AND provider_key != 'provider-b'
+WHERE group_id = 'web10.app/groups/dave/jazz-collectors'
+   AND provider_key != 'provider-b'
 -- Returns: provider-a
 
 -- Federated query to provider-a
 SELECT * FROM remote('provider-a', 'documents', 'user', 'password')
 WHERE doc_id IN (
   SELECT doc_id FROM remote('provider-a', 'doc_groups', 'user', 'password')
-  WHERE group_id = 'jazz-collectors'
+  WHERE group_id = 'web10.app/groups/dave/jazz-collectors'
 )
   AND deleted = 0
 ```
@@ -93,14 +93,14 @@ Alice → GET /alice/inbox
 A group can span providers. Members on different providers see each other's posts.
 
 ```
-web10-dev:
+web10.app/groups/charlie/st-louis-chess-club:
   members:
     alice @ provider-a
     bob @ provider-b
     charlie @ provider-c
 ```
 
-Alice posts on provider-A → attached to `web10-dev` → Bob discovers it on provider-B (federated query to provider-A) → Charlie discovers it on provider-C (federated query to provider-A).
+Alice posts on provider-A → attached to `web10.app/groups/charlie/st-louis-chess-club` → Bob discovers it on provider-B (federated query to provider-A) → Charlie discovers it on provider-C (federated query to provider-A).
 
 One group. Three providers. Federated discovery.
 
@@ -109,7 +109,7 @@ One group. Three providers. Federated discovery.
 Shows which providers your groups span:
 
 ```
-web10-dev → admin: you
+web10.app/groups/charlie/st-louis-chess-club → owner: you
   members:
     alice @ provider-a (you)
     bob @ provider-b

--- a/knowledge/knowledge-base/web10-v3-brainstorm/groups.md
+++ b/knowledge/knowledge-base/web10-v3-brainstorm/groups.md
@@ -77,7 +77,7 @@ A post can belong to multiple groups:
 ```ts
 await createDocument({
   text: "team update",
-  groups: ["alice.close-friends", "web10-dev"]
+   groups: ["alice.close-friends", "charlie/st-louis-chess-club"]
 });
 ```
 
@@ -227,7 +227,7 @@ No Gmail mailing list limits. A group can have 100k members. ClickHouse filters 
 
 ```
 alice.followers → 50k members
-web10-dev → 100k members
+charlie/st-louis-chess-club → 100k members
 jazz-collectors → 500k members
 ```
 

--- a/knowledge/knowledge-base/web10-v3-brainstorm/manifesto-additions.md
+++ b/knowledge/knowledge-base/web10-v3-brainstorm/manifesto-additions.md
@@ -57,7 +57,7 @@ web10 makes groups easy. One group. Infinite apps. The group is a platform primi
 ```
 alice.close-friends → social app sees posts, music app sees playlists, doc app sees files
 jazz-collectors → music app, social app, podcast app — same circle
-web10-dev → teams, communities, collaboration — same membership
+charlie/st-louis-chess-club → teams, communities, collaboration — same membership
 ```
 
 The group is managed once, at the platform level. Every app can scope content to it. No rebuilding. No silos. No "close friends" trapped in one app.

--- a/knowledge/knowledge-base/web10-v3-brainstorm/overview.md
+++ b/knowledge/knowledge-base/web10-v3-brainstorm/overview.md
@@ -5,7 +5,7 @@
 Two services. That's it.
 
 ```
-ClickHouse  — everything structured (posts, reactions, comments, groups, permissions)
+ClickHouse  — everything structured (documents, groups, permissions)
 MinIO       — every blob (images, video, audio)
 ```
 
@@ -36,7 +36,7 @@ graph TB
     subgraph ClickHouse
         Documents["documents (everything)"]
         DocGroups["doc_groups"]
-        GroupsTable["groups"]
+        GroupContracts["group_contracts"]
         GroupMembers["group_members"]
     end
 
@@ -49,7 +49,7 @@ graph TB
     App --> Media
     CRUD --> Documents
     CRUD --> DocGroups
-    Groups --> GroupsTable
+    Groups --> GroupContracts
     Groups --> GroupMembers
     Media --> Blobs
 
@@ -59,7 +59,7 @@ graph TB
     style Media fill:#e3f2fd,stroke:#1565c0,color:#000
     style Documents fill:#fff3e0,stroke:#e65100,color:#000
     style DocGroups fill:#fff3e0,stroke:#e65100,color:#000
-    style GroupsTable fill:#fff3e0,stroke:#e65100,color:#000
+    style GroupContracts fill:#fff3e0,stroke:#e65100,color:#000
     style GroupMembers fill:#fff3e0,stroke:#e65100,color:#000
     style Blobs fill:#fce4ec,stroke:#c62828,color:#000
 ```
@@ -67,13 +67,12 @@ graph TB
 ## The Tables
 
 ```sql
--- Posts: everything. JSON body for schema flexibility.
+-- Everything structured. One table. JSON body for schema flexibility.
 CREATE TABLE documents (
     doc_id String,
     author_key String,
-    collection_name String,     -- 'public_posts', 'private_posts', etc.
-    body String,                -- JSON: full post content
-    discoverable UInt8,         -- can this post appear in feeds?
+    collection_name String,     -- 'posts', 'reactions', 'comments', 'outbox'
+    body String,                -- JSON: full content
     tags Array(String),
     created_at DateTime64(3),
     updated_at DateTime64(3),
@@ -82,11 +81,10 @@ CREATE TABLE documents (
 ORDER BY (author_key, doc_id)
 TTL created_at + INTERVAL 90 DAY;
 
--- Post-to-group mapping. Groups define who can see the post.
+-- Document-to-group mapping. Groups define who can see the document.
 CREATE TABLE doc_groups (
     doc_id String,
     group_id String,
-    permission String,          -- 'read', 'write' — author decides at attachment time
     created_at DateTime64(3),
     updated_at DateTime64(3),
     deleted UInt8 DEFAULT 0
@@ -114,13 +112,11 @@ CREATE TABLE provider_service_contracts (
 ) ENGINE = ReplacingMergeTree(updated_at)
 ORDER BY (provider_key, allowed_origin);
 
--- Group contracts. Join policy, settings.
+-- Group contracts. Join policy, roles (JSON).
 CREATE TABLE group_contracts (
-    group_id String,
-    name String,
-    admin_key String,
-    join_policy String,         -- 'open', 'request', 'invite_only'
-    settings String,            -- JSON
+    group_id String,           -- 'web10.app/groups/jacoby149/abacus-enthusiasts'
+    roles String,              -- JSON array of roles with services + permissions
+    join_policy String,        -- 'open', 'request', 'invite_only'
     created_at DateTime64(3),
     updated_at DateTime64(3),
     deleted UInt8 DEFAULT 0
@@ -131,7 +127,7 @@ ORDER BY group_id;
 CREATE TABLE group_join_requests (
     group_id String,
     requester_key String,
-    status String,              -- 'pending', 'approved', 'denied'
+    status String,             -- 'pending', 'approved', 'denied'
     requested_at DateTime64(3),
     resolved_at DateTime64(3),
     updated_at DateTime64(3),
@@ -143,7 +139,7 @@ ORDER BY (group_id, requester_key);
 CREATE TABLE user_group_sharing (
     user_key String,
     group_id String,
-    sharing_enabled UInt8,      -- 1 = sharing, 0 = blocked
+    sharing_enabled UInt8,     -- 1 = sharing, 0 = blocked
     created_at DateTime64(3),
     updated_at DateTime64(3),
     deleted UInt8 DEFAULT 0
@@ -167,22 +163,11 @@ CREATE TABLE group_blacklist (
 ) ENGINE = MergeTree()
 ORDER BY (user_key, group_id, blocked_key);
 
--- Groups: policy containers. Hold people, not data.
--- (Metadata like join_policy lives in group_contracts table)
-CREATE TABLE groups (
-    group_id String,
-    admin_key String,
-    created_at DateTime64(3),
-    updated_at DateTime64(3),
-    deleted UInt8 DEFAULT 0
-) ENGINE = ReplacingMergeTree(updated_at)
-ORDER BY group_id;
-
 -- Group membership.
 CREATE TABLE group_members (
     group_id String,
     member_key String,
-    role String,                -- 'admin', 'member'
+    role String,               -- role name from the contract (e.g. 'owner', 'member')
     joined_at DateTime64(3),
     updated_at DateTime64(3),
     deleted UInt8 DEFAULT 0
@@ -190,11 +175,11 @@ CREATE TABLE group_members (
 ORDER BY (group_id, member_key);
 ```
 
-## Everything Is a Post
+## Everything Is a Document
 
 No dedicated reactions table. No dedicated comments table. No dedicated follows table. No dedicated social media endpoints. One table. One CRUD. One permission model.
 
-**A reaction is a post:**
+**A reaction is a document:**
 ```json
 {
   "doc_id": "react-abc",
@@ -207,7 +192,7 @@ No dedicated reactions table. No dedicated comments table. No dedicated follows 
 }
 ```
 
-**A comment is a post:**
+**A comment is a document:**
 ```json
 {
   "doc_id": "comment-xyz",
@@ -226,7 +211,7 @@ No dedicated reactions table. No dedicated comments table. No dedicated follows 
 alice.followers → members: bob, charlie
 ```
 
-The `ref` type (see `document-typing.md`) is the universal pointer. Any post can reference any other post. The API resolves refs on read. The app decides what a ref means — reaction, comment, reply, quote, remix. The platform doesn't care.
+The `ref` type (see `document-typing.md`) is the universal pointer. Any document can reference any other document. The API resolves refs on read. The app decides what a ref means — reaction, comment, reply, quote, remix. The platform doesn't care.
 
 **Engagement is a query, not a table:**
 ```sql
@@ -235,7 +220,7 @@ SELECT count(), any(body)
 FROM documents
 WHERE deleted = 0
   AND collection_name = 'reactions'
-  AND hasToken(body, 'post-123');  -- ref contains the target doc_id
+  AND hasToken(body, 'post-123');
 ```
 
 **Comments for a post:**
@@ -294,8 +279,8 @@ sequenceDiagram
     participant ClickHouse
 
     Client->>API: GET /alice/posts?discover=true
-    API->>ClickHouse: SELECT documents WHERE<br/>group membership check for alice<br/>+ discoverable = 1<br/>+ deleted = 0
-    ClickHouse-->>API: 50 post IDs + metadata
+    API->>ClickHouse: SELECT documents WHERE<br/>group membership check for alice<br/>+ deleted = 0
+    ClickHouse-->>API: 50 document IDs + metadata
     API-->>Client: feed response
 
     Note over Client,ClickHouse: No discovery index. No ledger mirror.<br/>One table. One query. Permissions filtered at query time.
@@ -309,7 +294,6 @@ FROM documents p
 JOIN doc_groups pg ON p.doc_id = pg.doc_id
 JOIN group_members gm ON pg.group_id = gm.group_id
 WHERE p.deleted = 0
-  AND p.discoverable = 1
   AND gm.member_key = 'alice'
   AND gm.deleted = 0
   AND NOT EXISTS (
@@ -326,9 +310,9 @@ ORDER BY p.created_at DESC
 LIMIT 50;
 ```
 
-Alice sees every post attached to a group she belongs to. No visibility column. No collection ceiling. Just group membership.
+Alice sees every document attached to a group she belongs to. No visibility column. No collection ceiling. Just group membership.
 
-The `discoverable` flag is per-record. The author controls it. `discoverable: false` means the post exists but doesn't appear in feeds — only visible by direct link or to the author.
+**The discover group.** Public documents are attached to `web10/discover` — an open group with auto-enrollment on signup, including the anon user. Anyone can read documents attached to it. The author controls it: attach to the group for public, don't for private.
 
 ## Permissions: Service Contracts + Groups
 
@@ -371,7 +355,7 @@ flowchart LR
         G["jazz-collectors\nmembers: alice, dave, eve"]
     end
 
-    subgraph Post["Post"]
+    subgraph Post["Document"]
         P["Attached to\njazz-collectors"]
     end
 
@@ -386,19 +370,19 @@ flowchart LR
     style Result fill:#e3f2fd,stroke:#1565c0,color:#000
 ```
 
-A post with no groups is private. Attaching it to a group makes it visible to group members. The author decides the permission level (read/write). The group admin manages membership and can moderate (remove from discover, not edit).
+A document with no groups is private. Attaching it to a group makes it visible to group members. The group's roles define what members can do. The group owner manages membership and can moderate (remove from discover, not edit).
 
-## Private Post Viewing
+## Private Document Viewing
 
-A post is private by default. Attaching it to a group makes it visible to group members.
+A document is private by default. Attaching it to a group makes it visible to group members.
 
 ```mermaid
 flowchart TD
-    A["User requests\nposts"] --> B{"discover flag?"}
-    B -->|"false"| C["Only user's own posts\n(groups don't matter)"]
+    A["User requests\ndocuments"] --> B{"discover flag?"}
+    B -->|"false"| C["Only user's own documents\n(groups don't matter)"]
     B -->|"true"| D["Group membership check"]
 
-    D --> E{"Is requester a member\nof any group the post\nis attached to?"}
+    D --> E{"Is requester a member\nof any group the document\nis attached to?"}
     E -->|"yes"| F["Show it"]
     E -->|"no"| G{"Is requester\nthe author?"}
     G -->|"yes"| F
@@ -412,13 +396,13 @@ flowchart TD
 
 ## Groups: Policy Containers
 
-Groups are not data containers. They hold people and permissions. Any document from any service can be attached to any group. The group's policy decides who sees it.
+Groups are not data containers. They hold people and roles. Any document from any service can be attached to any group. The group's roles define who sees it and what they can do.
 
 ```mermaid
 graph TB
     subgraph Platform
         GroupsAPI["Groups CRUD\n/groups"]
-        GroupsTable["groups"]
+        ContractsTable["group_contracts"]
         MembersTable["group_members"]
     end
 
@@ -435,15 +419,15 @@ graph TB
         WatchParty["Watch parties attached to groups"]
     end
 
-    GroupsAPI --> GroupsTable
+    GroupsAPI --> ContractsTable
     GroupsAPI --> MembersTable
-    SocialPosts --> GroupsTable
+    SocialPosts --> ContractsTable
     SocialFeed --> MembersTable
-    SharedPlaylist --> GroupsTable
-    WatchParty --> GroupsTable
+    SharedPlaylist --> ContractsTable
+    WatchParty --> ContractsTable
 
     style GroupsAPI fill:#e3f2fd,stroke:#1565c0,color:#000
-    style GroupsTable fill:#fff3e0,stroke:#e65100,color:#000
+    style ContractsTable fill:#fff3e0,stroke:#e65100,color:#000
     style MembersTable fill:#fff3e0,stroke:#e65100,color:#000
     style SocialPosts fill:#f5f5f5,stroke:#333,color:#000
     style SocialFeed fill:#f5f5f5,stroke:#333,color:#000
@@ -455,11 +439,11 @@ Alice creates a group. Bob and Charlie join. Now any app on web10 can attach con
 
 ### Follows Are Groups
 
-Follows are groups. `alice.followers` is a group where Alice is the admin. Bob requests to join → Alice approves → Bob is a member → Bob sees posts attached to that group.
+Follows are groups. `alice.followers` is a group where Alice is the owner. Bob requests to join → Alice approves → Bob is a member → Bob sees posts attached to that group.
 
 ```ts
-await followUser('alice');        // request to join alice.followers
-await approveFollower('bob');     // approve bob into alice.followers
+await followUser('alice');        // join alice.followers (open) or request (request)
+await approveFollower('bob');     // approve bob into alice.followers (request only)
 await unfollow('alice');          // leave alice.followers
 ```
 
@@ -469,20 +453,25 @@ No separate follows table. Groups handle it.
 
 Two views:
 
-**Groups you administer** — you control membership.
+**Groups you manage** — you control membership and roles.
 ```
-alice.close-friends → admin: you, invite only
-alice.public        → admin: you, open
-```
-
-**Groups you belong to** — you can view, leave, or opt out your posts.
-```
-jazz-collectors → admin: dave, request
-web10-dev       → admin: charlie, open
+alice.close-friends → owner: you, invite only
+  members: bob, charlie, dave
+  [Add member] [Remove member] [Edit roles] [View audience]
 ```
 
-**Opt out all documents** — bulk remove every post you've attached to a group. Reversible.
-**Make everything private** — remove all groups from all your posts. One click.
+**Groups you belong to** — you can view membership, leave, or control sharing.
+```
+jazz-collectors → owner: dave, request
+  members: alice (you), dave, eve
+  [View members] [Block sharing] [Leave]
+```
+
+**Block sharing** — pause sharing without leaving. You stay a member. You still see their content. They can't see yours. Reversible.
+
+**Opt out all documents** — bulk remove every document you've attached to a group. Reversible.
+**Make everything private** — remove all groups from all your documents. One click.
+**Turn off all service contracts** — no website touches your data. Ever. Kill switch.
 
 ## The Write Flow
 
@@ -544,7 +533,7 @@ sequenceDiagram
 
 - **The CRUD pattern.** `/{user}/{service}` is still the API surface. The dev writes to it. The API routes to ClickHouse.
 - **The sovereignty story.** Service contracts control which apps access your data. Groups control which people see your content. The authenticator manages both — block sharing, opt out, privatize all, kill switch. The user controls their data.
-- **Groups as platform primitive.** One membership, infinite apps. Cross-app identity.
+- **Groups as platform primitive.** One membership, infinite apps. Cross-app identity. Owned audience.
 
 ## Summary
 
@@ -554,7 +543,7 @@ No mirrors. No sync. No double-write. No discovery index. No ledger. No FerretDB
 
 One CRUD endpoint. `?discover=true` for cross-user visibility. Service contracts control app access. Groups control people access. Both must pass.
 
-Groups are policy containers. They hold people, not data. One membership. Infinite apps. Follows are groups. The authenticator manages everything — block sharing, opt out, privatize all, kill switch.
+Groups are policy containers. They hold people, not data. One membership. Infinite apps. Follows are groups. The authenticator manages everything — block sharing, opt out, privatize all, kill switch. The group owner holds the audience.
 
 **Additional docs in this directory:**
 - `groups.md` — policy containers, join policies, moderation, blocking, authenticator

--- a/knowledge/knowledge-base/web10-v3-brainstorm/tombstone-cleanup.md
+++ b/knowledge/knowledge-base/web10-v3-brainstorm/tombstone-cleanup.md
@@ -9,7 +9,7 @@ Every update or delete is an insert. A tombstone row with `deleted = 1` and a hi
 **Update a post:**
 ```sql
 INSERT INTO documents VALUES (
-    'post-1', 'alice', 'posts', '{"text": "updated"}', 1, [],
+    'post-1', 'alice', 'posts', '{"text": "updated"}', [],
     '2026-01-01 00:00:00.000', '2026-01-02 00:00:00.000', 0
 );
 ```
@@ -18,16 +18,16 @@ ReplacingMergeTree keeps the row with the highest `updated_at`. Old version is g
 **Delete a post:**
 ```sql
 INSERT INTO documents VALUES (
-    'post-1', 'alice', 'posts', '{"text": "original"}', 1, [],
+    'post-1', 'alice', 'posts', '{"text": "original"}', [],
     '2026-01-01 00:00:00.000', '2026-01-03 00:00:00.000', 1
 );
 ```
 Tombstone stays. Query filters `WHERE deleted = 0`. TTL physically removes it.
 
-**Revoke a post_group attachment:**
+**Revoke a doc_group attachment:**
 ```sql
 INSERT INTO doc_groups VALUES (
-    'post-1', 'alice.close-friends', 'read',
+    'post-1', 'web10.app/groups/alice/close-friends',
     '2026-01-01 00:00:00.000', '2026-01-03 00:00:00.000', 1
 );
 ```

--- a/knowledge/knowledge-base/web10-v3/README.md
+++ b/knowledge/knowledge-base/web10-v3/README.md
@@ -8,6 +8,14 @@ Everything here is decided. Everything else is brainstorming.
 
 Work-in-progress ideas, alternatives, and explorations live in `web10-v3-brainstorm/`. When a direction is picked and finalized, it moves here.
 
+## Files
+
+- `groups.md` — groups as a generic platform primitive. Policy containers, service-scoped roles, join policies, blocking, cross-app identity. No app-specific assumptions.
+- `web10-social-groups.md` — how web10-social uses groups. Community groups, discover, private circles, follows. Specific roles and join policies for social use cases.
+- `contract-schemas.md` — ClickHouse table schemas for service contracts, group contracts, membership, join requests, sharing toggle, blacklists.
+- `group-identity-management.md` — group profile, URLs, service-scoped roles, permissions, CRUD operations.
+- `sdk-api.md` — the JavaScript/TypeScript SDK. Typed `createClient()`. Groups baked into every CRUD verb. Auth, service contracts, media, aggregate, cross-node addressing. What ClickHouse each call triggers.
+
 ## Structure
 
 Decisions land here as they're made:

--- a/knowledge/knowledge-base/web10-v3/contract-schemas.md
+++ b/knowledge/knowledge-base/web10-v3/contract-schemas.md
@@ -3,7 +3,7 @@
 Two concerns. Two contracts.
 
 1.  **Service Contracts (App Trust):** "Do we want to spin up these data buckets for this app?" Binary infrastructure toggle.
-2.  **Group Contracts (People Access):** "Who do we want this data to reach?" Granular social policy.
+2.  **Group Contracts (People Access):** "Who do we want this data to reach?" Granular social policy with service-scoped roles.
 
 ## Service Contracts
 
@@ -69,7 +69,7 @@ Blocked apps simply have no row. No row = denied.
 
 ## Group Contracts
 
-Group membership, roles, join policy. The contract is people + policy only. Roles are service-scoped.
+Group membership, roles, join policy. The contract is people + policy only. Roles are service-scoped — each role lists the services it applies to and the explicit permissions it grants.
 
 ```sql
 CREATE TABLE group_contracts (
@@ -90,9 +90,45 @@ FROM group_contracts
 WHERE group_id = 'web10.app/groups/jacoby149/abacus-enthusiasts' AND deleted = 0;
 ```
 
+**Roles are JSON.** Each role defines the services it touches and the permissions it grants:
+```json
+{
+  "roles": [
+    {
+      "name": "owner",
+      "services": ["*"],
+      "permissions": ["readAll", "create", "updateOwn", "updateAll", "deleteOwn", "deleteAll", "hideAll", "manageRoles", "assignRoles", "revokeRoles", "deleteGroup"]
+    },
+    {
+      "name": "member",
+      "services": ["posts", "comments"],
+      "permissions": ["readAll", "create", "updateOwn", "deleteOwn"]
+    }
+  ]
+}
+```
+
+A `page-curator` only touches `group-identity-service`. A `moderator` only touches `posts` and `comments`. A follower `member` only gets `readAll` on `posts`. The model scales infinitely without creating more groups.
+
 **Profile data** (banner, description, website, avatar) lives in `group-identity-service` — not the contract. Roles with access to that service write it, members read. The contract stays pure: people + policy.
 
-**Service-scoped roles.** Each role lists the services it applies to. A `page-curator` only touches `group-identity-service`. A `moderator` only touches `posts` and `comments`. The model scales infinitely without creating more groups.
+## Group Membership
+
+Active members.
+
+```sql
+CREATE TABLE group_members (
+    group_id String,
+    member_key String,
+    role String,                -- 'owner', 'moderator', 'page-curator', 'member'
+    joined_at DateTime64(3),
+    updated_at DateTime64(3),
+    deleted UInt8 DEFAULT 0
+) ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY (group_id, member_key);
+```
+
+**Multiple roles per user.** A user can hold multiple roles in the same group. The DB maps `user → group → [roles]`. Roles span different services.
 
 ## Group Membership Requests
 
@@ -111,13 +147,21 @@ CREATE TABLE group_join_requests (
 ORDER BY (group_id, requester_key);
 ```
 
-**Flow:**
+**Open policy flow (instant follow):**
 ```
-Bob requests to join alice.followers
-  → INSERT INTO group_join_requests ('alice.followers', 'bob', 'pending', ...)
+Bob follows a public profile (open join policy)
+  → INSERT INTO group_members ('web10.app/groups/alice/followers', 'bob', 'member', now(), ...)
+  → Bob is immediately a member with the 'member' role
+  → No request queue. No approval. Instant.
+```
+
+**Request policy flow (private follow):**
+```
+Bob requests to follow a private profile (request join policy)
+  → INSERT INTO group_join_requests ('web10.app/groups/alice/followers', 'bob', 'pending', ...)
 Alice approves
   → UPDATE status to 'approved', resolved_at = now()
-  → INSERT INTO group_members ('alice.followers', 'bob', 'member', ...)
+  → INSERT INTO group_members ('web10.app/groups/alice/followers', 'bob', 'member', ...)
 Alice denies
   → UPDATE status to 'denied', resolved_at = now()
 ```
@@ -138,15 +182,40 @@ CREATE TABLE user_group_sharing (
 ORDER BY (user_key, group_id);
 ```
 
-**Query:** is Alice sharing with `jazz-collectors`?
+**Query:** is Alice sharing with `web10.app/groups/dave/jazz-collectors`?
 ```sql
 SELECT sharing_enabled FROM user_group_sharing
 WHERE user_key = 'alice'
-  AND group_id = 'jazz-collectors'
+  AND group_id = 'web10.app/groups/dave/jazz-collectors'
   AND deleted = 0;
 ```
 
 Default is `1` (sharing on). If the row is missing, sharing is on. Toggle to `0` → the discover query filters out Alice's posts for this group. Toggle back to `1` → posts reappear. Reversible.
+
+## Blacklists
+
+Two levels of blocking.
+
+**User-wide blacklist** — block someone entirely.
+```sql
+CREATE TABLE user_blacklist (
+    user_key String,
+    blocked_key String,
+    created_at DateTime64(3)
+) ENGINE = MergeTree()
+ORDER BY (user_key, blocked_key);
+```
+
+**Per-group blacklist** — block someone from your content in one group.
+```sql
+CREATE TABLE group_blacklist (
+    user_key String,
+    group_id String,
+    blocked_key String,
+    created_at DateTime64(3)
+) ENGINE = MergeTree()
+ORDER BY (user_key, group_id, blocked_key);
+```
 
 ## Summary
 
@@ -156,3 +225,7 @@ All contract tables follow the same patterns:
 - Background job compacts tombstones on schedule
 - No row = denied (service contracts, provider contracts)
 - Missing row = enabled (sharing toggle — default on)
+- Roles are JSON arrays with service-scoped permissions
+- Multiple roles per user in the same group
+- Open join policy = instant membership, no request queue
+- Request join policy = pending request, owner approves or denies

--- a/knowledge/knowledge-base/web10-v3/contract-schemas.md
+++ b/knowledge/knowledge-base/web10-v3/contract-schemas.md
@@ -1,0 +1,158 @@
+# Contract Schemas
+
+Two concerns. Two contracts.
+
+1.  **Service Contracts (App Trust):** "Do we want to spin up these data buckets for this app?" Binary infrastructure toggle.
+2.  **Group Contracts (People Access):** "Who do we want this data to reach?" Granular social policy.
+
+## Service Contracts
+
+App Trust (Infrastructure). Which websites can access your service. CORS. App-level. Browser-enforced.
+
+```sql
+CREATE TABLE service_contracts (
+    user_key String,           -- owner of the service
+    service_name String,       -- 'posts', 'mail', 'notes'
+    allowed_origin String,     -- 'twitter-clone.web10.com'
+    created_at DateTime64(3),
+    updated_at DateTime64(3),
+    deleted UInt8 DEFAULT 0
+) ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY (user_key, service_name, allowed_origin);
+```
+
+**Query:** can `twitter-clone.web10.com` access `alice.posts`?
+```sql
+SELECT 1 FROM service_contracts
+WHERE user_key = 'alice'
+  AND service_name = 'posts'
+  AND allowed_origin = 'twitter-clone.web10.com'
+  AND deleted = 0
+LIMIT 1;
+```
+
+**Kill switch:** revoke all origins for a user.
+```sql
+INSERT INTO service_contracts
+SELECT user_key, service_name, allowed_origin, created_at, now(), 1
+FROM service_contracts
+WHERE user_key = 'alice' AND deleted = 0;
+```
+
+Tombstone-append. Background job compacts. Same pattern everywhere.
+
+## Provider Service Contracts
+
+Node Trust. Which apps can participate on this node. Server-enforced. Provider admin manages.
+
+```sql
+CREATE TABLE provider_service_contracts (
+    provider_key String,       -- 'provider-a'
+    allowed_origin String,     -- 'twitter-clone.web10.com'
+    created_at DateTime64(3),
+    updated_at DateTime64(3),
+    deleted UInt8 DEFAULT 0
+) ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY (provider_key, allowed_origin);
+```
+
+**Query:** can `spamapp.com` participate on `provider-a`?
+```sql
+SELECT 1 FROM provider_service_contracts
+WHERE provider_key = 'provider-a'
+  AND allowed_origin = 'spamapp.com'
+  AND deleted = 0
+LIMIT 1;
+```
+
+Blocked apps simply have no row. No row = denied.
+
+## Group Contracts
+
+Group membership, roles, join policy. The contract is people + policy only. Roles are service-scoped.
+
+```sql
+CREATE TABLE group_contracts (
+    group_id String,           -- 'web10.app/groups/jacoby149/abacus-enthusiasts'
+    roles String,              -- JSON array of roles with services + permissions
+    join_policy String,        -- 'open', 'request', 'invite_only'
+    created_at DateTime64(3),
+    updated_at DateTime64(3),
+    deleted UInt8 DEFAULT 0
+) ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY group_id;
+```
+
+**Query:** what's the join policy and roles for `web10.app/groups/jacoby149/abacus-enthusiasts`?
+```sql
+SELECT join_policy, roles
+FROM group_contracts
+WHERE group_id = 'web10.app/groups/jacoby149/abacus-enthusiasts' AND deleted = 0;
+```
+
+**Profile data** (banner, description, website, avatar) lives in `group-identity-service` — not the contract. Roles with access to that service write it, members read. The contract stays pure: people + policy.
+
+**Service-scoped roles.** Each role lists the services it applies to. A `page-curator` only touches `group-identity-service`. A `moderator` only touches `posts` and `comments`. The model scales infinitely without creating more groups.
+
+## Group Membership Requests
+
+Pending join requests. The "request" join policy needs a queue.
+
+```sql
+CREATE TABLE group_join_requests (
+    group_id String,
+    requester_key String,
+    status String,             -- 'pending', 'approved', 'denied'
+    requested_at DateTime64(3),
+    resolved_at DateTime64(3),
+    updated_at DateTime64(3),
+    deleted UInt8 DEFAULT 0
+) ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY (group_id, requester_key);
+```
+
+**Flow:**
+```
+Bob requests to join alice.followers
+  → INSERT INTO group_join_requests ('alice.followers', 'bob', 'pending', ...)
+Alice approves
+  → UPDATE status to 'approved', resolved_at = now()
+  → INSERT INTO group_members ('alice.followers', 'bob', 'member', ...)
+Alice denies
+  → UPDATE status to 'denied', resolved_at = now()
+```
+
+## Block Sharing
+
+Per-user, per-group toggle. "Pause sharing without leaving."
+
+```sql
+CREATE TABLE user_group_sharing (
+    user_key String,           -- the user controlling sharing
+    group_id String,
+    sharing_enabled UInt8,     -- 1 = sharing, 0 = blocked
+    created_at DateTime64(3),
+    updated_at DateTime64(3),
+    deleted UInt8 DEFAULT 0
+) ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY (user_key, group_id);
+```
+
+**Query:** is Alice sharing with `jazz-collectors`?
+```sql
+SELECT sharing_enabled FROM user_group_sharing
+WHERE user_key = 'alice'
+  AND group_id = 'jazz-collectors'
+  AND deleted = 0;
+```
+
+Default is `1` (sharing on). If the row is missing, sharing is on. Toggle to `0` → the discover query filters out Alice's posts for this group. Toggle back to `1` → posts reappear. Reversible.
+
+## Summary
+
+All contract tables follow the same patterns:
+- `ReplacingMergeTree(updated_at)` for updates
+- `deleted UInt8 DEFAULT 0` for tombstones
+- Background job compacts tombstones on schedule
+- No row = denied (service contracts, provider contracts)
+- Missing row = enabled (sharing toggle — default on)

--- a/knowledge/knowledge-base/web10-v3/group-identity-management.md
+++ b/knowledge/knowledge-base/web10-v3/group-identity-management.md
@@ -1,0 +1,102 @@
+# Group Identity Management
+
+## The Model
+
+A group is a collection of web10 users operating on data services. Roles define access, scoped to exactly which services they apply to. One group. No parent-child chains.
+
+```
+Group contract (one record):
+  group_id, join_policy, roles
+
+Roles are service-scoped:
+  owner → all services ("*")
+  moderator → posts, comments
+  page-curator → group-identity-service
+  member → posts, comments
+```
+
+**Service-scoped roles.** Each role lists the services it applies to. A `page-curator` can only touch the identity service. A `moderator` can only touch posts and comments. The model scales infinitely without creating more groups.
+
+## Group Permissions
+
+Each role defines explicit permissions scoped to its services. Permissions are camelCase, self-focused by default:
+
+- `readAll` — view any content in the service
+- `create` — add new content
+- `updateOwn` — edit your own content
+- `deleteOwn` — remove your own content
+- `hideAll` — hide any content from discover (moderation)
+- `manageRoles` — create/edit/remove roles
+- `assignRoles` / `revokeRoles` — manage user roles
+- `deleteGroup` — destroy the group
+
+`updateAll` and `deleteAll` are reserved for v2 collaboration. v1 is self-focused: you only touch your own stuff unless explicitly granted otherwise.
+
+## Group Profile
+
+The `group-identity-service` holds the group's profile — banner, name, website, avatar. Append-only. Curators add records, they don't overwrite. Members see the most recent. No accidental overwrites.
+
+## Group URLs
+
+Free — namespaced by creator:
+```
+web10.app/groups/jacoby149/abacus-enthusiasts
+web10.app/groups/alice/abacus-enthusiasts
+```
+
+No fighting over names. Anyone can claim any slug under their own username.
+
+Premium — vanity URL (paid):
+```
+web10.app/groups/abacus-enthusiasts
+```
+
+You pay the node owner for the bare name. No username prefix. Status as a service — like a domain registration. The username-prefixed URL stays as the canonical anchor; the vanity URL redirects to it. Node owner collects revenue, user buys visibility.
+
+## Service URLs
+
+Same pattern. Collections are namespaced by username — `jacoby149/posts`, `alice/posts`.
+
+Multiple apps can claim the same collection name. That's a feature — if two apps speak the same format to the same collection, they interoperate by default. Collision means your data works everywhere. The collection is the contract. Shared format = free for all mosh pit.
+
+## Content Lives With The Author
+
+Posts, notes, mail, files — live in the author's collection. Groups define who discovers them.
+
+```ts
+// Alice posts to a group
+await createDocument({
+  service: "posts",
+  body: { text: "Check out this jazz record", groups: ["web10.app/groups/jacoby149/abacus-enthusiasts"] }
+});
+// Lives in Alice's collection. Visible to group members.
+
+// Bob discovers Alice's post
+const posts = await discover({ group: "web10.app/groups/jacoby149/abacus-enthusiasts" });
+// Returns posts from all group members.
+```
+
+One insert. Zero fan-out. Groups are discovery, not containers.
+
+## Impersonation & Verification
+
+- Names aren't unique. Two groups can be named "Jazz Lovers."
+- Owner and moderator list is public. Users can see who controls the group.
+- Verified badges (future): `verified: true` in metadata.
+- Users can report impersonating groups.
+
+## App-Level vs Platform-Level
+
+- **Platform:** documents table, CRUD API, `group_contracts` / `group_members` tables
+- **App (web10-social):** metadata schema, UI, role enforcement
+
+## CRUD Operations
+
+- **Create:** `INSERT INTO group_contracts` — auto-add owner
+- **Read:** `SELECT * FROM group_contracts WHERE group_id = 'web10.app/groups/jacoby149/abacus-enthusiasts' AND deleted = 0`
+- **Update:** owner/manager tombstones old, inserts new
+- **Delete:** owner tombstones
+
+## Summary
+
+Groups are collections of users operating on data services. The contract holds service-scoped roles and permissions. One group. Roles define access per service. Content lives with the author. Groups define discovery. One insert. Zero fan-out.

--- a/knowledge/knowledge-base/web10-v3/group-identity-management.md
+++ b/knowledge/knowledge-base/web10-v3/group-identity-management.md
@@ -2,7 +2,7 @@
 
 ## The Model
 
-A group is a collection of web10 users operating on data services. Roles define access, scoped to exactly which services they apply to. One group. No parent-child chains.
+A group is a collection of web10 users operating on data services. Roles define access, scoped to exactly which services they apply to. One group. No parent-child chains. Multiple roles per user — a user can hold different roles for different services in the same group.
 
 ```
 Group contract (one record):
@@ -15,7 +15,7 @@ Roles are service-scoped:
   member → posts, comments
 ```
 
-**Service-scoped roles.** Each role lists the services it applies to. A `page-curator` can only touch the identity service. A `moderator` can only touch posts and comments. The model scales infinitely without creating more groups.
+**Service-scoped roles.** Each role lists the services it applies to and the explicit permissions it grants. A `page-curator` can only touch the identity service. A `moderator` can only touch posts and comments. A follower `member` only gets `readAll` on posts — no create, no update, no delete. The model scales infinitely without creating more groups.
 
 ## Group Permissions
 
@@ -30,11 +30,29 @@ Each role defines explicit permissions scoped to its services. Permissions are c
 - `assignRoles` / `revokeRoles` — manage user roles
 - `deleteGroup` — destroy the group
 
-`updateAll` and `deleteAll` are reserved for v2 collaboration. v1 is self-focused: you only touch your own stuff unless explicitly granted otherwise.
+`updateAll` and `deleteAll` are reserved for collaboration. Default is self-focused: you only touch your own stuff unless explicitly granted otherwise.
+
+**Role examples:**
+- **Owner** — `["*"]` services, all permissions including `manageRoles`, `assignRoles`, `revokeRoles`, `deleteGroup`
+- **Moderator** — `["posts", "comments"]`, `readAll`, `create`, `updateOwn`, `deleteOwn`, `hideAll`, `assignRoles`, `revokeRoles`
+- **Page Curator** — `["group-identity-service"]`, `readAll`, `create`, `updateOwn`, `deleteOwn`
+- **Member** — `["posts", "comments"]`, `readAll`, `create`, `updateOwn`, `deleteOwn`
+- **Follower** — `["posts"]`, `readAll` only (no create, no update, no delete)
 
 ## Group Profile
 
 The `group-identity-service` holds the group's profile — banner, name, website, avatar. Append-only. Curators add records, they don't overwrite. Members see the most recent. No accidental overwrites.
+
+## Group Collections
+
+Each group holds collections:
+- `group-settings-service` — config, permissions
+- `group-identity-service` — group banner, name, website, avatar (append-only)
+- `posts` — group posts
+- `comments` — group comments
+- Whatever else the group needs
+
+The group can hold any number of collections. Roles are scoped to exactly which ones they can touch.
 
 ## Group URLs
 
@@ -69,7 +87,7 @@ await createDocument({
   service: "posts",
   body: { text: "Check out this jazz record", groups: ["web10.app/groups/jacoby149/abacus-enthusiasts"] }
 });
-// Lives in Alice's collection. Visible to group members.
+// Lives in Alice's collection. Visible to group members with readAll on posts.
 
 // Bob discovers Alice's post
 const posts = await discover({ group: "web10.app/groups/jacoby149/abacus-enthusiasts" });
@@ -99,4 +117,4 @@ One insert. Zero fan-out. Groups are discovery, not containers.
 
 ## Summary
 
-Groups are collections of users operating on data services. The contract holds service-scoped roles and permissions. One group. Roles define access per service. Content lives with the author. Groups define discovery. One insert. Zero fan-out.
+Groups are collections of users operating on data services. The contract holds service-scoped roles and explicit permissions. One group. Multiple roles per user. Roles define access per service. Content lives with the author. Groups define discovery. One insert. Zero fan-out.

--- a/knowledge/knowledge-base/web10-v3/groups.md
+++ b/knowledge/knowledge-base/web10-v3/groups.md
@@ -1,33 +1,56 @@
 # Groups: Policy Containers
 
-Groups are not data containers. They are policy containers — they define who gets what access to content that lives elsewhere.
+Groups are not data containers. They are policy containers — they define who gets what access to content that lives elsewhere. But they're more than that. A group is an **owned audience relationship**. The owner holds the membership list. They can see who's in it, reach out to them, and that relationship belongs to them — not the platform.
 
 ## What Groups Are
 
-A group is a collection of web10 users operating on a data service. It doesn't hold posts, files, or playlists. It holds people. When you attach a document to a group, group members can see it.
+A group is a collection of web10 users operating on data services. It doesn't hold posts, files, or playlists. It holds people and roles. Three things happen when a group exists:
+
+1. **Discovery** — content attached to the group is visible to members. This is how people find creators, and how creators reach their audience.
+2. **Policy** — roles define what each member can do. Service-scoped permissions control access.
+3. **Ownership** — the group owner holds the audience relationship. They can see every member's web10 identity, reach out directly, and that list is theirs.
 
 ```
 Group "jazz-collectors":
-  owner: dave
-  moderators: alice
-  members: alice, dave, eve
+  roles: [curator, listener, contributor]
+  members: alice (curator), dave (listener), eve (contributor)
 ```
 
-Roles define access, scoped to services. One group. No parent-child chains.
+The group owner can query the membership list. They see web10 usernames, emails (if set), phone numbers (if set). They can text a follower, email a fan, message a member — directly, through web10, no platform gatekeeping the relationship. On legacy platforms, your followers are the platform's asset. You can't export them. You can't message them without the platform's permission. Here, the group membership is yours.
 
-- **Owner** — all services, manages roles, deletes group, changes architecture
-- **Moderator** — posts, comments; moderates content, assigns roles
-- **Page Curator** — group-identity-service; edits banner, name, website
-- **Member** — posts, comments; views, creates, edits own content
+**Service-scoped roles.** Each group defines its own roles. Each role lists the services it applies to and the explicit permissions it grants. One group. No parent-child chains. Multiple roles per user — a user can hold different roles for different services in the same group.
 
-Alice attaches a post, a file, and a playlist to this group. Dave and eve can see all three. Same group. Different doc types. The group doesn't care what the document is.
+**Roles are generic.** There are no predefined roles. A group defines whatever roles make sense for its purpose. A music group might have `curator`, `listener`, and `contributor`. A project group might have `admin`, `reviewer`, and `editor`. A followers group might have `owner` and `member`. The platform doesn't care what you call them or what they do.
+
+**Permissions are explicit.** Each role lists exactly which permissions it grants on which services. No inheritance. No hidden defaults. What you see is what you get.
+
+**The owner sees the audience.** The group owner can read the full membership list — every member's web10 identity and any contact info they've made available (email, phone). This is the audience relationship. The influencer owns it. They can reach out directly. No platform approval. No rate limits on relationship-building.
+
+```json
+{
+  "roles": [
+    {
+      "name": "curator",
+      "services": ["playlists", "comments"],
+      "permissions": ["readAll", "create", "updateOwn", "deleteOwn", "hideAll"]
+    },
+    {
+      "name": "listener",
+      "services": ["playlists"],
+      "permissions": ["readAll"]
+    }
+  ]
+}
+```
+
+Alice attaches a post, a file, and a playlist to this group. Dave and eve can see what their roles allow. Same group. Different doc types. The group doesn't care what the document is.
 
 ## Two Contract Types
 
 v3 has two contract types. They control completely different concerns.
 
 **Service contract** — App Trust (Infrastructure). "Do we want to spin up these data buckets for this app?"
-It's a binary toggle. CORS. Browser-enforced. No data permissions involved. If you turn it off, the app can't even talk to your node.
+Binary toggle. CORS. Browser-enforced. No data permissions involved. If you turn it off, the app can't even talk to your node.
 
 ```
 service:posts → allowed: twitter-clone.web10.com
@@ -43,7 +66,7 @@ provider-a:
 ```
 
 **Group contract** — People Access (Social). "Who do we want this data to reach?"
-Granular, user-controlled social policy. The author decides per-post whether to attach it to a group. Members discover it.
+Granular, user-controlled social policy. Roles define access, scoped to services. Content is attached to groups. Members discover it based on their role.
 
 ```
 jazz-collectors → members: alice, dave, eve
@@ -62,7 +85,7 @@ The service contract is the outer wall. The groups are the inner permissions.
 
 ## Posting to Groups
 
-When you create a post, you pick the groups it belongs to. Those groups already define who sees it.
+When you create content, you pick the groups it belongs to. Those groups already define who sees it through their roles.
 
 ```ts
 await createDocument({
@@ -71,19 +94,19 @@ await createDocument({
 });
 ```
 
-Bob sees it because he's a member. Eve doesn't.
+Bob sees it because he's a member with `readAll` on the relevant service. Eve doesn't see it because she's not in the group.
 
-A post can belong to multiple groups:
+Content can belong to multiple groups:
 ```ts
 await createDocument({
   text: "team update",
-  groups: ["alice.close-friends", "web10-dev"]
+   groups: ["alice.close-friends", "charlie/st-louis-chess-club"]
 });
 ```
 
-Anyone in either group can read it. Union of members.
+Anyone in either group with the right role and permissions can read it. Union of members.
 
-A post with no groups is private — only the author sees it.
+Content with no groups is private — only the author sees it.
 
 ## Join Policies
 
@@ -92,45 +115,28 @@ Groups have three join policies:
 | Policy | How it works |
 |---|---|
 | Open | Anyone joins automatically |
-| Request | Anyone can request, moderator approves or denies |
-| Invite only | Only people the moderator explicitly adds can join |
+| Request | Anyone can request, owner approves or denies |
+| Invite only | Only people explicitly added can join |
 
-**Open** — `alice.public`. Anyone can see posts attached to it. No gatekeeping.
+**Open** — anyone can join instantly. No gatekeeping. Used for public boards, open communities, public follower groups.
 
-**Request** — `alice.followers`. Bob requests to join → Alice approves → Bob is a member. This is the follow flow.
+**Request** — someone requests to join, the group owner approves or denies. Used for private follower groups, curated communities.
 
-**Invite only** — `alice.close-friends`. Alice adds Bob and Charlie. No one else can join unless Alice invites them.
-
-The author decides the permission level, not the group. You set it when you attach:
-
-```ts
-await attachToGroup({
-  doc_id: "post-1",
-  group_id: "jazz-collectors",
-  permission: "read"   // or "write"
-});
-```
-
-The group moderator can add/remove people, but they can't change `read` to `write` on your doc. Two separate controls:
-
-- **Group moderator** — who's in the group
-- **Document author** — what access the group gets
+**Invite only** — only people the owner explicitly adds can join. Used for close friends, private circles, invited communities.
 
 ## Moderation
 
-Group moderators can moderate content in their group. They can hide a post from the group's discover — hiding it from group members. They cannot edit the content.
+Group roles can include moderation permissions. A role with `hideAll` can hide content from the group's discover — hiding it from group members. Roles cannot edit content they don't own. Roles cannot escalate their own permissions.
 
 ```
-Group moderator can:
-  ✓ Hide a post from group discover
-  ✓ Remove a member
-  ✗ Edit the content
-  ✗ Escalate read to write
+Moderation role can:
+  ✓ Hide content from group discover
+  ✓ Remove a member (if role grants revokeRoles)
+  ✗ Edit content they don't own
+  ✗ Escalate their own permissions
 ```
 
-The post still exists in your collection. It's just removed from that group's discover. Like YouTube taking down a video — your file is still yours, it's just not on their platform.
-
-The group is a curation layer, not an ownership layer.
+Content still exists in the author's collection. It's just removed from that group's discover. The group is a curation layer, not an ownership layer.
 
 ## Blocking
 
@@ -148,11 +154,11 @@ user-wide blacklist:
 ```
 jazz-collectors → per-group blacklist: dave
   dave is still a member
-  dave sees everyone's posts in jazz-collectors
-  dave does NOT see alice's posts in jazz-collectors
+  dave sees everyone's content in jazz-collectors
+  dave does NOT see alice's content in jazz-collectors
 ```
 
-The per-group blacklist is the nuance. You can be in a group with someone you don't want seeing your content. You don't have to leave the group. You don't have to kick them out. You just block them from your posts in that group.
+The per-group blacklist is the nuance. You can be in a group with someone you don't want seeing your content. You don't have to leave the group. You don't have to kick them out. You just block them from your content in that group.
 
 ## Group URLs
 
@@ -192,62 +198,56 @@ Collections use the same pattern — `jacoby149/posts`, `alice/posts`. Multiple 
 
 The web10 authenticator is where you manage groups and take charge of your data.
 
-**Groups you manage** — you control membership.
+**Groups you manage** — you control membership and roles. You see your audience.
 ```
-alice.close-friends → moderator: you, invite only
+alice.close-friends → owner: you, invite only
   members: bob, charlie, dave
-  [Add member] [Remove member]
+  [Add member] [Remove member] [Edit roles] [View audience]
 ```
+
+The owner can see the full membership list — web10 usernames, emails (if set), phone numbers (if set). This is the audience relationship. The influencer owns it.
 
 **Groups you belong to** — you can view membership, leave, or control sharing.
 ```
-jazz-collectors → moderator: dave, request
+jazz-collectors → owner: dave, request
   members: alice (you), dave, eve
   [View members] [Block sharing] [Leave]
 ```
 
-**Block sharing** — pause sharing with a group without leaving. You stay a member. You still see their posts. They can't see yours. Reversible.
+**Block sharing** — pause sharing with a group without leaving. You stay a member. You still see their content. They can't see yours. Reversible.
 
 ```
 jazz-collectors → [Block sharing]
-  Your posts: hidden from group
-  Their posts: still visible to you
+  Your content: hidden from group
+  Their content: still visible to you
   [Unblock]
 ```
 
-**Opt out all documents** — bulk remove every post you've attached to a group. Reversible.
+**Opt out all documents** — bulk remove every piece of content you've attached to a group. Reversible.
 
-**Make everything private** — remove all groups from all your posts. One click. Everything goes dark.
+**Make everything private** — remove all groups from all your content. One click. Everything goes dark.
 
 **Turn off all service contracts** — no website touches your data. Ever. Kill switch.
 
 ## Scale
 
-No Gmail mailing list limits. A group can have 100k members. ClickHouse filters it in milliseconds. One insert serves everyone. No fan-out.
+No mailing list limits. A group can have 100k members. ClickHouse filters it in milliseconds. One insert serves everyone. No fan-out.
 
 ```
 alice.followers → 50k members
-web10-dev → 100k members
+charlie/st-louis-chess-club → 100k members
 jazz-collectors → 500k members
 ```
 
-A post attached to any of these groups is discoverable by all members. One insert. Zero fan-out. The query filters at read time.
+Content attached to any of these groups is discoverable by all members with the right role. One insert. Zero fan-out. The query filters at read time.
 
-## Follows as Groups
-
-Follows are groups. `alice.followers` is a group where Alice is the moderator. Bob requests to join → Alice approves → Bob is a member → Bob sees posts attached to that group.
-
-```ts
-await followUser('alice');        // request to join alice.followers
-await approveFollower('bob');     // approve bob into alice.followers
-await unfollow('alice');          // leave alice.followers
-```
-
-No separate follows table. Groups handle it.
+**The audience is the asset.** At scale, the group membership list is the influencer's most valuable thing. 50k followers isn't a vanity number — it's 50k people the influencer can reach directly. Their web10 usernames, emails, phones. The influencer can message them, email them, text them. On legacy platforms, 50k followers is a number the platform controls. The influencer can't export the list, can't message them without the platform's permission, can't take the relationship if they leave. Here, the group membership is owned data. It moves with the influencer. It's the difference between renting an audience and owning one.
 
 ## Summary
 
-Groups are policy containers. They hold people, not data. Any document from any service can be attached to any group. The author decides the permission level. The group moderator manages membership and can moderate (hide from discover, not edit). Groups carry across apps. One membership. Infinite apps.
+Groups are policy containers, discovery mechanisms, and owned audience relationships. They hold people, not data. Any document from any service can be attached to any group. Groups define their own roles with service-scoped permissions. One membership. Infinite apps.
+
+For the group owner, the membership list is the audience. Web10 usernames, emails, phones — directly accessible. The influencer owns that relationship. They can reach out, export it, and take it with them. No platform gatekeeping.
 
 Service contracts control which websites can access your data. Group contracts control which people can see your content. Both must pass. Browser enforces the outer wall. Server enforces the inner permissions.
 

--- a/knowledge/knowledge-base/web10-v3/groups.md
+++ b/knowledge/knowledge-base/web10-v3/groups.md
@@ -1,0 +1,254 @@
+# Groups: Policy Containers
+
+Groups are not data containers. They are policy containers — they define who gets what access to content that lives elsewhere.
+
+## What Groups Are
+
+A group is a collection of web10 users operating on a data service. It doesn't hold posts, files, or playlists. It holds people. When you attach a document to a group, group members can see it.
+
+```
+Group "jazz-collectors":
+  owner: dave
+  moderators: alice
+  members: alice, dave, eve
+```
+
+Roles define access, scoped to services. One group. No parent-child chains.
+
+- **Owner** — all services, manages roles, deletes group, changes architecture
+- **Moderator** — posts, comments; moderates content, assigns roles
+- **Page Curator** — group-identity-service; edits banner, name, website
+- **Member** — posts, comments; views, creates, edits own content
+
+Alice attaches a post, a file, and a playlist to this group. Dave and eve can see all three. Same group. Different doc types. The group doesn't care what the document is.
+
+## Two Contract Types
+
+v3 has two contract types. They control completely different concerns.
+
+**Service contract** — App Trust (Infrastructure). "Do we want to spin up these data buckets for this app?"
+It's a binary toggle. CORS. Browser-enforced. No data permissions involved. If you turn it off, the app can't even talk to your node.
+
+```
+service:posts → allowed: twitter-clone.web10.com
+service:playlists → allowed: music.web10.com
+```
+
+**Provider level** — Node Trust. Server-enforced. Which apps are allowed to participate on this node at all.
+
+```
+provider-a:
+  allowed apps: twitter-clone.web10.com, music.web10.com
+  blocked apps: spamapp.com
+```
+
+**Group contract** — People Access (Social). "Who do we want this data to reach?"
+Granular, user-controlled social policy. The author decides per-post whether to attach it to a group. Members discover it.
+
+```
+jazz-collectors → members: alice, dave, eve
+```
+
+**The separation:** Service contracts decide if an app gets a bucket. Group contracts decide who gets to look inside it.
+
+```
+service:posts → allowed: twitter-clone.web10.com → GET /alice/posts?discover=true
+  1. Service contract: origin allowed? → yes
+  2. Groups: which posts are in groups bob belongs to? → post-1, post-2
+  3. Return post-1, post-2
+```
+
+The service contract is the outer wall. The groups are the inner permissions.
+
+## Posting to Groups
+
+When you create a post, you pick the groups it belongs to. Those groups already define who sees it.
+
+```ts
+await createDocument({
+  text: "behind the scenes",
+  groups: ["alice.close-friends"]
+});
+```
+
+Bob sees it because he's a member. Eve doesn't.
+
+A post can belong to multiple groups:
+```ts
+await createDocument({
+  text: "team update",
+  groups: ["alice.close-friends", "web10-dev"]
+});
+```
+
+Anyone in either group can read it. Union of members.
+
+A post with no groups is private — only the author sees it.
+
+## Join Policies
+
+Groups have three join policies:
+
+| Policy | How it works |
+|---|---|
+| Open | Anyone joins automatically |
+| Request | Anyone can request, moderator approves or denies |
+| Invite only | Only people the moderator explicitly adds can join |
+
+**Open** — `alice.public`. Anyone can see posts attached to it. No gatekeeping.
+
+**Request** — `alice.followers`. Bob requests to join → Alice approves → Bob is a member. This is the follow flow.
+
+**Invite only** — `alice.close-friends`. Alice adds Bob and Charlie. No one else can join unless Alice invites them.
+
+The author decides the permission level, not the group. You set it when you attach:
+
+```ts
+await attachToGroup({
+  doc_id: "post-1",
+  group_id: "jazz-collectors",
+  permission: "read"   // or "write"
+});
+```
+
+The group moderator can add/remove people, but they can't change `read` to `write` on your doc. Two separate controls:
+
+- **Group moderator** — who's in the group
+- **Document author** — what access the group gets
+
+## Moderation
+
+Group moderators can moderate content in their group. They can hide a post from the group's discover — hiding it from group members. They cannot edit the content.
+
+```
+Group moderator can:
+  ✓ Hide a post from group discover
+  ✓ Remove a member
+  ✗ Edit the content
+  ✗ Escalate read to write
+```
+
+The post still exists in your collection. It's just removed from that group's discover. Like YouTube taking down a video — your file is still yours, it's just not on their platform.
+
+The group is a curation layer, not an ownership layer.
+
+## Blocking
+
+Two levels of blocking. The author controls both.
+
+**User-wide blacklist** — block someone entirely. They can't see any of your content, anywhere.
+
+```
+user-wide blacklist:
+  blocked: bob, charlie
+```
+
+**Per-group blacklist** — block someone from seeing your content in a specific group. They're still in the group. They still see everyone else's content. Just not yours.
+
+```
+jazz-collectors → per-group blacklist: dave
+  dave is still a member
+  dave sees everyone's posts in jazz-collectors
+  dave does NOT see alice's posts in jazz-collectors
+```
+
+The per-group blacklist is the nuance. You can be in a group with someone you don't want seeing your content. You don't have to leave the group. You don't have to kick them out. You just block them from your posts in that group.
+
+## Group URLs
+
+Free — namespaced by creator:
+```
+web10.app/groups/jacoby149/abacus-enthusiasts
+web10.app/groups/alice/jazz-collectors
+```
+
+No fighting over names. Anyone can claim any slug under their username.
+
+Premium — vanity URL (paid to node owner):
+```
+web10.app/groups/abacus-enthusiasts
+```
+
+Bare name, no username prefix. Status as a service. Redirects to the canonical `:username/:slug` URL. Node owner collects revenue.
+
+## Cross-App Identity
+
+Groups carry across apps. The same membership works everywhere:
+
+```
+jacoby149/abacus-enthusiasts:
+  members: alice, dave, eve
+
+Social app → dave sees alice's posts in this group
+Music app  → dave sees alice's playlists in this group
+Doc app    → dave sees alice's files in this group
+```
+
+One membership. Infinite apps. The group is managed once, at the platform level.
+
+Collections use the same pattern — `jacoby149/posts`, `alice/posts`. Multiple apps can target the same collection. That's a feature: shared format means interoperability. Collision is a mosh pit, not a problem.
+
+## The Authenticator — Group Management
+
+The web10 authenticator is where you manage groups and take charge of your data.
+
+**Groups you manage** — you control membership.
+```
+alice.close-friends → moderator: you, invite only
+  members: bob, charlie, dave
+  [Add member] [Remove member]
+```
+
+**Groups you belong to** — you can view membership, leave, or control sharing.
+```
+jazz-collectors → moderator: dave, request
+  members: alice (you), dave, eve
+  [View members] [Block sharing] [Leave]
+```
+
+**Block sharing** — pause sharing with a group without leaving. You stay a member. You still see their posts. They can't see yours. Reversible.
+
+```
+jazz-collectors → [Block sharing]
+  Your posts: hidden from group
+  Their posts: still visible to you
+  [Unblock]
+```
+
+**Opt out all documents** — bulk remove every post you've attached to a group. Reversible.
+
+**Make everything private** — remove all groups from all your posts. One click. Everything goes dark.
+
+**Turn off all service contracts** — no website touches your data. Ever. Kill switch.
+
+## Scale
+
+No Gmail mailing list limits. A group can have 100k members. ClickHouse filters it in milliseconds. One insert serves everyone. No fan-out.
+
+```
+alice.followers → 50k members
+web10-dev → 100k members
+jazz-collectors → 500k members
+```
+
+A post attached to any of these groups is discoverable by all members. One insert. Zero fan-out. The query filters at read time.
+
+## Follows as Groups
+
+Follows are groups. `alice.followers` is a group where Alice is the moderator. Bob requests to join → Alice approves → Bob is a member → Bob sees posts attached to that group.
+
+```ts
+await followUser('alice');        // request to join alice.followers
+await approveFollower('bob');     // approve bob into alice.followers
+await unfollow('alice');          // leave alice.followers
+```
+
+No separate follows table. Groups handle it.
+
+## Summary
+
+Groups are policy containers. They hold people, not data. Any document from any service can be attached to any group. The author decides the permission level. The group moderator manages membership and can moderate (hide from discover, not edit). Groups carry across apps. One membership. Infinite apps.
+
+Service contracts control which websites can access your data. Group contracts control which people can see your content. Both must pass. Browser enforces the outer wall. Server enforces the inner permissions.
+
+The authenticator is where you take charge: block sharing, opt out, privatize all, kill switch. One toggle. Everything goes dark.

--- a/knowledge/knowledge-base/web10-v3/sdk-api.md
+++ b/knowledge/knowledge-base/web10-v3/sdk-api.md
@@ -1,0 +1,377 @@
+# web10 SDK v3
+
+The JavaScript/TypeScript SDK. One client. Groups are baked into every verb.
+
+## Installation
+
+```bash
+npm install web10-npm
+```
+
+```ts
+import { createClient } from 'web10-npm'
+```
+
+## Creating a Client
+
+```ts
+const w = createClient({ authUrl: 'https://auth.web10.app' })
+```
+
+Optional `apiOrigin` overrides the node host. Defaults to `api.web10.app`.
+
+## Auth
+
+```ts
+// Open popup, wait for login
+await w.login()
+
+// Listen for sign-in/sign-out
+w.authListen((signedIn) => {
+  if (signedIn) {
+    const token = w.readToken()
+    console.log(token.username, token.provider)
+  }
+})
+
+// Check state
+w.isSignedIn()
+
+// Logout
+w.signOut()
+```
+
+## Service Contracts (App Trust)
+
+Thin layer. CORS. Browser-enforced. Declares which services your app needs. The user approves or denies in the authenticator.
+
+```ts
+w.smrOnReady([{
+  service: 'posts',
+  cross_origins: ['your-domain.com'],
+}])
+```
+
+This is infrastructure trust — "do we want to spin up these data buckets for this app?" It does not control who sees data. Groups do that.
+
+## CRUD With Groups
+
+The four verbs. Groups change everything.
+
+### Create
+
+The document body is typed content. Groups are metadata — a separate part of the request the API validates. The API checks membership and role permissions before attaching.
+
+```ts
+const doc = await w.create('posts', {
+  // Typed document body — leaf-level types
+  text: { type: 'text', value: 'just shipped the new groups feature' },
+  media: [{ type: 'minio', value: 'jacoby149/media/img-abc.jpg' }],
+}, {
+  // Metadata — API validates membership + permissions
+  groups: [
+    'web10.app/groups/web10/discover',
+    'web10.app/groups/jacoby149/followers',
+  ],
+})
+```
+
+The API checks each group:
+1. Is the user a member?
+2. Does their role grant `create` on that service?
+
+If a check fails, the attachment is rejected. The document still creates — just not attached to that group.
+
+No groups = private. Only the author sees it.
+
+Multiple groups = union of members. Anyone in either group with the right role can read it.
+
+Behind the scenes the API inserts one row into `documents`, then one row per group into `doc_groups`. One transaction. No fan-out.
+
+### Read
+
+Every read is group-filtered. You see a document because you're a member of a group it's attached to — even your own posts.
+
+**Personal read** — `me` is a reserved group that returns your own documents, regardless of group attachment:
+
+```ts
+const myPosts = await w.read('posts', {
+  groups: ['me'],
+  $sort: { created_at: -1 },
+  $limit: 50,
+})
+```
+
+The API knows `me` means "documents where `author_key = :user`". No group join. Same query shape. Consistent.
+
+**Group-filtered read** — the discover query. Pass groups, get documents attached to those groups:
+
+```ts
+// Discover — public board
+const posts = await w.read('posts', {
+  groups: ['web10.app/groups/web10/discover'],
+  $sort: { created_at: -1 },
+  $limit: 50,
+})
+```
+
+The API translates `groups` into a join against `doc_groups` → `group_members`. You get documents where the group matches and you're a member. Blacklists are checked automatically.
+
+**Feed pattern** — read across multiple groups:
+
+```ts
+const posts = await w.read('posts', {
+  groups: [
+    'web10.app/groups/web10/discover',
+    'web10.app/groups/alice/followers',
+    'web10.app/groups/charlie/st-louis-chess-club',
+  ],
+  $sort: { created_at: -1 },
+  $limit: 50,
+})
+```
+
+Union of all groups. One query.
+
+### Update
+
+Same separation. Body changes in the first arg. Group changes in the options:
+
+```ts
+await w.update('posts', { _id: 'doc-123' }, {
+  $set: { text: { type: 'text', value: 'updated content' } },
+}, {
+  $groups: ['web10.app/groups/web10/discover'],
+})
+```
+
+`$groups` replaces the group attachment list. API validates membership on each. Remove a group → the document disappears from that group's discover. Add a group → it appears.
+
+### Delete
+
+Tombstone. Insert a deleted marker. The document disappears from all groups:
+
+```ts
+await w.delete('posts', { _id: 'doc-123' })
+```
+
+The API tombstones the `documents` row and all `doc_groups` rows. Background job compacts on schedule.
+
+## Group Operations
+
+Groups are first-class. The SDK exposes them directly.
+
+### Create a Group
+
+Explicit roles. Explicit members. The API doesn't assume anything — you assign every role, including yourself.
+
+```ts
+const group = await w.createGroup({
+  name: 'St. Louis Chess Club',
+  join_policy: 'invite_only',
+  roles: [
+    {
+      name: 'admin',
+      services: ['*'],
+      permissions: [
+        // Content
+        'readAll', 'create', 'updateOwn', 'updateAll', 'deleteOwn', 'deleteAll', 'hideAll',
+        // Group management
+        'manageRoles', 'assignRoles', 'revokeRoles', 'deleteGroup', 'modifyJoinPolicy',
+      ],
+    },
+    {
+      name: 'member',
+      services: ['posts', 'comments'],
+      permissions: ['readAll', 'create', 'updateOwn', 'deleteOwn'],
+    },
+  ],
+  members: [
+    { member_key: 'jacoby149', role: 'admin' },
+  ],
+})
+// → { group_id: 'web10.app/groups/jacoby149/st-louis-chess-club' }
+```
+
+The `members` array is required. **The API enforces that the creator is assigned a role with group management permissions** (`manageRoles`, `assignRoles`, `revokeRoles`, `deleteGroup`, or `modifyJoinPolicy`). You cannot create a group you can't manage. If the assignment doesn't include at least one management permission for the creator, the request is rejected.
+
+Group management permissions are separate from content permissions:
+
+| Permission | What it does |
+|---|---|
+| `manageRoles` | Add, rename, or remove role definitions |
+| `assignRoles` | Add members or promote existing members |
+| `revokeRoles` | Remove members or demote roles |
+| `deleteGroup` | Delete the group (tombstone) |
+| `modifyJoinPolicy` | Change open/request/invite_only |
+
+### Get Groups
+
+### Get Groups
+
+```ts
+// All groups the user belongs to (full details)
+const groups = await w.getGroups({ member: 'jacoby149' })
+// → [
+//    { group_id: 'web10.app/groups/web10/discover', name: 'Discover', join_policy: 'open', member_count: 1200000, my_role: null },
+//    { group_id: 'web10.app/groups/jacoby149/followers', name: 'Followers', join_policy: 'open', member_count: 342, my_role: 'admin' },
+//    { group_id: 'web10.app/groups/jacoby149/close-friends', name: 'Close Friends', join_policy: 'invite_only', member_count: 12, my_role: 'admin' },
+//    { group_id: 'web10.app/groups/charlie/st-louis-chess-club', name: 'St. Louis Chess Club', join_policy: 'invite_only', member_count: 47, my_role: 'member' }
+//  ]
+
+// Groups where you manage membership
+const managed = await w.getGroups({ manages: 'jacoby149' })
+```
+
+### Join a Group
+
+```ts
+// Open policy — instant
+const joined = await w.joinGroup('web10.app/groups/alice/followers')
+// → { group_id: 'web10.app/groups/alice/followers', member_key: 'jacoby149', role: 'member' }
+
+// Request policy — pending until owner approves
+const pending = await w.requestJoin('web10.app/groups/alice/followers')
+// → { group_id: 'web10.app/groups/alice/followers', status: 'pending' }
+```
+
+### Leave a Group
+
+```ts
+await w.leaveGroup('web10.app/groups/alice/followers')
+// → { group_id: 'web10.app/groups/alice/followers', member_key: 'jacoby149', status: 'left' }
+```
+
+### Invite a Member
+
+Sends an invite. The target user receives it with the role offered. They can accept or decline.
+
+```ts
+await w.inviteMember('web10.app/groups/jacoby149/close-friends', 'bob', 'member')
+// → Bob receives an invite
+// → Bob accepts → added to group_members
+// → Bob declines → invite expires, not added
+```
+
+### Accept / Decline Invite
+
+```ts
+const result = await w.acceptInvite('web10.app/groups/jacoby149/close-friends')
+// → { group_id: 'web10.app/groups/jacoby149/close-friends', role: 'member' }
+
+await w.declineInvite('web10.app/groups/jacoby149/close-friends')
+// → { group_id: 'web10.app/groups/jacoby149/close-friends', status: 'declined' }
+```
+
+### Remove Member
+
+Direct remove. Only works if your role has `revokeRoles`.
+
+```ts
+await w.removeMember('web10.app/groups/jacoby149/close-friends', 'bob')
+// → { group_id: 'web10.app/groups/jacoby149/close-friends', member_key: 'bob', status: 'removed' }
+```
+
+### Get Members
+
+```ts
+const members = await w.getMembers('web10.app/groups/jacoby149/followers')
+// → [{ member_key: 'alice', role: 'admin' },
+//    { member_key: 'bob', role: 'member' },
+//    { member_key: 'charlie', role: 'member' }]
+```
+
+### Update Group
+
+```ts
+const updated = await w.updateGroup('web10.app/groups/jacoby149/close-friends', {
+  join_policy: 'request',
+})
+```
+
+## Aggregate
+
+Server-side pipelines. Read-only. Sandboxed. Same group filter:
+
+```ts
+const stats = await w.aggregate('posts', [
+  { $match: { groups: 'web10.app/groups/web10/discover' } },
+  { $group: { _id: '$author', count: { $sum: 1 } } },
+  { $sort: { count: -1 } },
+])
+```
+
+## Media
+
+Three-step upload: request presigned URL, upload to MinIO, confirm.
+
+```ts
+// Convenience — does all three
+const record = await w.upload(file, {
+  filename: 'photo.jpg',
+  mimeType: 'image/jpeg',
+  altText: 'screenshot',
+})
+
+// Manual flow
+const presigned = await w.requestUploadUrl({
+  filename: 'photo.jpg',
+  mimeType: 'image/jpeg',
+  sizeBytes: file.size,
+})
+// POST FormData to presigned.upload_url
+const record = await w.confirmUpload({
+  url: presigned.upload_url,
+  filename: 'photo.jpg',
+  mimeType: 'image/jpeg',
+  sizeBytes: file.size,
+})
+
+// Read URL (presigned GET, cached)
+const { readUrl } = await w.getReadUrl(record.object_key)
+```
+
+## What ClickHouse Happens
+
+Each SDK call triggers specific ClickHouse operations:
+
+| SDK call | ClickHouse |
+|---|---|
+| `w.create('posts', ..., { groups })` | `INSERT INTO documents` + `INSERT INTO doc_groups` (N rows) |
+| `w.read('posts', { groups: ['me'] })` | `SELECT FROM documents WHERE author_key = :user` (reserved group, no join) |
+| `w.read('posts', { groups })` | `SELECT FROM documents JOIN doc_groups JOIN group_members WHERE member = :user AND group IN (...)` |
+| `w.update('posts', ..., { $groups })` | `INSERT INTO documents` (new version) + tombstone old `doc_groups` + new `doc_groups` |
+| `w.delete('posts', ...)` | `INSERT INTO documents` (tombstone) + tombstone `doc_groups` |
+| `w.createGroup(...)` | `INSERT INTO group_contracts` + `INSERT INTO group_members` (all members) |
+| `w.joinGroup(...)` | `INSERT INTO group_members` (open) or `INSERT INTO group_join_requests` (request) |
+| `w.inviteMember(...)` | `INSERT INTO group_join_requests` |
+| `w.acceptInvite(...)` | `INSERT INTO group_members` |
+| `w.getGroups({ member })` | `SELECT group_id, name, member_count, my_role FROM group_contracts JOIN group_members WHERE member_key = :user` |
+| `w.getMembers(...)` | `SELECT member_key, role FROM group_members WHERE group_id = :group` |
+
+Everything is append-only. Updates are new inserts. Deletes are tombstones. `ReplacingMergeTree` keeps the latest version. Background job compacts on schedule.
+
+## Cross-Node Addressing
+
+Optional `username` and `provider` on every CRUD call:
+
+```ts
+const posts = await w.read('posts', {}, 'alice', 'api.web10.app')
+```
+
+No provider = hits your own node. Provider = routes to that node's origin.
+
+## Summary
+
+v3 SDK vs v2 SDK:
+
+| v2 | v3 |
+|---|---|
+| `create(service, body)` — no groups | `create(service, { body, groups: [...] })` — groups required for visibility |
+| `read(service, query)` — raw collection | `read(service, { groups: [...] })` — always group-filtered. `['me']` for your own data. |
+| `update(service, query, update)` — no groups | `update(service, query, { $set, $groups })` — group changes |
+| SMR contracts control data access | SMR is CORS only. Groups control data access. |
+| Separate follow/friend APIs | Follow = join group. Friends = group membership. |
+| `discoverable` boolean | No boolean. Groups handle it. `web10/discover` = public board. |
+
+Groups are not a separate API surface. They are baked into the verbs. Create carries groups. Read filters by groups. Update changes groups. The SDK doesn't have a "groups API" — it has CRUD that understands groups.

--- a/knowledge/knowledge-base/web10-v3/web10-social-group-policy-example.json.md
+++ b/knowledge/knowledge-base/web10-v3/web10-social-group-policy-example.json.md
@@ -1,0 +1,152 @@
+# Web10 Social Group Policy Examples
+
+One group. One JSON. Service-scoped roles. Explicit permissions.
+
+Groups are collections of web10 users operating on data services. Roles define access, scoped to exactly which services they apply to. Default is self-focused: you only touch your own content unless explicitly granted otherwise.
+
+**Multiple roles per user.** A user can hold multiple roles in the same group. `alice` can be a `member` (for posts/comments) AND a `page-curator` (for group-identity-service). The DB maps `user → group → [roles]`. Roles span different services.
+
+## Example 1: Community Group
+
+```json
+{
+  "group_id": "web10.app/groups/jacoby149/abacus-enthusiasts",
+  "join_policy": "request",
+  "roles": [
+    {
+      "name": "owner",
+      "services": ["*"],
+      "permissions": [
+        "readAll", "create", "updateOwn", "updateAll",
+        "deleteOwn", "deleteAll", "hideAll",
+        "manageRoles", "assignRoles", "revokeRoles", "deleteGroup"
+      ]
+    },
+    {
+      "name": "moderator",
+      "services": ["posts", "comments"],
+      "permissions": [
+        "readAll", "create", "updateOwn",
+        "deleteOwn", "hideAll",
+        "assignRoles", "revokeRoles"
+      ]
+    },
+    {
+      "name": "page-curator",
+      "services": ["group-identity-service"],
+      "permissions": [
+        "readAll", "create", "updateOwn", "deleteOwn"
+      ]
+    },
+    {
+      "name": "member",
+      "services": ["posts", "comments"],
+      "permissions": [
+        "readAll", "create", "updateOwn", "deleteOwn"
+      ]
+    }
+  ]
+}
+```
+
+**Service-scoped roles.** Each role lists the services it applies to:
+- `moderator` and `member` only touch `posts` and `comments`.
+- `page-curator` only touches `group-identity-service` (banner, name, website).
+- `owner` touches everything (`"*"`).
+
+**Explicit, self-focused permissions.** Default is you only touch your own stuff. `updateAll` and `deleteAll` are reserved for v2 collaboration. `hideAll` is the moderation power.
+
+- `readAll` — view any content in the service
+- `create` — add new content
+- `updateOwn` — edit your own content
+- `deleteOwn` — remove your own content
+- `hideAll` — hide any content from discover (moderation)
+- `manageRoles` — create/edit/remove roles
+- `assignRoles` / `revokeRoles` — manage user roles
+- `deleteGroup` — destroy the group
+
+**Append-only identity.** `group-identity-service` is append-only. Curators add records, they don't overwrite. Members see the most recent. No accidental overwrites.
+
+## Example 2: Discover (Default)
+
+The public board. Everyone is a member by default. Replaces the `discover: true` boolean entirely.
+
+```json
+{
+  "group_id": "web10.app/groups/web10/discover",
+  "join_policy": "open",
+  "roles": [
+    {
+      "name": "member",
+      "services": ["posts"],
+      "permissions": [
+        "readAll",
+        "create",
+        "updateOwn",
+        "deleteOwn"
+      ]
+    }
+  ]
+}
+```
+
+**How it works:**
+- `join_policy: "open"` + auto-enrollment on signup = **everyone is a member by default**.
+- `readAll` = anyone can see anything posted here. This **is** the public board.
+- `create`, `updateOwn`, `deleteOwn` = you can post to it and manage your own stuff.
+- No moderators. No owners. One role. Everyone shares it.
+
+**Discovery is group membership.** No `discover` boolean. No separate discover index logic. Posts attached to the discover group are public. Posts without it are private.
+
+## Example 3: Private Circle (Burner Insta)
+
+A private group. The creator is the only owner. Approved friends are members. Members can see private posts.
+
+```json
+{
+  "group_id": "web10.app/groups/jacoby149/close-friends",
+  "join_policy": "request",
+  "roles": [
+    {
+      "name": "owner",
+      "services": ["*"],
+      "permissions": [
+        "readAll", "create", "updateOwn", "updateAll",
+        "deleteOwn", "deleteAll", "hideAll",
+        "manageRoles", "assignRoles", "revokeRoles", "deleteGroup"
+      ]
+    },
+    {
+      "name": "member",
+      "services": ["posts"],
+      "permissions": [
+        "readAll",
+        "create",
+        "updateOwn",
+        "deleteOwn"
+      ]
+    }
+  ]
+}
+```
+
+**How it works:**
+- `join_policy: "request"` + no auto-enrollment = **private by default**.
+- Owner posts private content to the group.
+- Friends request to join. Owner approves. They become `member`.
+- Members get `readAll` on posts, so they can see the owner's private posts.
+- No moderators. No curators. Just owner + members.
+
+**Private sharing is just a group.** No separate "private posts" service. No visibility booleans. If it's in the group, members see it. If it's not, they don't.
+
+## Group Collections
+
+Each group holds collections:
+
+- `group-settings-service` — config, permissions
+- `group-identity-service` — group banner, name, website, avatar (append-only)
+- `posts` — group posts
+- `comments` — group comments
+- Whatever else the group needs
+
+The group can hold any number of collections. Roles are scoped to exactly which ones they can touch.

--- a/knowledge/knowledge-base/web10-v3/web10-social-group-policy-example.json.md
+++ b/knowledge/knowledge-base/web10-v3/web10-social-group-policy-example.json.md
@@ -139,6 +139,47 @@ A private group. The creator is the only owner. Approved friends are members. Me
 
 **Private sharing is just a group.** No separate "private posts" service. No visibility booleans. If it's in the group, members see it. If it's not, they don't.
 
+## Example 4: Follow a Public Profile
+
+Following a public profile is a group join. The user's followers group uses `join_policy: "open"`, so the follow is instant — no approval needed. The follower is added as a `member` and can see posts the author attaches to that group.
+
+```json
+{
+  "group_id": "web10.app/groups/coolguydavid/followers",
+  "join_policy": "open",
+  "roles": [
+    {
+      "name": "owner",
+      "services": ["*"],
+      "permissions": [
+        "readAll", "create", "updateOwn", "updateAll",
+        "deleteOwn", "deleteAll", "hideAll",
+        "manageRoles", "assignRoles", "revokeRoles", "deleteGroup"
+      ]
+    },
+    {
+      "name": "member",
+      "services": ["posts"],
+      "permissions": [
+        "readAll"
+      ]
+    }
+  ]
+}
+```
+
+**How it works:**
+- `join_policy: "open"` = **instant follow**. Click follow → you are added as a `member` of `coolguydavid/followers`. No request. No approval.
+- The follower's `member` role only grants `readAll` on `posts` — they can see what the author shares, not post or modify.
+- The author posts by attaching content to the `followers` group. Members discover it via group membership.
+- Unfollow is just leaving the group. No approval needed.
+
+**Public vs private profile is the join policy.** The same group shape works for both:
+- `join_policy: "open"` → public profile. Anyone can follow instantly.
+- `join_policy: "request"` → private profile. Follow requires the author's approval (same shape as Example 3).
+
+**Follows are groups.** No follows table. No follows endpoint. One group membership, one set of roles, one permission model. The author controls the join policy. The follower gets `readAll` on posts. That's the entire follow mechanic.
+
 ## Group Collections
 
 Each group holds collections:

--- a/knowledge/knowledge-base/web10-v3/web10-social-groups.md
+++ b/knowledge/knowledge-base/web10-v3/web10-social-groups.md
@@ -1,0 +1,165 @@
+# Web10 Social Groups
+
+Web10-social is an app that runs on the web10 platform. It uses groups the same way any app does — groups are generic policy containers. Web10-social just happens to define specific roles for social use cases.
+
+This doc explains how web10-social uses groups. The generic group model is in `groups.md`.
+
+## Web10-Social Roles
+
+Web10-social defines these roles for its groups. They are not platform roles — they are choices the social app makes.
+
+**Owner** — all services (`"*"`), full permissions. The group creator. Manages roles, membership, and group lifecycle.
+
+```json
+{
+  "name": "owner",
+  "services": ["*"],
+  "permissions": ["readAll", "create", "updateOwn", "updateAll", "deleteOwn", "deleteAll", "hideAll", "manageRoles", "assignRoles", "revokeRoles", "deleteGroup"]
+}
+```
+
+**Moderator** — `posts`, `comments`; can moderate content and manage roles.
+
+```json
+{
+  "name": "moderator",
+  "services": ["posts", "comments"],
+  "permissions": ["readAll", "create", "updateOwn", "deleteOwn", "hideAll", "assignRoles", "revokeRoles"]
+}
+```
+
+**Page Curator** — `group-identity-service`; manages group banner, name, website.
+
+```json
+{
+  "name": "page-curator",
+  "services": ["group-identity-service"],
+  "permissions": ["readAll", "create", "updateOwn", "deleteOwn"]
+}
+```
+
+**Member** — `posts`, `comments`; can view, create, edit own content.
+
+```json
+{
+  "name": "member",
+  "services": ["posts", "comments"],
+  "permissions": ["readAll", "create", "updateOwn", "deleteOwn"]
+}
+```
+
+**Follower** — `posts`; read-only. Can see what the author shares, not post or modify.
+
+```json
+{
+  "name": "member",
+  "services": ["posts"],
+  "permissions": ["readAll"]
+}
+```
+
+## Web10-Social Group Types
+
+Web10-social uses groups for different social scenarios. Each scenario defines its own roles and join policy.
+
+### Community Group
+
+A community with an owner, moderators, curators, and members. Used for topic-based communities, interest groups, and curated spaces.
+
+```json
+{
+  "group_id": "web10.app/groups/jacoby149/abacus-enthusiasts",
+  "join_policy": "request",
+  "roles": [
+    { "name": "owner", "services": ["*"], "permissions": ["readAll", "create", "updateOwn", "updateAll", "deleteOwn", "deleteAll", "hideAll", "manageRoles", "assignRoles", "revokeRoles", "deleteGroup"] },
+    { "name": "moderator", "services": ["posts", "comments"], "permissions": ["readAll", "create", "updateOwn", "deleteOwn", "hideAll", "assignRoles", "revokeRoles"] },
+    { "name": "page-curator", "services": ["group-identity-service"], "permissions": ["readAll", "create", "updateOwn", "deleteOwn"] },
+    { "name": "member", "services": ["posts", "comments"], "permissions": ["readAll", "create", "updateOwn", "deleteOwn"] }
+  ]
+}
+```
+
+**How it works:**
+- `join_policy: "request"` — members request to join, owner or moderator approves
+- Owner has full control, moderators can hide content and manage roles
+- Page curators manage the group identity without touching posts
+- Members can post, comment, and edit their own content
+
+### Discover (Public Board)
+
+The public board. Everyone is a member by default. Replaces the `discover: true` boolean.
+
+```json
+{
+  "group_id": "web10.app/groups/web10/discover",
+  "join_policy": "open",
+  "roles": [
+    { "name": "member", "services": ["posts"], "permissions": ["readAll", "create", "updateOwn", "deleteOwn"] }
+  ]
+}
+```
+
+**How it works:**
+- `join_policy: "open"` + auto-enrollment on signup = everyone is a member by default
+- `readAll` = anyone can see anything posted here. This **is** the public board.
+- `create`, `updateOwn`, `deleteOwn` = you can post to it and manage your own stuff
+- No moderators. No owners. One role. Everyone shares it.
+
+**Discovery is group membership.** No `discover` boolean. No separate discover index logic. Posts attached to the discover group are public. Posts without it are private.
+
+### Private Circle
+
+A private group. The creator is the only owner. Approved friends are members. Members can see private posts.
+
+```json
+{
+  "group_id": "web10.app/groups/jacoby149/close-friends",
+  "join_policy": "request",
+  "roles": [
+    { "name": "owner", "services": ["*"], "permissions": ["readAll", "create", "updateOwn", "updateAll", "deleteOwn", "deleteAll", "hideAll", "manageRoles", "assignRoles", "revokeRoles", "deleteGroup"] },
+    { "name": "member", "services": ["posts"], "permissions": ["readAll", "create", "updateOwn", "deleteOwn"] }
+  ]
+}
+```
+
+**How it works:**
+- `join_policy: "request"` + no auto-enrollment = private by default
+- Owner posts private content to the group
+- Friends request to join. Owner approves. They become `member`
+- Members get `readAll` on posts, so they can see the owner's private posts
+- No moderators. No curators. Just owner + members
+
+### Follow a Public Profile
+
+Following a public profile is a group join. The user's followers group uses `join_policy: "open"`, so the follow is instant — no approval needed. The follower is added as a `member` and can see posts the author attaches to that group. But the followers group is more than a content distribution channel. **It is the influencer's owned audience.**
+
+```json
+{
+  "group_id": "web10.app/groups/coolguydavid/followers",
+  "join_policy": "open",
+  "roles": [
+    { "name": "owner", "services": ["*"], "permissions": ["readAll", "create", "updateOwn", "updateAll", "deleteOwn", "deleteAll", "hideAll", "manageRoles", "assignRoles", "revokeRoles", "deleteGroup"] },
+    { "name": "member", "services": ["posts"], "permissions": ["readAll"] }
+  ]
+}
+```
+
+**How it works:**
+- `join_policy: "open"` = instant follow. Click follow → you are added as a `member` of `coolguydavid/followers`. No request. No approval.
+- The follower's `member` role only grants `readAll` on `posts` — they can see what the author shares, not post or modify.
+- The author posts by attaching content to the `followers` group. Members discover it via group membership.
+- Unfollow is just leaving the group. No approval needed.
+
+**The audience is the asset.** The owner (coolguydavid) can read the full membership list. Every follower's web10 username, email (if set), phone (if set). They can message a follower, email a fan, text a supporter — directly, through web10. That list is theirs. They can export it. They can take it if they move nodes. On legacy platforms, followers are the platform's asset — you can't export them, can't message them without the platform's permission, can't take them if you leave. Here, the followers group membership is owned data.
+
+**Public vs private profile is the join policy.** The same group shape works for both:
+- `join_policy: "open"` → public profile. Anyone can follow instantly.
+- `join_policy: "request"` → private profile. Follow requires the author's approval.
+
+**Follows are groups.** No follows table. No follows endpoint. One group membership, one set of roles, one permission model. The author controls the join policy. The follower gets `readAll` on posts. The author owns the audience relationship. That's the entire follow mechanic.
+
+## Summary
+
+Web10-social uses groups for communities, discovery, private circles, and follows. The roles are choices the social app makes — not platform requirements. Any app can define its own roles for its own groups. The platform doesn't care what you call them or what they do.
+
+For the generic group model, see `groups.md`. For contract schemas, see `contract-schemas.md`.


### PR DESCRIPTION
Refactored the entire knowledge base to align with v3 architecture decisions:

- **Documents over posts** — renamed all references from posts/documents/posts to documents across social v3, v2-to-v3 migration, brainstorm, and v3 docs
- **Service-scoped roles** — groups define their own roles with explicit permissions per service (owner, moderator, page-curator, member, follower). Multiple roles per user supported.
- **Discover group** — replaced the per-record `discoverable` flag with `web10/discover` open group. Public = attach to discover group. Private = don't.
- **Fully-qualified group IDs** — all examples now use `web10.app/groups/owner/name` format instead of bare strings like `jazz-collectors`
- **Removed `permission` column** from `doc_groups` — roles define access, not per-attachment permissions
- **Removed `groups` table** — `group_contracts` is the single source of truth
- **New files** — `sdk-api.md` (SDK documentation), `web10-social-groups.md` (social-specific group usage)
- **Added blacklist schemas** — user-wide and per-group blacklists
- **Added follow example** — open join policy for public profiles, request join policy for private profiles